### PR TITLE
Document network_mode: host in docker-compose.yml (#30)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,15 @@ services:
     container_name: addarr-refresh
     build: .
     restart: unless-stopped
+    # Host networking is used because Addarr is a Telegram bot that makes
+    # outbound connections only (no listening ports). It needs to reach
+    # Radarr, Sonarr, Lidarr, Transmission, and SABnzbd which typically
+    # run on the same host. Host mode avoids the need to configure bridge
+    # networking or explicit port mappings for each service.
+    #
+    # To use bridge networking instead (e.g. for Docker Swarm or stricter
+    # network isolation), remove this line and ensure Addarr can reach
+    # your media services via their container names or host.docker.internal.
     network_mode: host
     volumes:
       - ./config.yaml:/app/config.yaml:ro


### PR DESCRIPTION
## Summary
- Added inline comments to `docker-compose.yml` explaining why `network_mode: host` is used (outbound-only Telegram bot, needs to reach local media services)
- Documented how to switch to bridge networking for Docker Swarm or stricter isolation

Closes #30

## Test plan
- [x] Flake8 lint clean
- [x] All 1005 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)