### PR TITLE
chore: remove unused DEFAULT_SETTINGS dict from definitions.py

### DIFF
--- a/src/definitions.py
+++ b/src/definitions.py
@@ -30,24 +30,6 @@ ALLOWLIST_PATH = os.path.join(ROOT_DIR, "allowlist.txt")
 # Data directory for persistent storage
 DATA_PATH = os.path.join(ROOT_DIR, "data")
 
-# Default configuration settings
-DEFAULT_SETTINGS = {
-    "entrypointAuth": "auth",      # auth or a custom entrypoint
-    "entrypointAdd": "start",      # start or a custom entrypoint
-    "entrypointDelete": "delete",  # delete or a custom entrypoint
-    "entrypointAllSeries": "allSeries",  # allSeries or a custom entrypoint
-    "entrypointAllMovies": "allMovies",  # allMovies or a custom entrypoint
-    "entrypointAllMusic": "allMusic",    # allMusic or a custom entrypoint
-    "entrypointTransmission": "transmission",  # transmission or a custom entrypoint
-    "entrypointSabnzbd": "sabnzbd",      # sabnzbd or a custom entrypoint
-    "logToConsole": True,
-    "debugLogging": False,
-    "language": "en-us",
-    "transmission": {"enable": False},
-    "enableAdmin": False
-}
-
-
 def load_config():
     config_path = Path("config.yaml")
     if not config_path.exists():


### PR DESCRIPTION
## Summary
- Removed the `DEFAULT_SETTINGS` dictionary which was never imported or referenced anywhere in the codebase
- Entrypoints and defaults are managed through `config.yaml` and `config_example.yaml`, making this dict dead code

## Test plan
- [ ] Verify no import errors after removal
- [ ] `grep -r DEFAULT_SETTINGS src/` returns no results

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)