### PR TITLE
fix: use nested config path for allowlist check

### DIFF
--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -103,7 +103,7 @@ def is_admin(user_id: int) -> bool:
 
 def is_allowed(user_id: int) -> bool:
     """Check if user is in allowlist"""
-    if not config.get("enableAllowlist"):
+    if not config.get("security", {}).get("enableAllowlist", False):
         return True
 
     if not os.path.exists(ALLOWLIST_PATH):


### PR DESCRIPTION
## Summary
- Fixed `is_allowed()` in `src/utils/helpers.py` to read `enableAllowlist` from the correct nested config path (`security.enableAllowlist`) instead of the root level

## Test plan
- [ ] Verify allowlist enforcement works when `security.enableAllowlist: true` is set in config
- [ ] Verify all users are allowed when `security.enableAllowlist: false`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)