### PR TITLE
Add Transmission health checks to HealthService (#22)

### DIFF
--- a/docs/issues/issue-22/TASKS.md
+++ b/docs/issues/issue-22/TASKS.md
@@ -1,0 +1,39 @@
+# Issue #22: Add Transmission Health Checks to HealthService
+
+### Phase 1: Implement Transmission Health Check (1 task)
+
+**Goal:** Include Transmission in the periodic health check loop so it appears in `download_clients` results alongside SABnzbd.
+
+- [x] **1.1** Add `check_transmission_health` to HealthService and wire into `run_health_checks`
+    - **Context:**
+        - **Why:** `HealthService.run_health_checks()` monitors Radarr, Sonarr, Lidarr, and SABnzbd but skips Transmission entirely — operators have no visibility into Transmission connectivity
+        - **Architecture:** Delegates to `TransmissionClient` instead of making direct HTTP calls (unlike SABnzbd/media checks). Transmission uses an RPC protocol with 409 session ID negotiation that the client already handles — reimplementing it in the health service would be duplication. The method takes no parameters because `TransmissionClient.__init__` reads config internally (flat structure: `host`, `port`, `ssl`, `username`, `password`).
+        - **Key refs:**
+            - `src/services/health.py:190` — `check_sabnzbd_health()` as pattern for download client health check (return `Tuple[bool, str]`)
+            - `src/services/health.py:223` — `run_health_checks()` where Transmission block goes (before SABnzbd block at line 256)
+            - `src/api/transmission.py:66` — `get_session()` returns `{"arguments": {"version": "4.0.0", ...}, "result": "success"}`
+            - `tests/test_services/test_health_service.py:270` — `TestCheckSabnzbdHealth` as pattern for test class structure
+        - **Watch out:**
+            - Mock via `patch("src.services.health.TransmissionClient")` — NOT `aioresponses`, since we delegate to the client rather than making direct HTTP
+            - Existing `test_run_health_checks_sabnzbd_enabled` patches `config.get` with a `side_effect` that doesn't handle `"transmission"` — it falls through to `default={}`, so `{}.get("enable")` is falsy. No breakage.
+            - Exception hierarchy must match other health checks: `ClientConnectorError` → `TimeoutError` → generic `Exception`
+    - **Scope:** Add `check_transmission_health() -> Tuple[bool, str]` method, add Transmission block in `run_health_checks()`, plus 8 tests (5 unit + 3 integration)
+    - **Touches:** `src/services/health.py`, `tests/test_services/test_health_service.py`
+    - **Action items:**
+        - [RED] Write `TestCheckTransmissionHealth` in `tests/test_services/test_health_service.py` (5 tests: success, missing version, connection error, timeout, generic exception) — patch `src.services.health.TransmissionClient`, configure `get_session()` return/side_effect
+        - [RED] Write 3 integration tests in `TestRunHealthChecks` (transmission enabled, transmission disabled, both download clients enabled) — patch `config.get` side_effect and `patch.object` on health check methods
+        - [GREEN] Add `from src.api.transmission import TransmissionClient` to `src/services/health.py`
+        - [GREEN] Implement `check_transmission_health()` after `check_sabnzbd_health` — create `TransmissionClient()`, call `get_session()`, extract version from `arguments.version`
+        - [GREEN] Add Transmission block in `run_health_checks()` before SABnzbd — check `config.get("transmission", {}).get("enable")`, call method, append to `download_clients`
+    - **Success:** `pytest tests/test_services/test_health_service.py -v` all pass (8 new + existing), `pytest --tb=short -q` full suite green, `flake8` clean
+    - **Completed:** 2026-02-20
+    - **Learnings:**
+        - Transmission health check delegates to `TransmissionClient` rather than direct HTTP — different pattern from SABnzbd/media because RPC 409 negotiation is too complex to duplicate
+        - Mocking approach differs accordingly: `patch("src.services.health.TransmissionClient")` instead of `aioresponses` — mock the class, configure `get_session()` return value on the instance
+        - Existing integration test `test_run_health_checks_sabnzbd_enabled` was unaffected because its config `side_effect` falls through to `default={}` for unhandled keys
+    - **Key Changes:**
+        - Added `check_transmission_health() -> Tuple[bool, str]` in `src/services/health.py:224`
+        - Added Transmission block in `run_health_checks()` in `src/services/health.py:270` (before SABnzbd)
+        - Added `TestCheckTransmissionHealth` (5 tests) in `tests/test_services/test_health_service.py`
+        - Added 3 integration tests to `TestRunHealthChecks` (enabled, disabled, both clients)
+    - **Notes:** All 1022 tests pass. Health service now checks all 5 services: Radarr, Sonarr, Lidarr, Transmission, SABnzbd.

--- a/docs/issues/issue-22/plan.md
+++ b/docs/issues/issue-22/plan.md
@@ -1,0 +1,94 @@
+# Fix: Add Transmission Health Checks to HealthService (Issue #22)
+
+## Context
+
+`HealthService.run_health_checks()` monitors media services (Radarr, Sonarr, Lidarr) and SABnzbd, but **Transmission is missing**. When Transmission is enabled in config, it should appear in `download_clients` results alongside SABnzbd — with version info on success, and descriptive errors on failure.
+
+**Design decision**: Delegate to `TransmissionClient` rather than making direct HTTP calls (unlike SABnzbd/media checks). Transmission uses an RPC protocol with 409 session ID negotiation that `TransmissionClient` already handles. Reimplementing it would be duplication.
+
+The method takes **no parameters** — `TransmissionClient.__init__` reads config internally (flat structure: `host`, `port`, `ssl`, `username`, `password`). Only the `enable` flag is needed from `run_health_checks()`.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `tests/test_services/test_health_service.py` | Add `TestCheckTransmissionHealth` (5 tests) + 3 integration tests to `TestRunHealthChecks` |
+| `src/services/health.py` | Add import, `check_transmission_health()` method, Transmission block in `run_health_checks()` |
+
+## TDD Steps
+
+### Step 1 — RED: Write failing tests
+
+Add `TestCheckTransmissionHealth` class after `TestCheckSabnzbdHealth` (~line 391). Mock via `patch("src.services.health.TransmissionClient")`:
+
+| Test | Mock behavior | Expected return |
+|---|---|---|
+| `test_check_transmission_health_success` | `get_session()` returns `{"arguments": {"version": "4.0.0"}, "result": "success"}` | `(True, "Online (v4.0.0)")` |
+| `test_check_transmission_health_missing_version` | `get_session()` returns `{"arguments": {}, "result": "success"}` | `(True, "Online (vUnknown)")` |
+| `test_check_transmission_health_connection_error` | `get_session()` raises `aiohttp.ClientConnectorError` | `(False, "Error: Connection failed")` |
+| `test_check_transmission_health_timeout` | `get_session()` raises `asyncio.TimeoutError()` | `(False, "Error: Connection timeout")` |
+| `test_check_transmission_health_generic_exception` | `get_session()` raises `RuntimeError("Unexpected")` | `(False, "Error: Unexpected")` |
+
+Add 3 integration tests to `TestRunHealthChecks`:
+
+| Test | Config setup | Assertion |
+|---|---|---|
+| `test_run_health_checks_transmission_enabled` | Patch config with transmission `enable: True` | `download_clients` contains `{"name": "Transmission", ...}`, `check_transmission_health` called once |
+| `test_run_health_checks_transmission_disabled` | Default config (transmission `enable: False`) | `check_transmission_health` NOT called, no Transmission in results |
+| `test_run_health_checks_both_download_clients` | Both transmission + sabnzbd enabled | `download_clients` has 2 entries: Transmission and SABnzbd |
+
+### Step 2 — GREEN: Implement
+
+**`src/services/health.py`** — Add import:
+```python
+from src.api.transmission import TransmissionClient
+```
+
+**`src/services/health.py`** — Add method after `check_sabnzbd_health` (~line 221):
+```python
+async def check_transmission_health(self) -> Tuple[bool, str]:
+    """Check Transmission connection via RPC client."""
+    try:
+        client = TransmissionClient()
+        data = await client.get_session()
+        version = data.get("arguments", {}).get("version", "Unknown")
+        return True, f"Online (v{version})"
+    except aiohttp.ClientConnectorError:
+        return False, "Error: Connection failed"
+    except asyncio.TimeoutError:
+        return False, "Error: Connection timeout"
+    except Exception as e:
+        return False, f"Error: {str(e)}"
+```
+
+**`src/services/health.py`** — Add Transmission block in `run_health_checks()` before the SABnzbd block (~line 256):
+```python
+# Check Transmission
+transmission = config.get("transmission", {})
+if transmission.get("enable"):
+    is_healthy, status = await self.check_transmission_health()
+    results["download_clients"].append({
+        "name": "Transmission",
+        "healthy": is_healthy,
+        "status": status
+    })
+```
+
+### Step 3 — Verify
+
+```bash
+pytest tests/test_services/test_health_service.py -v
+pytest --tb=short -q
+flake8 src/services/health.py tests/test_services/test_health_service.py
+```
+
+## Existing test compatibility
+
+The existing `test_run_health_checks_sabnzbd_enabled` patches `config.get` with a `side_effect` that only handles `sabnzbd`/`radarr`/`sonarr`/`lidarr`. For `transmission`, it falls through to `default={}`, so `{}.get("enable")` is falsy — the Transmission block is skipped. No breakage.
+
+## Verification
+
+1. `pytest tests/test_services/test_health_service.py -v` — all tests pass including 8 new ones
+2. `pytest --tb=short -q` — full suite green
+3. `flake8 src/services/health.py tests/test_services/test_health_service.py` — clean
+4. `python scripts/test_runner.py services --coverage` — `check_transmission_health` fully covered


### PR DESCRIPTION
## Summary
- Add `check_transmission_health()` to `HealthService` that delegates to `TransmissionClient` for RPC session negotiation and version extraction
- Wire Transmission into `run_health_checks()` so it appears in `download_clients` results alongside SABnzbd when enabled
- Add 8 tests: 5 unit tests (success, missing version, connection error, timeout, generic exception) + 3 integration tests (enabled, disabled, both download clients)

## Changes
- **Services**: `src/services/health.py` — new `check_transmission_health()` method + Transmission block in `run_health_checks()`
- **Tests**: `tests/test_services/test_health_service.py` — `TestCheckTransmissionHealth` class (5 tests) + 3 integration tests in `TestRunHealthChecks`
- **Docs**: `docs/issues/issue-22/` — plan and TASKS.md

## Test plan
- [x] All 1022 tests pass (`pytest --tb=short -q`)
- [x] Flake8 clean
- [x] 8 new health service tests cover success, error, and integration paths
- [x] Existing tests unaffected (no regressions)

## Related issue
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)