### PR TITLE
fix: log and display download client errors instead of swallowing them

### DIFF
--- a/src/bot/handlers/media.py
+++ b/src/bot/handlers/media.py
@@ -933,14 +933,16 @@ class MediaHandler:
             try:
                 if await self.media_service.get_transmission_status():
                     status_lines.append("\n📥 Transmission: ✅ Connected")
-            except Exception:
-                pass
+            except Exception as e:
+                logger.error(f"Error checking Transmission status: {e}")
+                status_lines.append("\n📥 Transmission: ❌ Unavailable")
 
             try:
                 if await self.media_service.get_sabnzbd_status():
                     status_lines.append("📥 SABnzbd: ✅ Connected")
-            except Exception:
-                pass
+            except Exception as e:
+                logger.error(f"Error checking SABnzbd status: {e}")
+                status_lines.append("📥 SABnzbd: ❌ Unavailable")
 
             return "\n".join(status_lines)
 


### PR DESCRIPTION
## Summary
- Replaced bare `except: pass` blocks in download client status checks with proper error logging and user-visible "Unavailable" messages
- Affects Transmission and SABnzbd status display in the `/status` command

## Test plan
- [ ] Verify status command shows "Unavailable" when Transmission/SABnzbd are unreachable
- [ ] Verify errors are logged with details

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)