### PR TITLE
merge: sync main with development

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -163,14 +163,14 @@ jobs:
           with open(diff_file, 'r') as f:
               diff = f.read()
 
-          # Cap diff size to ~32KB to stay within Groq token limits
-          if len(diff) > 32000:
-              diff = diff[:32000] + "\n\n... (diff truncated for token limit)"
+          # Cap diff size to ~80KB to stay within Groq token limits
+          if len(diff) > 80000:
+              diff = diff[:80000] + "\n\n... (diff truncated for token limit)"
 
           title = os.environ.get('PR_TITLE', 'PR Review')
 
           request = {
-              "model": "qwen/qwen3-32b",
+              "model": "meta-llama/llama-4-scout-17b-16e-instruct",
               "temperature": 0.3,
               "max_tokens": 4096,
               "messages": [
@@ -210,7 +210,7 @@ jobs:
 
           echo "Groq API HTTP status: ${HTTP_CODE}"
 
-          # Extract the review text and strip <think> blocks from Qwen
+          # Extract the review text and strip any reasoning blocks
           python3 << 'PYEOF' > ai_review.txt
           import json, re, sys
 

--- a/src/api/base.py
+++ b/src/api/base.py
@@ -11,11 +11,36 @@ handling.
 
 from abc import ABC, abstractmethod
 import json
+import os
 import aiohttp
-from typing import Tuple, Optional, Any
+from typing import List, Tuple, Optional, Any
 
 from ..utils.logger import get_logger
 from ..config.settings import config
+
+
+def filter_root_folders(paths: List[str], service_config: dict) -> List[str]:
+    """Filter root folder paths based on service exclusion config.
+
+    Args:
+        paths: List of root folder paths from the API.
+        service_config: Service-level config dict (e.g. config["radarr"]).
+
+    Returns:
+        Filtered list of paths.
+    """
+    paths_config = service_config.get("paths", {})
+    excluded = paths_config.get("excludedRootFolders", [])
+    if excluded:
+        narrow = paths_config.get("narrowRootFolderNames", False)
+        if narrow:
+            paths = [
+                p for p in paths
+                if os.path.basename(p.rstrip("/")) not in excluded
+            ]
+        else:
+            paths = [p for p in paths if p not in excluded]
+    return paths
 
 
 class APIError(Exception):

--- a/src/api/radarr.py
+++ b/src/api/radarr.py
@@ -10,6 +10,7 @@ from typing import Optional, List, Dict, Any
 from colorama import Fore
 import json
 
+from src.api.base import filter_root_folders
 from src.config.settings import config
 from src.utils.logger import get_logger
 
@@ -117,7 +118,8 @@ class RadarrClient:
         try:
             results = await self._make_request("rootFolder")
             if results:
-                return [folder["path"] for folder in results]
+                paths = [folder["path"] for folder in results]
+                return filter_root_folders(paths, config.get("radarr", {}))
             return []
         except Exception as e:
             logger.error(f"Failed to get root folders: {str(e)}")

--- a/src/api/sonarr.py
+++ b/src/api/sonarr.py
@@ -10,6 +10,7 @@ from typing import Optional, List, Dict, Any
 from colorama import Fore
 import json
 
+from src.api.base import filter_root_folders
 from src.config.settings import config
 from src.utils.logger import get_logger
 
@@ -94,7 +95,8 @@ class SonarrClient:
         try:
             results = await self._make_request("rootFolder")
             if results:
-                return [folder["path"] for folder in results]
+                paths = [folder["path"] for folder in results]
+                return filter_root_folders(paths, config.get("sonarr", {}))
             return []
         except Exception as e:
             logger.error(f"Failed to get root folders: {str(e)}")
@@ -141,11 +143,15 @@ class SonarrClient:
 
             series = lookup_response[0]  # Use first result
 
+            # Read seasonFolder from config
+            season_folder = config.get("sonarr", {}).get("features", {}).get("seasonFolder", True)
+
             data = {
                 "tvdbId": series["tvdbId"],
                 "title": series["title"],
                 "qualityProfileId": quality_profile_id,
                 "rootFolderPath": root_folder,
+                "seasonFolder": season_folder,
                 "monitored": True,
                 "addOptions": {
                     "searchForMissingEpisodes": True

--- a/src/bot/handlers/media.py
+++ b/src/bot/handlers/media.py
@@ -18,6 +18,7 @@ from telegram.ext import (
 )
 
 from src.bot.keyboards import get_system_keyboard
+from src.config.settings import config
 from src.utils.logger import get_logger, log_user_interaction
 from src.bot.handlers.auth import require_auth
 from src.services.media import MediaService
@@ -153,6 +154,11 @@ class MediaHandler:
         if not update.effective_message or not update.effective_user:
             return ConversationHandler.END
 
+        if config.get("radarr", {}).get("adminRestrictions", False):
+            if update.effective_user.id not in config.get("admins", []):
+                await update.message.reply_text("Access restricted to admins only.")
+                return ConversationHandler.END
+
         log_user_interaction(logger, update.effective_user, "/movie")
 
         context.user_data["search_type"] = "movie"
@@ -179,6 +185,11 @@ class MediaHandler:
         if not update.effective_message or not update.effective_user:
             return ConversationHandler.END
 
+        if config.get("sonarr", {}).get("adminRestrictions", False):
+            if update.effective_user.id not in config.get("admins", []):
+                await update.message.reply_text("Access restricted to admins only.")
+                return ConversationHandler.END
+
         log_user_interaction(logger, update.effective_user, "/series")
 
         context.user_data["search_type"] = "series"
@@ -204,6 +215,11 @@ class MediaHandler:
         """Start music search conversation"""
         if not update.effective_message or not update.effective_user:
             return ConversationHandler.END
+
+        if config.get("lidarr", {}).get("adminRestrictions", False):
+            if update.effective_user.id not in config.get("admins", []):
+                await update.message.reply_text("Access restricted to admins only.")
+                return ConversationHandler.END
 
         log_user_interaction(logger, update.effective_user, "/music")
 

--- a/tests/test_api/test_radarr.py
+++ b/tests/test_api/test_radarr.py
@@ -202,6 +202,101 @@ class TestRadarrRootFolders:
             folders = await radarr_client.get_root_folders()
         assert folders == []
 
+    @pytest.mark.asyncio
+    async def test_get_root_folders_excludes_by_basename_when_narrow(self, aio_mock):
+        """narrowRootFolderNames makes excludedRootFolders match by basename."""
+        from src.config.settings import config
+        orig_paths = config._config["radarr"]["paths"].copy()
+        config._config["radarr"]["paths"]["excludedRootFolders"] = ["movies2"]
+        config._config["radarr"]["paths"]["narrowRootFolderNames"] = True
+        try:
+            from src.api.radarr import RadarrClient
+            client = RadarrClient()
+            aio_mock.get(
+                f"{BASE}/rootFolder",
+                payload=[
+                    {"path": "/data/movies", "freeSpace": 1000},
+                    {"path": "/data/movies2", "freeSpace": 500},
+                ],
+                status=200,
+            )
+            folders = await client.get_root_folders()
+            assert "/data/movies" in folders
+            assert "/data/movies2" not in folders
+        finally:
+            config._config["radarr"]["paths"] = orig_paths
+
+    @pytest.mark.asyncio
+    async def test_get_root_folders_excludes_by_full_path_when_not_narrow(self, aio_mock):
+        """Without narrowRootFolderNames, excludedRootFolders matches full path."""
+        from src.config.settings import config
+        orig_paths = config._config["radarr"]["paths"].copy()
+        config._config["radarr"]["paths"]["excludedRootFolders"] = ["/data/movies2"]
+        config._config["radarr"]["paths"]["narrowRootFolderNames"] = False
+        try:
+            from src.api.radarr import RadarrClient
+            client = RadarrClient()
+            aio_mock.get(
+                f"{BASE}/rootFolder",
+                payload=[
+                    {"path": "/data/movies", "freeSpace": 1000},
+                    {"path": "/data/movies2", "freeSpace": 500},
+                ],
+                status=200,
+            )
+            folders = await client.get_root_folders()
+            assert "/data/movies" in folders
+            assert "/data/movies2" not in folders
+        finally:
+            config._config["radarr"]["paths"] = orig_paths
+
+    @pytest.mark.asyncio
+    async def test_get_root_folders_narrow_handles_trailing_slash(self, aio_mock):
+        """narrowRootFolderNames matches basename even with trailing slashes."""
+        from src.config.settings import config
+        orig_paths = config._config["radarr"]["paths"].copy()
+        config._config["radarr"]["paths"]["excludedRootFolders"] = ["movies2"]
+        config._config["radarr"]["paths"]["narrowRootFolderNames"] = True
+        try:
+            from src.api.radarr import RadarrClient
+            client = RadarrClient()
+            aio_mock.get(
+                f"{BASE}/rootFolder",
+                payload=[
+                    {"path": "/data/movies/", "freeSpace": 1000},
+                    {"path": "/data/movies2/", "freeSpace": 500},
+                ],
+                status=200,
+            )
+            folders = await client.get_root_folders()
+            assert "/data/movies/" in folders
+            assert "/data/movies2/" not in folders
+        finally:
+            config._config["radarr"]["paths"] = orig_paths
+
+    @pytest.mark.asyncio
+    async def test_get_root_folders_empty_exclusion_returns_all(self, aio_mock):
+        """Empty excludedRootFolders returns all folders unfiltered."""
+        from src.config.settings import config
+        orig_paths = config._config["radarr"]["paths"].copy()
+        config._config["radarr"]["paths"]["excludedRootFolders"] = []
+        config._config["radarr"]["paths"]["narrowRootFolderNames"] = True
+        try:
+            from src.api.radarr import RadarrClient
+            client = RadarrClient()
+            aio_mock.get(
+                f"{BASE}/rootFolder",
+                payload=[
+                    {"path": "/data/movies", "freeSpace": 1000},
+                    {"path": "/data/movies2", "freeSpace": 500},
+                ],
+                status=200,
+            )
+            folders = await client.get_root_folders()
+            assert len(folders) == 2
+        finally:
+            config._config["radarr"]["paths"] = orig_paths
+
 
 # ---------------------------------------------------------------------------
 # get_quality_profiles

--- a/tests/test_api/test_sonarr.py
+++ b/tests/test_api/test_sonarr.py
@@ -5,6 +5,7 @@ Tests for src/api/sonarr.py -- SonarrClient.
 import pytest
 import aiohttp
 from unittest.mock import patch
+from aioresponses import CallbackResult
 
 from tests.fixtures.sample_data import (
     SONARR_SEARCH_RESULTS,
@@ -133,6 +134,48 @@ class TestSonarrRootFolders:
         with patch.object(sonarr_client, "_make_request", side_effect=Exception("boom")):
             folders = await sonarr_client.get_root_folders()
         assert folders == []
+
+    @pytest.mark.asyncio
+    async def test_get_root_folders_excludes_by_basename_when_narrow(self, aio_mock):
+        """narrowRootFolderNames makes excludedRootFolders match by basename."""
+        from src.config.settings import config
+        orig_paths = config._config["sonarr"]["paths"].copy()
+        config._config["sonarr"]["paths"]["excludedRootFolders"] = ["tv2"]
+        config._config["sonarr"]["paths"]["narrowRootFolderNames"] = True
+        try:
+            from src.api.sonarr import SonarrClient
+            client = SonarrClient()
+            aio_mock.get(
+                f"{BASE}/rootFolder",
+                payload=[{"path": "/data/tv"}, {"path": "/data/tv2"}],
+                status=200,
+            )
+            folders = await client.get_root_folders()
+            assert "/data/tv" in folders
+            assert "/data/tv2" not in folders
+        finally:
+            config._config["sonarr"]["paths"] = orig_paths
+
+    @pytest.mark.asyncio
+    async def test_get_root_folders_excludes_by_full_path_when_not_narrow(self, aio_mock):
+        """Without narrowRootFolderNames, excludedRootFolders matches full path."""
+        from src.config.settings import config
+        orig_paths = config._config["sonarr"]["paths"].copy()
+        config._config["sonarr"]["paths"]["excludedRootFolders"] = ["/data/tv2"]
+        config._config["sonarr"]["paths"]["narrowRootFolderNames"] = False
+        try:
+            from src.api.sonarr import SonarrClient
+            client = SonarrClient()
+            aio_mock.get(
+                f"{BASE}/rootFolder",
+                payload=[{"path": "/data/tv"}, {"path": "/data/tv2"}],
+                status=200,
+            )
+            folders = await client.get_root_folders()
+            assert "/data/tv" in folders
+            assert "/data/tv2" not in folders
+        finally:
+            config._config["sonarr"]["paths"] = orig_paths
 
 
 # ---------------------------------------------------------------------------
@@ -435,6 +478,38 @@ class TestSonarrAddSeries:
             success, message = await sonarr_client.add_series(81189, "/tv", 1)
         assert success is False
         assert "outer boom" in message
+
+    @pytest.mark.asyncio
+    async def test_add_series_includes_season_folder_from_config(self, aio_mock):
+        """add_series POST body should include seasonFolder from config."""
+        from src.config.settings import config
+        config._config["sonarr"]["features"]["seasonFolder"] = True
+        try:
+            from src.api.sonarr import SonarrClient
+            client = SonarrClient()
+
+            aio_mock.get(
+                f"{BASE}/series/lookup?term=tvdb:81189",
+                payload=SONARR_SEARCH_RESULTS[:1],
+                status=200,
+            )
+
+            posted_data = {}
+
+            def capture(url, **kwargs):
+                posted_data.update(kwargs.get("json", {}))
+                return CallbackResult(
+                    payload={"id": 1, "title": "Breaking Bad"}, status=200
+                )
+
+            aio_mock.post(f"{BASE}/series", callback=capture)
+
+            success, _ = await client.add_series(81189, "/tv", 1)
+            assert success is True
+            assert "seasonFolder" in posted_data, "POST body must include seasonFolder"
+            assert posted_data["seasonFolder"] is True
+        finally:
+            config._config["sonarr"]["features"]["seasonFolder"] = True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **feat**: implement all previously unused config options (root folder exclusion, admin restrictions, monitor options, season folders, metadata profiles)
- **refactor**: extract shared root folder filtering into `base.py`, DRY across Radarr/Sonarr/Lidarr
- **fix**: read `metadataProfileId` from config instead of hardcoding
- **fix**: switch PR review model from Qwen3-32B (6K TPM) to Llama 4 Scout (30K TPM) to fix review failures on larger PRs
- **chore**: dependabot bumps (actions/checkout 6, actions/setup-python 6, actions/github-script 8, github/codeql-action 4)
- **chore**: CodeQL optimization, CLAUDE.md updates, test suite sync

## Test plan
- [x] All API client tests pass (145 tests)
- [x] Root folder filtering tests cover narrow/full-path/trailing-slash/empty exclusion
- [x] metadataProfileId config test verifies POST body reads from config
- [x] CI passes: lint, tests, translations, Docker build, CodeQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)