### PR TITLE
fix: switch AI reviewer to Llama 3.3 70B

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -170,7 +170,7 @@ jobs:
           title = os.environ.get('PR_TITLE', 'PR Review')
 
           request = {
-              "model": "meta-llama/llama-4-scout-17b-16e-instruct",
+              "model": "llama-3.3-70b-versatile",
               "temperature": 0.3,
               "max_tokens": 4096,
               "messages": [


### PR DESCRIPTION
## Summary
- Switches from Llama 4 Scout 17B to Llama 3.3 70B for PR reviews
- Larger model follows system prompt constraints (especially "Do NOT" rules) more reliably

## Test plan
- [ ] Retrigger review on existing PR to verify improved output quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)