### PR TITLE
Fix deprecated CallbackContext and mixed imports in transmission handler

### DIFF
--- a/.claude/commands/addarr-setup.md
+++ b/.claude/commands/addarr-setup.md
@@ -1,0 +1,39 @@
+Load skills for an Addarr development session. Invoke each skill listed below using the Skill tool. Do NOT summarize or skip any — invoke them all sequentially.
+
+Argument: $ARGUMENTS
+
+## Skill sets
+
+### Always load (all setups):
+- `addarr-testing`
+- `python-testing-pro`
+
+### If argument is `dev` (or no argument):
+- `task-writer`
+- `superpowers:test-driven-development`
+- `superpowers:writing-plans`
+- `superpowers:brainstorming`
+- `superpowers:systematic-debugging`
+- `superpowers:verification-before-completion`
+
+### If argument is `pr`:
+- `superpowers:verification-before-completion`
+
+Also read these reference files into context (use the Read tool):
+- `.claude/skills/addarr-workflow/references/create-pr.md`
+- `.claude/skills/addarr-workflow/references/preflight.md`
+
+### If argument is `feedback`:
+- `superpowers:receiving-code-review`
+- `superpowers:systematic-debugging`
+- `superpowers:verification-before-completion`
+
+Also read these reference files into context (use the Read tool):
+- `.claude/skills/addarr-workflow/references/feedback.md`
+
+### If unrecognized argument:
+Ask the user which setup they want: `dev`, `pr`, or `feedback`.
+
+## After loading
+
+Confirm which skills were loaded and say you're ready to start.

--- a/.claude/skills/addarr-workflow/SKILL.md
+++ b/.claude/skills/addarr-workflow/SKILL.md
@@ -12,6 +12,8 @@ description: |
 
 Orchestrates the development workflow for Addarr. Entry point: `/addarr [argument]`
 
+**IMPORTANT:** All PRs target `development` as base branch, never `main`.
+
 ## Entry Points
 
 | Command | Flow | Description |

--- a/docs/issues/issue-77/TASKS.md
+++ b/docs/issues/issue-77/TASKS.md
@@ -1,0 +1,31 @@
+# Issue #77: Fix Deprecated CallbackContext and Mixed Imports in Transmission Handler
+
+### Phase 1: Align Transmission Handler with Project Conventions (1 task)
+
+**Goal:** Replace deprecated `CallbackContext` with `ContextTypes.DEFAULT_TYPE` and convert relative imports to absolute, matching all 8 other handlers.
+
+- [x] **1.1** Fix imports and method signatures in transmission handler
+    - **Context:**
+        - **Why:** `transmission.py` is the only handler using deprecated `CallbackContext` (python-telegram-bot v20+) and mixing relative/absolute imports. This creates inconsistency and will break when `CallbackContext` is removed upstream.
+        - **Architecture:** Pure cleanup — no behavior changes. All other handlers use `ContextTypes.DEFAULT_TYPE` and absolute `from src.xxx` imports. Follow existing pattern exactly.
+        - **Key refs:** `src/bot/handlers/transmission.py:9` (CallbackContext import), `:14-16` (mixed imports), `:39` and `:81` (method signatures). Reference handler: `src/bot/handlers/sabnzbd.py` (same download-client pattern).
+        - **Watch out:** Tests use `make_context` fixture — no `CallbackContext` references in tests, so no test changes needed. Verify with `grep -r "CallbackContext" tests/` before and after.
+    - **Scope:** Import block + 2 method signatures in transmission.py
+    - **Touches:** `src/bot/handlers/transmission.py`
+    - **Action items:**
+        - [GREEN] Run `pytest tests/test_handlers/test_transmission_handler.py -v` to establish baseline (all 7 tests pass)
+        - [GREEN] Replace `CallbackContext` import with `ContextTypes` on line 9
+        - [GREEN] Convert 2 relative imports to absolute on lines 14-15
+        - [GREEN] Update `transmission_command` signature: `CallbackContext` → `ContextTypes.DEFAULT_TYPE` on line 39
+        - [GREEN] Update `handle_callback` signature: `CallbackContext` → `ContextTypes.DEFAULT_TYPE` on line 81
+        - [GREEN] Run `pytest tests/test_handlers/test_transmission_handler.py -v` — all 7 tests pass
+        - [GREEN] Run `pytest --tb=short -q` — no regressions
+        - [GREEN] Run `flake8 src/bot/handlers/transmission.py` — clean
+    - **Success:** All tests pass, lint clean, no `CallbackContext` or relative imports remain in file
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - `replace_all` on the Edit tool cleanly handles updating both method signatures in one pass since `context: CallbackContext` was unique enough as a search pattern
+        - Tests needed zero changes — `make_context` fixture fully abstracts the context type, confirming good test design
+    - **Key Changes:**
+        - `src/bot/handlers/transmission.py`: Replaced `CallbackContext` import with `ContextTypes`, converted 2 relative imports (`...services`, `...utils`) to absolute (`src.services`, `src.utils`), updated 2 method signatures to `ContextTypes.DEFAULT_TYPE`
+    - **Notes:** All 1029 tests pass, 0 regressions. Transmission handler now matches all 8 other handlers.

--- a/docs/issues/issue-77/plan.md
+++ b/docs/issues/issue-77/plan.md
@@ -1,0 +1,115 @@
+# Fix #77: Deprecated CallbackContext and Mixed Imports
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Align `transmission.py` with the rest of the codebase by replacing deprecated `CallbackContext` with `ContextTypes.DEFAULT_TYPE` and converting relative imports to absolute.
+
+**Architecture:** Pure cleanup — no behavior changes. All 8 other handlers already use `ContextTypes.DEFAULT_TYPE` and absolute `from src.xxx` imports. This brings the 9th handler into consistency.
+
+**Tech Stack:** python-telegram-bot v20+, Python 3.11
+
+---
+
+### Task 1: Verify existing tests pass (baseline)
+
+**Files:**
+- Read: `tests/test_handlers/test_transmission_handler.py`
+
+**Step 1: Run transmission tests**
+
+Run: `pytest tests/test_handlers/test_transmission_handler.py -v`
+Expected: All 7 tests PASS
+
+**Step 2: Confirm no `CallbackContext` references in tests**
+
+Run: `grep -r "CallbackContext" tests/`
+Expected: No matches (tests use `make_context` fixture)
+
+---
+
+### Task 2: Fix imports in transmission handler
+
+**Files:**
+- Modify: `src/bot/handlers/transmission.py:9` (telegram.ext import)
+- Modify: `src/bot/handlers/transmission.py:14-16` (relative imports)
+
+**Step 1: Replace `CallbackContext` import with `ContextTypes`**
+
+```python
+# Line 9 — BEFORE:
+from telegram.ext import CommandHandler, CallbackContext, CallbackQueryHandler
+
+# AFTER:
+from telegram.ext import CommandHandler, CallbackQueryHandler, ContextTypes
+```
+
+**Step 2: Convert relative imports to absolute**
+
+```python
+# Lines 14-16 — BEFORE:
+from ...services.transmission import transmission_service
+from ...utils.logger import get_logger
+from src.bot.keyboards import get_yes_no_keyboard
+
+# AFTER:
+from src.services.transmission import transmission_service
+from src.utils.logger import get_logger
+from src.bot.keyboards import get_yes_no_keyboard
+```
+
+---
+
+### Task 3: Update method signatures
+
+**Files:**
+- Modify: `src/bot/handlers/transmission.py:39` (`transmission_command`)
+- Modify: `src/bot/handlers/transmission.py:81` (`handle_callback`)
+
+**Step 1: Update `transmission_command` signature**
+
+```python
+# Line 39 — BEFORE:
+async def transmission_command(self, update: Update, context: CallbackContext) -> None:
+
+# AFTER:
+async def transmission_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+```
+
+**Step 2: Update `handle_callback` signature**
+
+```python
+# Line 81 — BEFORE:
+async def handle_callback(self, update: Update, context: CallbackContext) -> None:
+
+# AFTER:
+async def handle_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+```
+
+---
+
+### Task 4: Verify and commit
+
+**Step 1: Run transmission tests**
+
+Run: `pytest tests/test_handlers/test_transmission_handler.py -v`
+Expected: All 7 tests PASS
+
+**Step 2: Run full test suite**
+
+Run: `pytest --tb=short -q`
+Expected: All tests PASS, no regressions
+
+**Step 3: Lint the changed file**
+
+Run: `flake8 src/bot/handlers/transmission.py`
+Expected: Clean (no output)
+
+**Step 4: Commit**
+
+```bash
+git add src/bot/handlers/transmission.py
+git commit -m "fix: replace deprecated CallbackContext with ContextTypes.DEFAULT_TYPE (#77)
+
+Convert relative imports to absolute imports matching project convention.
+No behavior changes."
+```

--- a/src/bot/handlers/transmission.py
+++ b/src/bot/handlers/transmission.py
@@ -6,13 +6,13 @@ Description: Telegram command handler for Transmission operations.
 """
 
 from telegram import Update
-from telegram.ext import CommandHandler, CallbackContext, CallbackQueryHandler
+from telegram.ext import CommandHandler, CallbackQueryHandler, ContextTypes
 from telegram.constants import ParseMode
 from typing import List
 
 
-from ...services.transmission import transmission_service
-from ...utils.logger import get_logger
+from src.services.transmission import transmission_service
+from src.utils.logger import get_logger
 from src.bot.keyboards import get_yes_no_keyboard
 
 logger = get_logger("addarr.handlers.transmission")
@@ -36,7 +36,7 @@ class TransmissionHandler:
             CallbackQueryHandler(self.handle_callback, pattern=r"^transmission_.*")
         ]
 
-    async def transmission_command(self, update: Update, context: CallbackContext) -> None:
+    async def transmission_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle /transmission command
 
         Shows Transmission status and turtle mode options
@@ -78,7 +78,7 @@ class TransmissionHandler:
             parse_mode=ParseMode.MARKDOWN
         )
 
-    async def handle_callback(self, update: Update, context: CallbackContext) -> None:
+    async def handle_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle callback queries for Transmission commands"""
         query = update.callback_query
         await query.answer()


### PR DESCRIPTION
## Summary
- Replace deprecated `CallbackContext` with `ContextTypes.DEFAULT_TYPE` in transmission handler
- Convert relative imports to absolute imports matching all other handlers
- No behavior changes — pure consistency cleanup

## Changes
- **Handler:** `src/bot/handlers/transmission.py` — updated import block (removed `CallbackContext`, added `ContextTypes`, converted 2 relative imports to absolute) and 2 method signatures
- **Tooling:** Added `/addarr-setup` command for dev session skill loading
- **Docs:** Added `docs/issues/issue-77/` with plan and TASKS.md

## Test plan
- [x] All 7 transmission handler tests pass
- [x] Full suite: 1029 tests pass, 0 regressions
- [x] Flake8: clean
- [x] Translation validation: all 9 locales valid

## Related issue
Closes #77