### PR TITLE
Upgrade AI review model to GPT-OSS-120B with 8K TPM guard

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -48,8 +48,8 @@ jobs:
               mediaType: { format: 'diff' }
             });
             const fs = require('fs');
-            // Truncate diff to ~100KB to stay within model context limits
-            const diffText = diff.data.substring(0, 100000);
+            // Truncate diff to ~50KB — further trimmed later to fit 8K TPM limit
+            const diffText = diff.data.substring(0, 50000);
             fs.writeFileSync('pr_diff.txt', diffText);
 
             // Get PR details
@@ -157,7 +157,7 @@ jobs:
           PR_TITLE: ${{ steps.pr.outputs.title }}
           PR_BODY: ${{ steps.pr.outputs.body }}
         run: |
-          # Build request with Python — use code-only diff, cap at 32KB for token limits
+          # Build request with Python — use code-only diff, cap to stay within 8K TPM
           python3 << 'PYEOF'
           import json, os
 
@@ -166,18 +166,19 @@ jobs:
           with open(diff_file, 'r') as f:
               diff = f.read()
 
-          # Cap diff size to ~80KB to stay within Groq token limits
-          if len(diff) > 80000:
-              diff = diff[:80000] + "\n\n... (diff truncated for token limit)"
+          # Token budget: 8K TPM limit on Groq free tier
+          # ~2K output + ~425 prompt overhead = ~5,500 tokens for diff (~20K chars)
+          if len(diff) > 20000:
+              diff = diff[:20000] + "\n\n... (diff truncated to stay within 8K TPM limit)"
 
           title = os.environ.get('PR_TITLE', 'PR Review')
           pr_body = os.environ.get('PR_BODY', '').strip()
           description = f"\n\nPR Description:\n{pr_body}" if pr_body else ""
 
           request = {
-              "model": "llama-3.3-70b-versatile",
+              "model": "openai/gpt-oss-120b",
               "temperature": 0.3,
-              "max_tokens": 4096,
+              "max_tokens": 2048,
               "messages": [
                   {
                       "role": "system",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Handlers are registered in `AddarrBot._add_handlers()` in this order: Start, Aut
 GitHub Actions workflows in `.github/workflows/`:
 
 - **`ci.yml`** — Runs on PRs to `main`/`development`. Jobs: flake8 lint, pytest with coverage, translation validation (`--validate-i18n`), Docker build test.
-- **`auto-approve.yml`** — Triggered after CI succeeds. Performs AI-powered PR review via Groq (Qwen3-32B) plus rule-based checks (TODOs, print statements, large files, hardcoded secrets, bare excepts). Posts review comment and auto-approves. Requires `GROQ_API_KEY` and `REVIEWER_BOT_TOKEN` secrets.
+- **`auto-approve.yml`** — Triggered after CI succeeds. Performs AI-powered PR review via Groq (GPT-OSS-120B) plus rule-based checks (TODOs, print statements, large files, hardcoded secrets, bare excepts). Posts review comment and auto-approves. Requires `GROQ_API_KEY` and `REVIEWER_BOT_TOKEN` secrets.
 - **`codeql-analysis.yml`** — CodeQL security scanning on push/PR.
 - **`docker-hub-push.yml`** — Publishes Docker image to Docker Hub.
 


### PR DESCRIPTION
## Summary
- Switch CI AI review from `llama-3.3-70b-versatile` to `openai/gpt-oss-120b` for stronger code understanding (87.3% HumanEval, 62.4% SWE-bench)
- Cap token usage to stay within Groq free tier 8K TPM limit
- 75% cheaper input tokens ($0.15 vs $0.59 per M)

## Changes
- **Model**: `llama-3.3-70b-versatile` → `openai/gpt-oss-120b`
- **Diff cap**: 80KB → 20KB (~5,500 tokens input budget)
- **Max output tokens**: 4,096 → 2,048
- **Initial fetch**: 100KB → 50KB

## Test plan
- [ ] Merge and observe next PR review runs use new model
- [ ] Verify reviews complete without rate limit errors

## Related issue
N/A — infrastructure improvement