### PR TITLE
fix: read Lidarr metadataProfileId from config instead of hardcoding

### DIFF
--- a/src/api/lidarr.py
+++ b/src/api/lidarr.py
@@ -42,6 +42,7 @@ class LidarrClient:
             logger.error(Fore.RED + "❌ Lidarr API key not configured")
             raise ValueError("Lidarr API key not configured")
 
+        self.metadata_profile_id = lidarr_config.get("metadataProfileId", 1)
         self.headers = {
             "X-Api-Key": self.api_key,
             "Content-Type": "application/json"
@@ -152,7 +153,7 @@ class LidarrClient:
                 "foreignArtistId": artist["foreignArtistId"],
                 "artistName": artist["artistName"],
                 "qualityProfileId": quality_profile_id or 1,  # Default profile if not specified
-                "metadataProfileId": 1,  # Default metadata profile
+                "metadataProfileId": self.metadata_profile_id,
                 "rootFolderPath": root_folder or "/music",  # Default path if not specified
                 "monitored": True,
                 "addOptions": {


### PR DESCRIPTION
## Summary
- Read `metadataProfileId` from Lidarr config section during client init
- Use the configured value in `add_artist()` instead of hardcoded `1`
- Falls back to `1` if not configured

## Test plan
- [ ] Set `metadataProfileId: 2` in config and verify Lidarr add requests use profile 2
- [ ] Verify default of `1` still works when key is absent

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)