### PR TITLE
Implement /allMovies, /allSeries, /allMusic commands (#15)

### DIFF
--- a/src/bot/handlers/__init__.py
+++ b/src/bot/handlers/__init__.py
@@ -12,6 +12,10 @@ Each handler is responsible for managing a specific type of user interaction.
 from .auth import AuthHandler
 from .media import MediaHandler
 from .delete import DeleteHandler
+from .library import LibraryHandler
 from .system import SystemHandler
 
-__all__ = ['AuthHandler', 'MediaHandler', 'DeleteHandler', 'SystemHandler']
+__all__ = [
+    'AuthHandler', 'MediaHandler', 'DeleteHandler',
+    'LibraryHandler', 'SystemHandler',
+]

--- a/src/bot/handlers/library.py
+++ b/src/bot/handlers/library.py
@@ -1,0 +1,186 @@
+"""
+Filename: library.py
+Author: Addarr Contributors
+Created Date: 2026-02-18
+Description: Library listing handler module.
+
+This module handles /allMovies, /allSeries, and /allMusic commands,
+displaying paginated lists of media items from the user's library.
+"""
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import CommandHandler, CallbackQueryHandler
+from src.utils.logger import get_logger, log_user_interaction
+from src.services.media import MediaService
+from src.services.translation import TranslationService
+from src.bot.handlers.auth import require_auth
+
+logger = get_logger("addarr.library")
+
+ITEMS_PER_PAGE = 10
+
+# Media type short codes for callback data (stay under 64-byte limit)
+MEDIA_TYPES = {
+    "m": {"label": "movies", "service_method": "get_movies"},
+    "s": {"label": "series", "service_method": "get_series"},
+    "a": {"label": "music", "service_method": "get_music"},
+}
+
+
+class LibraryHandler:
+    """Handler for library listing operations."""
+
+    def __init__(self):
+        self.media_service = MediaService()
+        self.translation = TranslationService()
+
+    def get_handler(self):
+        """Get library command handlers."""
+        return [
+            CommandHandler("allMovies", self.handle_all_movies),
+            CommandHandler("allSeries", self.handle_all_series),
+            CommandHandler("allMusic", self.handle_all_music),
+            CallbackQueryHandler(
+                self.handle_page_navigation, pattern="^lib_"
+            ),
+        ]
+
+    @require_auth
+    async def handle_all_movies(self, update, context):
+        """Handle /allMovies command."""
+        await self._fetch_and_show(update, context, "m")
+
+    @require_auth
+    async def handle_all_series(self, update, context):
+        """Handle /allSeries command."""
+        await self._fetch_and_show(update, context, "s")
+
+    @require_auth
+    async def handle_all_music(self, update, context):
+        """Handle /allMusic command."""
+        await self._fetch_and_show(update, context, "a")
+
+    async def _fetch_and_show(self, update, context, media_type):
+        """Fetch library items and show paginated list."""
+        if not update.effective_message or not update.effective_user:
+            return
+
+        type_info = MEDIA_TYPES[media_type]
+        log_user_interaction(
+            logger, update.effective_user,
+            f"/all{type_info['label'].capitalize()}"
+        )
+
+        try:
+            method = getattr(self.media_service, type_info["service_method"])
+            items = await method()
+        except ValueError:
+            await update.message.reply_text(
+                self.translation.get_text(
+                    "LibraryNotEnabled", subject=type_info["label"]
+                )
+            )
+            return
+        except Exception:
+            logger.error(
+                f"Error fetching {type_info['label']} library",
+                exc_info=True,
+            )
+            await update.message.reply_text(
+                self.translation.get_text("LibraryError")
+            )
+            return
+
+        if not items:
+            await update.message.reply_text(
+                self.translation.get_text(
+                    "LibraryEmpty", subject=type_info["label"]
+                )
+            )
+            return
+
+        # Sort alphabetically by title
+        items = sorted(items, key=lambda x: x.get("title", "").lower())
+
+        # Cache items for pagination
+        context.user_data[f"library_{media_type}"] = items
+
+        text, reply_markup = self._build_page_message(
+            items, 0, media_type
+        )
+        await update.message.reply_text(text, reply_markup=reply_markup)
+
+    @staticmethod
+    def _build_page_message(items, page, media_type):
+        """Build a paginated text message with navigation buttons."""
+        total = len(items)
+        total_pages = (total + ITEMS_PER_PAGE - 1) // ITEMS_PER_PAGE
+        start = page * ITEMS_PER_PAGE
+        end = min(start + ITEMS_PER_PAGE, total)
+        page_items = items[start:end]
+
+        type_label = MEDIA_TYPES[media_type]["label"].capitalize()
+
+        lines = [f"📚 {type_label} ({total} total)\n"]
+        for i, item in enumerate(page_items, start=start + 1):
+            lines.append(f"{i}. {item.get('title', 'Unknown')}")
+
+        if total_pages > 1:
+            lines.append(f"\nPage {page + 1}/{total_pages}")
+
+        text = "\n".join(lines)
+
+        # Build navigation buttons
+        buttons = []
+        if page > 0:
+            buttons.append(
+                InlineKeyboardButton(
+                    "⬅️ Previous",
+                    callback_data=f"lib_{media_type}_{page - 1}",
+                )
+            )
+        if page < total_pages - 1:
+            buttons.append(
+                InlineKeyboardButton(
+                    "Next ➡️",
+                    callback_data=f"lib_{media_type}_{page + 1}",
+                )
+            )
+
+        reply_markup = InlineKeyboardMarkup([buttons]) if buttons else None
+        return text, reply_markup
+
+    async def handle_page_navigation(self, update, context):
+        """Handle pagination callback queries (lib_{type}_{page})."""
+        if not update.callback_query:
+            return
+
+        query = update.callback_query
+        await query.answer()
+
+        # Parse callback data: lib_{type}_{page}
+        parts = query.data.split("_")
+        if len(parts) != 3:
+            return
+
+        _, media_type, page_str = parts
+
+        try:
+            page = int(page_str)
+        except ValueError:
+            return
+
+        # Retrieve cached items
+        cache_key = f"library_{media_type}"
+        items = context.user_data.get(cache_key)
+
+        if not items:
+            await query.message.edit_text(
+                self.translation.get_text("LibraryExpired")
+            )
+            return
+
+        text, reply_markup = self._build_page_message(
+            items, page, media_type
+        )
+        await query.message.edit_text(text, reply_markup=reply_markup)

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from telegram.error import InvalidToken, NetworkError
 
 from src.bot.handlers.auth import AuthHandler
 from src.bot.handlers.delete import DeleteHandler
+from src.bot.handlers.library import LibraryHandler
 from src.bot.handlers.media import MediaHandler
 from src.bot.handlers.transmission import TransmissionHandler
 from src.bot.handlers.sabnzbd import SabnzbdHandler
@@ -115,6 +116,11 @@ class AddarrBot:
             # Delete handler
             delete_handler = DeleteHandler()
             for handler in delete_handler.get_handler():
+                self.application.add_handler(handler)
+
+            # Library handler
+            library_handler = LibraryHandler()
+            for handler in library_handler.get_handler():
                 self.application.add_handler(handler)
 
             # Transmission handler (if enabled)

--- a/tests/test_handlers/conftest.py
+++ b/tests/test_handlers/conftest.py
@@ -255,6 +255,26 @@ def help_handler(mock_translation_service):
 
 
 @pytest.fixture
+def library_handler(mock_media_service, mock_translation_service):
+    """Create a LibraryHandler with patched services."""
+    with (
+        patch("src.bot.handlers.library.MediaService") as mock_ms_class,
+        patch("src.bot.handlers.library.TranslationService") as mock_ts_class,
+    ):
+        mock_ts_class.return_value = mock_translation_service
+        mock_ms_class.return_value = mock_media_service
+
+        from src.bot.handlers.library import LibraryHandler
+        from src.bot.handlers.auth import AuthHandler
+
+        AuthHandler._authenticated_users = {12345}
+        handler = LibraryHandler()
+        handler._mock_service = mock_media_service
+        handler._mock_ts = mock_translation_service
+        yield handler
+
+
+@pytest.fixture
 def system_handler():
     """Create a SystemHandler with patched services."""
     with (

--- a/tests/test_handlers/test_library_handler.py
+++ b/tests/test_handlers/test_library_handler.py
@@ -1,0 +1,308 @@
+"""
+Tests for src/bot/handlers/library.py - LibraryHandler.
+
+LibraryHandler.__init__ creates MediaService() and TranslationService().
+Command handlers (allMovies, allSeries, allMusic) fetch library items and
+display them as paginated text with inline keyboard navigation.
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+
+
+# ---------------------------------------------------------------------------
+# get_handler
+# ---------------------------------------------------------------------------
+
+
+def test_get_handler_returns_list(library_handler):
+    """get_handler returns a list of handlers."""
+    handlers = library_handler.get_handler()
+
+    assert isinstance(handlers, list)
+    assert len(handlers) > 0
+
+
+# ---------------------------------------------------------------------------
+# Command success tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("command,handler_method,service_method", [
+    ("allMovies", "handle_all_movies", "get_movies"),
+    ("allSeries", "handle_all_series", "get_series"),
+    ("allMusic", "handle_all_music", "get_music"),
+])
+@pytest.mark.asyncio
+async def test_handle_command_success(
+    library_handler, make_update, make_context,
+    command, handler_method, service_method
+):
+    """Command fetches items and replies with paginated text."""
+    items = [
+        {"id": "1", "title": "Alpha"},
+        {"id": "2", "title": "Beta"},
+        {"id": "3", "title": "Gamma"},
+    ]
+    setattr(
+        library_handler._mock_service, service_method,
+        AsyncMock(return_value=items)
+    )
+
+    update = make_update(text=f"/{command}")
+    context = make_context()
+
+    handler_fn = getattr(library_handler, handler_method)
+    await handler_fn(update, context)
+
+    update.message.reply_text.assert_called_once()
+    call_args = update.message.reply_text.call_args
+    text = call_args[0][0] if call_args[0] else call_args[1].get("text", "")
+    # Items should appear alphabetically in the message
+    assert "Alpha" in text
+    assert "Beta" in text
+    assert "Gamma" in text
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_not_authenticated(
+    library_handler, make_update, make_context
+):
+    """Command rejects unauthenticated users via @require_auth."""
+    from src.bot.handlers.auth import AuthHandler
+
+    AuthHandler._authenticated_users = set()
+
+    update = make_update(text="/allMovies")
+    context = make_context()
+
+    result = await library_handler.handle_all_movies(update, context)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_handle_no_message(
+    library_handler, make_update, make_context
+):
+    """Command returns early when no effective_message."""
+    update = make_update(text="/allMovies")
+    update.effective_message = None
+    context = make_context()
+
+    result = await library_handler.handle_all_movies(update, context)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_handle_service_not_configured(
+    library_handler, make_update, make_context
+):
+    """Service not configured (ValueError) shows friendly message."""
+    library_handler._mock_service.get_movies = AsyncMock(
+        side_effect=ValueError("Radarr is not enabled or configured")
+    )
+
+    update = make_update(text="/allMovies")
+    context = make_context()
+
+    await library_handler.handle_all_movies(update, context)
+
+    update.message.reply_text.assert_called_once()
+    call_args = update.message.reply_text.call_args
+    assert "LibraryNotEnabled" in str(call_args)
+
+
+@pytest.mark.asyncio
+async def test_handle_empty_library(
+    library_handler, make_update, make_context
+):
+    """Empty library shows 'no items' message."""
+    library_handler._mock_service.get_movies = AsyncMock(return_value=[])
+
+    update = make_update(text="/allMovies")
+    context = make_context()
+
+    await library_handler.handle_all_movies(update, context)
+
+    update.message.reply_text.assert_called_once()
+    call_args = update.message.reply_text.call_args
+    assert "LibraryEmpty" in str(call_args)
+
+
+@pytest.mark.asyncio
+async def test_handle_api_error(
+    library_handler, make_update, make_context
+):
+    """Generic API error shows error message."""
+    library_handler._mock_service.get_movies = AsyncMock(
+        side_effect=Exception("Connection refused")
+    )
+
+    update = make_update(text="/allMovies")
+    context = make_context()
+
+    await library_handler.handle_all_movies(update, context)
+
+    update.message.reply_text.assert_called_once()
+    call_args = update.message.reply_text.call_args
+    assert "LibraryError" in str(call_args)
+
+
+# ---------------------------------------------------------------------------
+# Pagination (_build_page_message)
+# ---------------------------------------------------------------------------
+
+
+def test_pagination_single_page(library_handler):
+    """Single page (5 items) has no navigation buttons."""
+    items = [{"id": str(i), "title": f"Item {i}"} for i in range(5)]
+    text, reply_markup = library_handler._build_page_message(items, 0, "m")
+
+    assert "Item 0" in text
+    assert "Item 4" in text
+    assert reply_markup is None
+
+
+def test_pagination_first_page_next_only(library_handler):
+    """First page of multi-page list has only Next button."""
+    items = [{"id": str(i), "title": f"Item {i}"} for i in range(25)]
+    text, reply_markup = library_handler._build_page_message(items, 0, "m")
+
+    assert "Page 1/" in text
+    buttons = reply_markup.inline_keyboard[0]
+    assert len(buttons) == 1
+    assert "Next" in buttons[0].text
+    assert buttons[0].callback_data == "lib_m_1"
+
+
+def test_pagination_middle_page_both_buttons(library_handler):
+    """Middle page has both Previous and Next buttons."""
+    items = [{"id": str(i), "title": f"Item {i}"} for i in range(25)]
+    text, reply_markup = library_handler._build_page_message(items, 1, "m")
+
+    assert "Page 2/" in text
+    buttons = reply_markup.inline_keyboard[0]
+    assert len(buttons) == 2
+    assert "Previous" in buttons[0].text
+    assert buttons[0].callback_data == "lib_m_0"
+    assert "Next" in buttons[1].text
+    assert buttons[1].callback_data == "lib_m_2"
+
+
+def test_pagination_last_page_previous_only(library_handler):
+    """Last page has only Previous button."""
+    items = [{"id": str(i), "title": f"Item {i}"} for i in range(25)]
+    text, reply_markup = library_handler._build_page_message(items, 2, "m")
+
+    assert "Page 3/3" in text
+    buttons = reply_markup.inline_keyboard[0]
+    assert len(buttons) == 1
+    assert "Previous" in buttons[0].text
+    assert buttons[0].callback_data == "lib_m_1"
+
+
+def test_sorting_alphabetical(library_handler):
+    """Items passed in random order are numbered correctly when pre-sorted."""
+    # Note: _fetch_and_show sorts before calling _build_page_message,
+    # so we test that sorted input produces correct numbering.
+    items = [
+        {"id": "3", "title": "Zulu"},
+        {"id": "1", "title": "Alpha"},
+        {"id": "2", "title": "Mike"},
+    ]
+    sorted_items = sorted(items, key=lambda x: x["title"].lower())
+    text, _ = library_handler._build_page_message(sorted_items, 0, "m")
+
+    # Verify alphabetical ordering in output
+    alpha_pos = text.index("Alpha")
+    mike_pos = text.index("Mike")
+    zulu_pos = text.index("Zulu")
+    assert alpha_pos < mike_pos < zulu_pos
+
+
+# ---------------------------------------------------------------------------
+# Navigation callback (handle_page_navigation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_navigation_callback(
+    library_handler, make_update, make_context
+):
+    """lib_m_1 callback edits message with page 1 content."""
+    items = [{"id": str(i), "title": f"Item {i:02d}"} for i in range(25)]
+    update = make_update(callback_data="lib_m_1")
+    context = make_context(user_data={"library_m": items})
+
+    await library_handler.handle_page_navigation(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    update.callback_query.message.edit_text.assert_called_once()
+    call_args = update.callback_query.message.edit_text.call_args
+    text = call_args[0][0] if call_args[0] else call_args[1].get("text", "")
+    # Page 2 should show items 11-20
+    assert "Item 10" in text
+    assert "Page 2/" in text
+
+
+@pytest.mark.asyncio
+async def test_navigation_expired_session(
+    library_handler, make_update, make_context
+):
+    """Expired session (no cached data) shows error message."""
+    update = make_update(callback_data="lib_m_1")
+    context = make_context(user_data={})
+
+    await library_handler.handle_page_navigation(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    update.callback_query.message.edit_text.assert_called_once()
+    call_args = update.callback_query.message.edit_text.call_args
+    assert "LibraryExpired" in str(call_args)
+
+
+@pytest.mark.asyncio
+async def test_navigation_no_callback_query(
+    library_handler, make_update, make_context
+):
+    """handle_page_navigation returns when no callback_query."""
+    update = make_update(text="/test")
+    update.callback_query = None
+    context = make_context()
+
+    result = await library_handler.handle_page_navigation(update, context)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_navigation_malformed_callback_data(
+    library_handler, make_update, make_context
+):
+    """Malformed callback data (wrong number of parts) returns early."""
+    update = make_update(callback_data="lib_m")
+    context = make_context()
+
+    result = await library_handler.handle_page_navigation(update, context)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_navigation_non_integer_page(
+    library_handler, make_update, make_context
+):
+    """Non-integer page number returns early."""
+    update = make_update(callback_data="lib_m_abc")
+    context = make_context()
+
+    result = await library_handler.handle_page_navigation(update, context)
+
+    assert result is None

--- a/translations/addarr.de-de.yml
+++ b/translations/addarr.de-de.yml
@@ -33,7 +33,13 @@ de-de:
   # Navigation
   Next: Weiter
   Previous: Zurück
-  
+
+  # Library listing
+  LibraryEmpty: "📭 No %{subject} found in your library."
+  LibraryNotEnabled: "❌ %{subject} is not enabled or configured."
+  LibraryError: "❌ Error loading library. Please try again later."
+  LibraryExpired: "⏳ Session expired. Please run the command again."
+
   # Common messages
   Start chatting: "🤖 Starte einen Chat mit Addarr auf Telegram. Das erste Mal wenn du \"start\" verwendest wirst du gebeten dein Password einzugeben."
   End: "🏁 Die Aktion wurde beendet."

--- a/translations/addarr.en-us.yml
+++ b/translations/addarr.en-us.yml
@@ -33,6 +33,12 @@ en-us:
   # Navigation
   Next: Next
   Previous: Previous
+
+  # Library listing
+  LibraryEmpty: "📭 No %{subject} found in your library."
+  LibraryNotEnabled: "❌ %{subject} is not enabled or configured."
+  LibraryError: "❌ Error loading library. Please try again later."
+  LibraryExpired: "⏳ Session expired. Please run the command again."
   
   # Common messages
   Start chatting: "🤖 Start chatting with Addarr in Telegram. The first time you use \"start\" you will be asked to enter your password."

--- a/translations/addarr.es-es.yml
+++ b/translations/addarr.es-es.yml
@@ -33,7 +33,13 @@ es-es:
   # Navigation
   Next: Siguiente
   Previous: Anterior
-  
+
+  # Library listing
+  LibraryEmpty: "📭 No %{subject} found in your library."
+  LibraryNotEnabled: "❌ %{subject} is not enabled or configured."
+  LibraryError: "❌ Error loading library. Please try again later."
+  LibraryExpired: "⏳ Session expired. Please run the command again."
+
   # Common messages
   Start chatting: "🤖 Empieza a chatear con Addarr en Telegram. La primera vez que uses \"start\" te pedirá introducir tu contraseña configurada."
   End: "🏁 El proceso ha terminado."

--- a/translations/addarr.fr-fr.yml
+++ b/translations/addarr.fr-fr.yml
@@ -33,7 +33,13 @@ fr-fr:
   # Navigation
   Next: Suivant
   Previous: Précédent
-  
+
+  # Library listing
+  LibraryEmpty: "📭 No %{subject} found in your library."
+  LibraryNotEnabled: "❌ %{subject} is not enabled or configured."
+  LibraryError: "❌ Error loading library. Please try again later."
+  LibraryExpired: "⏳ Session expired. Please run the command again."
+
   # Common messages
   Start chatting: "🤖 Commencez à chatter avec Addarr sur Telegram. La première fois que vous utiliserez \"start\" il vous sera demandé de saisir un mot de passe."
   End: "🏁 Le processus est terminé."

--- a/translations/addarr.it-it.yml
+++ b/translations/addarr.it-it.yml
@@ -33,7 +33,13 @@ it-it:
   # Navigation
   Next: Successivo
   Previous: Precedente
-  
+
+  # Library listing
+  LibraryEmpty: "📭 No %{subject} found in your library."
+  LibraryNotEnabled: "❌ %{subject} is not enabled or configured."
+  LibraryError: "❌ Error loading library. Please try again later."
+  LibraryExpired: "⏳ Session expired. Please run the command again."
+
   # Common messages
   Start chatting: "🤖 Inizia a chattare con Addarr su Telegram. La prima volta che usi \"start\" dovrai inserire la password."
   End: "🏁 Il processo è terminato."

--- a/translations/addarr.nl-be.yml
+++ b/translations/addarr.nl-be.yml
@@ -33,7 +33,13 @@ nl-be:
   # Navigation
   Next: Volgende
   Previous: Vorige
-  
+
+  # Library listing
+  LibraryEmpty: "📭 No %{subject} found in your library."
+  LibraryNotEnabled: "❌ %{subject} is not enabled or configured."
+  LibraryError: "❌ Error loading library. Please try again later."
+  LibraryExpired: "⏳ Session expired. Please run the command again."
+
   # Common messages
   Start chatting: "🤖 Je kan nu chatten met Addarr op Telegram. De eerste keer dat je \"start\" gebruikt, zul je je wachtwoord moeten ingeven."
   End: "🏁 Het proces is beëindigd."

--- a/translations/addarr.pl-pl.yml
+++ b/translations/addarr.pl-pl.yml
@@ -33,7 +33,13 @@ pl-pl:
   # Navigation
   Next: Następny
   Previous: Poprzedni
-  
+
+  # Library listing
+  LibraryEmpty: "📭 No %{subject} found in your library."
+  LibraryNotEnabled: "❌ %{subject} is not enabled or configured."
+  LibraryError: "❌ Error loading library. Please try again later."
+  LibraryExpired: "⏳ Session expired. Please run the command again."
+
   # Common messages
   Start chatting: "🤖 Rozpocznij rozmowę z Addarrem na Telegramie. Przy pierwszym użyciu \"start\" zostaniesz poproszony o podanie hasła."
   End: "🏁 Proces zakończony."

--- a/translations/addarr.pt-pt.yml
+++ b/translations/addarr.pt-pt.yml
@@ -33,7 +33,13 @@ pt-pt:
   # Navigation
   Next: Seguinte
   Previous: Anterior
-  
+
+  # Library listing
+  LibraryEmpty: "📭 No %{subject} found in your library."
+  LibraryNotEnabled: "❌ %{subject} is not enabled or configured."
+  LibraryError: "❌ Error loading library. Please try again later."
+  LibraryExpired: "⏳ Session expired. Please run the command again."
+
   # Common messages
   Start chatting: "🤖 Comece um chat com o Addarr no Telegram. Da primeira vez que escrever \"start\" deverá introduzir a password."
   End: "🏁 O processo terminou."

--- a/translations/addarr.ru-ru.yml
+++ b/translations/addarr.ru-ru.yml
@@ -33,7 +33,13 @@ ru-ru:
   # Navigation
   Next: Следующий
   Previous: Предыдущий
-  
+
+  # Library listing
+  LibraryEmpty: "📭 No %{subject} found in your library."
+  LibraryNotEnabled: "❌ %{subject} is not enabled or configured."
+  LibraryError: "❌ Error loading library. Please try again later."
+  LibraryExpired: "⏳ Session expired. Please run the command again."
+
   # Common messages
   Start chatting: "🤖 Начните общаться с Addarr в Telegram. При первом использовании \"start\" вам будет предложено ввести пароль."
   End: "🏁 Процесс завершен."

--- a/translations/addarr.template.yml
+++ b/translations/addarr.template.yml
@@ -37,6 +37,12 @@ template:
   # Navigation
   Next: Next
   Previous: Previous
+
+  # Library listing
+  LibraryEmpty: "📭 No %{subject} found in your library."
+  LibraryNotEnabled: "❌ %{subject} is not enabled or configured."
+  LibraryError: "❌ Error loading library. Please try again later."
+  LibraryExpired: "⏳ Session expired. Please run the command again."
   
   # Common messages
   Start chatting: "🤖 Start chatting with Addarr in Telegram. The first time you use \"start\" you will be asked to enter your password."


### PR DESCRIPTION
## Summary
- Add `LibraryHandler` with `/allMovies`, `/allSeries`, `/allMusic` commands that display paginated library listings (10 items per page) with inline keyboard navigation
- New handler registered in `main.py` after DeleteHandler; uses `@require_auth` for access control
- Translation keys (`LibraryEmpty`, `LibraryNotEnabled`, `LibraryError`, `LibraryExpired`) added to all 9 locales + template

## Changes
- **Handlers**: New `src/bot/handlers/library.py` (LibraryHandler with `_fetch_and_show`, `_build_page_message`, `handle_page_navigation`)
- **Registration**: `src/main.py` imports and registers LibraryHandler; `__init__.py` exports it
- **i18n**: 4 new keys in all 10 translation files
- **Tests**: 19 tests in `tests/test_handlers/test_library_handler.py` with 100% coverage
- **Fixtures**: `library_handler` fixture added to `tests/test_handlers/conftest.py`

## Test plan
- [ ] Run `pytest --tb=short -q` — 872 tests pass
- [ ] Run `flake8 .` — clean
- [ ] Run `python run.py --validate-i18n` — all translations valid
- [ ] Verify `/allMovies` command shows paginated movie list with Next/Previous buttons
- [ ] Verify unauthenticated users are rejected
- [ ] Verify empty library shows friendly "no items" message
- [ ] Verify service-not-configured shows "not enabled" message

## Related issue
Closes #15