### PR TITLE
ops: improve Dockerfile security and health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,20 @@ RUN apk add --no-cache \
 # Copy files to container
 COPY . /app
 
-# Install ans build Addarr Refresh requirements, make symlink to redirect logs to stdout
-RUN	pip install --no-cache-dir -r requirements.txt --upgrade
+# Install and build Addarr Refresh requirements
+RUN pip install --no-cache-dir -r requirements.txt --upgrade
 
-ENTRYPOINT ["python", "/run.py"]
+# Create non-root user
+RUN addgroup -S addarr && adduser -S addarr -G addarr \
+    && chown -R addarr:addarr /app
+
+USER addarr
+
+# Graceful shutdown
+STOPSIGNAL SIGTERM
+
+# Health check - verify the bot process is running
+HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \
+    CMD pgrep -f "python /app/run.py" || exit 1
+
+ENTRYPOINT ["python", "/app/run.py"]


### PR DESCRIPTION
## Summary
- Run as non-root user (`addarr`) instead of root
- Added `HEALTHCHECK` instruction to verify bot process health
- Added `STOPSIGNAL SIGTERM` for graceful shutdown
- Fixed typo in comment ("Install ans build" → "Install and build")
- Fixed ENTRYPOINT to use absolute path `/app/run.py`

## Test plan
- [ ] `docker build -t addarr .` succeeds
- [ ] Container runs as non-root user (`docker exec addarr whoami` returns `addarr`)
- [ ] Health check reports healthy when bot is running
- [ ] `docker stop` triggers graceful shutdown

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)