### PR TITLE
ops: add healthcheck, resource limits, and backup volume to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,18 +3,31 @@
 # created date: 2024-11-08
 # description: Docker compose file for Addarr Refresh Telegram Bot.
 
-version: '3'
 services:
   addarr:
     container_name: addarr-refresh
     build: .
     restart: unless-stopped
-    network_mode: host
+    network_mode: host  # Required for reaching *arr services on localhost
     volumes:
       - ./config.yaml:/app/config.yaml:ro
       - ./chatid.txt:/app/chatid.txt:rw
       - ./admin.txt:/app/admin.txt:ro
       - ./allowlist.txt:/app/allowlist.txt:ro
       - ./logs:/app/logs:rw
+      - ./backup:/app/backup:rw
     environment:
       - PYTHONPATH=/app
+    healthcheck:
+      test: ["CMD", "pgrep", "-f", "python /app/run.py"]
+      interval: 60s
+      timeout: 10s
+      start_period: 30s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: '0.5'
+        reservations:
+          memory: 128M


### PR DESCRIPTION
## Summary
- Added healthcheck definition matching the Dockerfile HEALTHCHECK
- Added resource limits: 256M memory / 0.5 CPU with 128M reservation
- Added `backup/` volume mount so config backups persist
- Removed deprecated `version: '3'` key
- Added comment documenting the `network_mode: host` choice

## Test plan
- [ ] `docker compose up -d` starts successfully
- [ ] `docker compose ps` shows health status
- [ ] Backup directory persists after container restart

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)