### PR TITLE
chore: remove unused DEFAULT_SETTINGS from definitions.py

### DIFF
--- a/src/definitions.py
+++ b/src/definitions.py
@@ -30,23 +30,6 @@ ALLOWLIST_PATH = os.path.join(ROOT_DIR, "allowlist.txt")
 # Data directory for persistent storage
 DATA_PATH = os.path.join(ROOT_DIR, "data")
 
-# Default configuration settings
-DEFAULT_SETTINGS = {
-    "entrypointAuth": "auth",      # auth or a custom entrypoint
-    "entrypointAdd": "start",      # start or a custom entrypoint
-    "entrypointDelete": "delete",  # delete or a custom entrypoint
-    "entrypointAllSeries": "allSeries",  # allSeries or a custom entrypoint
-    "entrypointAllMovies": "allMovies",  # allMovies or a custom entrypoint
-    "entrypointAllMusic": "allMusic",    # allMusic or a custom entrypoint
-    "entrypointTransmission": "transmission",  # transmission or a custom entrypoint
-    "entrypointSabnzbd": "sabnzbd",      # sabnzbd or a custom entrypoint
-    "logToConsole": True,
-    "debugLogging": False,
-    "language": "en-us",
-    "transmission": {"enable": False},
-    "enableAdmin": False
-}
-
 
 def load_config():
     config_path = Path("config.yaml")

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -8,6 +8,13 @@ import pytest
 import yaml
 
 
+class TestModuleDoesNotExportDeadCode:
+    def test_no_default_settings(self):
+        """DEFAULT_SETTINGS was unused dead code and should be removed."""
+        from src import definitions
+        assert not hasattr(definitions, "DEFAULT_SETTINGS")
+
+
 class TestLoadConfig:
     def test_load_config_success(self, tmp_path, monkeypatch):
         config_data = {"admins": [111], "language": "en-us"}


### PR DESCRIPTION
## Summary
- Removed `DEFAULT_SETTINGS` dict that was never imported or used anywhere
- Added test asserting the dead code stays removed

## Test plan
- [x] `test_no_default_settings` — TDD RED/GREEN cycle
- [x] Full suite: 736 passed

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)