### PR TITLE
Fix STOPSIGNAL to use SIGTERM for graceful shutdown (#29)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN addgroup -S addarr && adduser -S addarr -G addarr \
 USER addarr
 
 # Graceful shutdown signal
-STOPSIGNAL SIGINT
+STOPSIGNAL SIGTERM
 
 # Health check - verify the process is running
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \


### PR DESCRIPTION
## Summary
- Changed `STOPSIGNAL` from `SIGINT` to `SIGTERM` in the Dockerfile for proper graceful shutdown behavior
- `SIGTERM` is the standard signal used by container orchestrators (Docker, Kubernetes) to request graceful shutdown

Closes #29

## Test plan
- [x] Docker build succeeds
- [x] Flake8 lint clean
- [x] All 1005 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)