### PR TITLE
Fix review bot think block and speed up CodeQL

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -161,12 +161,14 @@ jobs:
             -H "Content-Type: application/json" \
             -d @request.json)
 
-          # Extract the review text
+          # Extract the review text and strip <think> blocks from Qwen
           REVIEW=$(echo "$RESPONSE" | python3 -c "
-          import sys, json
+          import sys, json, re
           try:
               data = json.load(sys.stdin)
-              print(data['choices'][0]['message']['content'])
+              content = data['choices'][0]['message']['content']
+              content = re.sub(r'<think>.*?</think>\s*', '', content, flags=re.DOTALL)
+              print(content.strip())
           except (KeyError, IndexError, json.JSONDecodeError) as e:
               print(f'AI review unavailable: {e}')
           ")

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,11 +16,6 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ['python']
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,10 +23,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+          languages: python
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- Strip Qwen `<think>` reasoning blocks from AI review output so only the clean review is posted
- Remove unnecessary Autobuild step from CodeQL (Python doesn't need compilation)
- Simplify CodeQL matrix strategy (single language)

## Test plan
- [ ] Verify review bot posts clean output without think blocks
- [ ] Verify CodeQL runs faster without Autobuild step

🤖 Generated with [Claude Code](https://claude.com/claude-code)