### PR TITLE
Fix #11: Implement missing MediaService methods for delete command

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ from telegram.ext import Application
 from telegram.error import InvalidToken, NetworkError
 
 from src.bot.handlers.auth import AuthHandler
+from src.bot.handlers.delete import DeleteHandler
 from src.bot.handlers.media import MediaHandler
 from src.bot.handlers.transmission import TransmissionHandler
 from src.bot.handlers.sabnzbd import SabnzbdHandler
@@ -109,6 +110,11 @@ class AddarrBot:
             # Media handler
             media_handler = MediaHandler()
             for handler in media_handler.get_handler():
+                self.application.add_handler(handler)
+
+            # Delete handler
+            delete_handler = DeleteHandler()
+            for handler in delete_handler.get_handler():
                 self.application.add_handler(handler)
 
             # Transmission handler (if enabled)

--- a/tests/fixtures/sample_data.py
+++ b/tests/fixtures/sample_data.py
@@ -153,3 +153,48 @@ SABNZBD_QUEUE = {
 }
 
 SABNZBD_VERSION = {"version": "4.0.0"}
+
+# ---------------------------------------------------------------------------
+# Library items (internal *arr IDs, used by delete flow)
+# ---------------------------------------------------------------------------
+
+RADARR_LIBRARY_MOVIES = [
+    {"id": 1, "title": "Fight Club", "tmdbId": 550, "year": 1999},
+    {"id": 2, "title": "Pulp Fiction", "tmdbId": 680, "year": 1994},
+]
+
+RADARR_LIBRARY_MOVIE_DETAIL = {
+    "id": 1,
+    "title": "Fight Club",
+    "tmdbId": 550,
+    "year": 1999,
+    "overview": "An insomniac office worker...",
+    "path": "/movies/Fight Club (1999)",
+}
+
+SONARR_LIBRARY_SERIES = [
+    {"id": 1, "title": "Breaking Bad", "tvdbId": 81189, "year": 2008},
+    {"id": 2, "title": "Severance", "tvdbId": 295759, "year": 2022},
+]
+
+SONARR_LIBRARY_SERIES_DETAIL = {
+    "id": 1,
+    "title": "Breaking Bad",
+    "tvdbId": 81189,
+    "year": 2008,
+    "overview": "A high school chemistry teacher...",
+    "path": "/tv/Breaking Bad",
+}
+
+LIDARR_LIBRARY_ARTISTS = [
+    {"id": 1, "artistName": "Linkin Park", "foreignArtistId": "f59c5520-5f46-4d2c-b2c4-822eabf53419"},
+    {"id": 2, "artistName": "Radiohead", "foreignArtistId": "a74b1b7f-71a5-4011-9441-d0b5e4122711"},
+]
+
+LIDARR_LIBRARY_ARTIST_DETAIL = {
+    "id": 1,
+    "artistName": "Linkin Park",
+    "foreignArtistId": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+    "overview": "Linkin Park is an American rock band...",
+    "path": "/music/Linkin Park",
+}

--- a/tests/test_services/conftest.py
+++ b/tests/test_services/conftest.py
@@ -16,6 +16,9 @@ def mock_radarr_client():
     client.get_quality_profiles = AsyncMock(
         return_value=[{"id": 1, "name": "HD-1080p"}]
     )
+    client.get_movies = AsyncMock(return_value=[])
+    client.get_movie_by_id = AsyncMock(return_value=None)
+    client.delete_movie = AsyncMock(return_value=True)
     client.check_status = AsyncMock(return_value=True)
     return client
 
@@ -31,6 +34,9 @@ def mock_sonarr_client():
         return_value=[{"id": 1, "name": "HD-1080p"}]
     )
     client.get_seasons = AsyncMock(return_value=[])
+    client.get_all_series = AsyncMock(return_value=[])
+    client.get_series_by_id = AsyncMock(return_value=None)
+    client.delete_series = AsyncMock(return_value=True)
     client.check_status = AsyncMock(return_value=True)
     return client
 
@@ -48,5 +54,8 @@ def mock_lidarr_client():
     client.get_metadata_profiles = AsyncMock(
         return_value=[{"id": 1, "name": "Standard"}]
     )
+    client.get_artists = AsyncMock(return_value=[])
+    client.get_artist_by_id = AsyncMock(return_value=None)
+    client.delete_artist = AsyncMock(return_value=True)
     client.check_status = AsyncMock(return_value=True)
     return client


### PR DESCRIPTION
Add get-all, get-by-id, and delete methods across all three layers (API clients, service layer, handler registration) so the existing DeleteHandler becomes fully functional.

API clients: get_movies/get_movie_by_id/delete_movie (Radarr), get_all_series/get_series_by_id/delete_series (Sonarr), get_artists/get_artist_by_id/delete_artist (Lidarr).

MediaService: get_movies, get_movie, get_series (overloaded), get_music (overloaded), delete_movie, delete_series, delete_music.

Handler registration: wire DeleteHandler into AddarrBot._add_handlers().