### PR TITLE
Standardize singleton pattern across all services (#78)

### DIFF
--- a/docs/issues/issue-78/TASKS.md
+++ b/docs/issues/issue-78/TASKS.md
@@ -1,0 +1,142 @@
+# Issue #78: Standardize Singleton Pattern Across All Services
+
+### Phase 1: Convert Simple Services to Singleton Pattern (2 tasks)
+
+**Goal:** Convert `JobScheduler` and `TransmissionService` to the standard `__new__()` + `_initialize()` singleton pattern, matching `MediaService`/`HealthService`/etc.
+
+**Phase Context:**
+
+- Why NOT a shared base class: Each service has different init logic (config keys, client setup). The pattern is simple enough (~8 lines) that a mixin would add indirection for no gain.
+- The `conftest.py` `reset_singletons` fixture must be updated for each new singleton to prevent test state leakage.
+
+- [x] **1.1** Convert JobScheduler to singleton pattern
+    - **Context:**
+        - **Why:** `JobScheduler` uses plain `__init__` with a module-level `scheduler = JobScheduler()` instance. Multiple calls to `JobScheduler()` create separate objects, inconsistent with other services and risks duplicate job registrations.
+        - **Architecture:** Follow `MediaService` pattern exactly: `_instance = None` class var, `__new__()` checks `_instance`, `_initialize()` classmethod sets up `cls.jobs` and `cls.running`. Keep `scheduler = JobScheduler()` module-level instance for backward compat.
+        - **Key refs:** `src/services/scheduler.py:19-24` (current `__init__`), `src/services/media.py:30-35` (reference singleton pattern), `tests/conftest.py:190-217` (reset fixture)
+        - **Watch out:** Existing tests create `JobScheduler()` directly (not via module-level `scheduler`). After singleton conversion they'll all get the same instance — the `reset_singletons` fixture must reset `_instance = None` to isolate tests.
+    - **Scope:** Singleton conversion of JobScheduler + test + conftest reset
+    - **Touches:** `src/services/scheduler.py`, `tests/test_services/test_scheduler.py`, `tests/conftest.py`
+    - **Action items:**
+        - [RED] Add `TestJobSchedulerSingleton.test_singleton` asserting `JobScheduler() is JobScheduler()`
+        - [RED] Verify test fails: `pytest tests/test_services/test_scheduler.py::TestJobSchedulerSingleton -v`
+        - [GREEN] Convert `JobScheduler`: add `_instance = None`, `__new__()`, `_initialize()` classmethod (sets `cls.jobs = {}`, `cls.running = False`), remove `__init__`
+        - [GREEN] Add `JobScheduler._instance = None` to `reset_singletons` in `tests/conftest.py`
+        - [GREEN] Verify: `pytest tests/test_services/test_scheduler.py -v` then `pytest --tb=short -q`
+    - **Success:** All tests pass, `JobScheduler() is JobScheduler()` holds, conftest resets singleton between tests
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - The `__new__()` + `_initialize()` pattern drops in cleanly — existing tests pass because `reset_singletons` fixture gives each test a fresh instance
+        - Type annotation `cls.jobs: Dict[str, aiocron.Cron]` works on class vars set in `_initialize()` just like in `__init__`
+    - **Key Changes:**
+        - `src/services/scheduler.py`: Replaced `__init__` with `_instance`, `__new__()`, `_initialize()` classmethod
+        - `tests/test_services/test_scheduler.py`: Added `TestJobSchedulerSingleton` class
+        - `tests/conftest.py`: Added `JobScheduler._instance = None` to `reset_singletons`
+    - **Notes:** Module-level `scheduler = JobScheduler()` still works — first call creates the singleton, subsequent calls return it
+
+- [x] **1.2** Convert TransmissionService to singleton pattern
+    - **Context:**
+        - **Why:** `TransmissionService` uses plain `__init__` with module-level `transmission_service = TransmissionService()`. Same inconsistency as JobScheduler — multiple instantiations create separate objects with separate `_client` and `_config`.
+        - **Architecture:** Same `__new__()` + `_initialize()` pattern. `_initialize()` sets `cls._client = None` and `cls._config = config.get("transmission", {})`. Keep `transmission_service` module-level instance.
+        - **Key refs:** `src/services/transmission.py:19-22` (current `__init__`), `tests/test_services/test_transmission_service.py` (12 existing tests), `tests/conftest.py:190-217`
+        - **Watch out:** Tests set `service._client = mock_client` directly on instances. Since all `TransmissionService()` calls return the same instance after conversion, the `reset_singletons` fixture resetting `_instance = None` is critical to prevent client mock leakage between tests.
+    - **Scope:** Singleton conversion of TransmissionService + test + conftest reset
+    - **Touches:** `src/services/transmission.py`, `tests/test_services/test_transmission_service.py`, `tests/conftest.py`
+    - **Action items:**
+        - [RED] Add `TestTransmissionServiceSingleton.test_singleton` asserting `TransmissionService() is TransmissionService()`
+        - [RED] Verify test fails: `pytest tests/test_services/test_transmission_service.py::TestTransmissionServiceSingleton -v`
+        - [GREEN] Convert `TransmissionService`: add `_instance = None`, `__new__()`, `_initialize()` classmethod (sets `cls._client = None`, `cls._config = config.get(...)`), remove `__init__`
+        - [GREEN] Add `TransmissionService._instance = None` to `reset_singletons` in `tests/conftest.py`
+        - [GREEN] Verify: `pytest tests/test_services/test_transmission_service.py -v` then `pytest --tb=short -q`
+    - **Success:** All tests pass, `TransmissionService() is TransmissionService()` holds, conftest resets singleton
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - Existing tests that set `service._client = mock_client` still work because `reset_singletons` clears `_instance = None`, so each test gets a fresh singleton
+        - The `_config` class var gets set from `config.get()` during `_initialize()` — mock config injection handles this transparently
+    - **Key Changes:**
+        - `src/services/transmission.py`: Replaced `__init__` with `_instance`, `__new__()`, `_initialize()` classmethod
+        - `tests/test_services/test_transmission_service.py`: Added `TestTransmissionServiceSingleton` class
+        - `tests/conftest.py`: Added `TransmissionService._instance = None` to `reset_singletons`
+    - **Notes:** `is_enabled()` already existed on TransmissionService — no behavioral change needed
+
+### Phase 2: SABnzbdService — Singleton + Behavioral Change (1 task)
+
+**Goal:** Convert `SABnzbdService` to singleton pattern AND replace `ValueError` on disabled with `is_enabled()` check, matching TransmissionService's approach. Update both handlers and all affected tests.
+
+**Phase Context:**
+
+- Why `is_enabled()` instead of ValueError: The current pattern forces every consumer to wrap `SABnzbdService()` in try/except. TransmissionService already uses `is_enabled()` cleanly. Standardizing eliminates error-handling boilerplate and makes the singleton pattern viable (a singleton that raises on construction is problematic for re-instantiation).
+
+- [x] **2.1** Convert SABnzbdService to singleton with `is_enabled()` and update all consumers
+    - **Context:**
+        - **Why:** `SABnzbdService.__init__` raises `ValueError` when disabled, forcing try/except in `SabnzbdHandler.__init__` (`sabnzbd.py:21-27`) and `SettingsHandler.__init__` (`settings.py:49-52`). This is incompatible with singleton pattern (can't re-instantiate after first call) and inconsistent with TransmissionService.
+        - **Architecture:** `_initialize()` reads config, sets `cls._enabled`, `cls.base_url`, `cls.api_key`. If disabled or config errors: set `_enabled = False` + log (no raise). Add `is_enabled()` returning `bool(self._enabled)`. Handlers change from `if not self.sabnzbd_service:` to `if not self.sabnzbd_service.is_enabled():`.
+        - **Key refs:**
+            - Service: `src/services/sabnzbd.py:21-34` (current `__init__` with ValueError)
+            - SABnzbd handler: `src/bot/handlers/sabnzbd.py:21-27` (try/except init), `:31` and `:48` (None checks)
+            - Settings handler: `src/bot/handlers/settings.py:49-52` (try/except init), `:579`, `:596`, `:599` (truth checks)
+            - Service tests: `tests/test_services/test_sabnzbd_service.py:59-83` (3 init tests with ValueError)
+            - Handler tests: `tests/test_handlers/test_sabnzbd_handler.py:25` (ValueError side_effect), `:202` (same)
+            - Settings tests: `tests/test_handlers/test_settings_handler.py:643-656` (ValueError mock), `:686` (service=None)
+        - **Watch out:**
+            - The `sabnzbd_service` fixture (`test_sabnzbd_service.py:46-50`) creates via `SABnzbdService()` — needs `enabled_sabnzbd_config` to work, which it already has as dependency.
+            - Settings handler `handle_sabnzbd_pause_resume` uses `and self.sabnzbd_service` as truthiness — with singleton pattern the instance always exists, so must change to `.is_enabled()`.
+            - `aiohttp` import in sabnzbd.py is used inside methods, keep it.
+    - **Scope:** Service singleton conversion + handler updates + all test rewrites
+    - **Touches:** `src/services/sabnzbd.py`, `src/bot/handlers/sabnzbd.py`, `src/bot/handlers/settings.py`, `tests/test_services/test_sabnzbd_service.py`, `tests/test_handlers/test_sabnzbd_handler.py`, `tests/test_handlers/test_settings_handler.py`, `tests/conftest.py`
+    - **Action items:**
+        - [RED] Add `TestSABnzbdServiceSingleton.test_singleton` (uses `enabled_sabnzbd_config` fixture)
+        - [RED] Rewrite `test_init_disabled_raises` → `test_init_disabled_not_enabled`: assert `service.is_enabled() is False` (no ValueError)
+        - [RED] Rewrite `test_init_no_api_key`: assert `service.is_enabled() is False` (no ValueError)
+        - [RED] Verify all 3 new/changed tests fail
+        - [GREEN] Convert `SABnzbdService`: `_instance = None`, `__new__()`, `_initialize()` (sets `_enabled`, `base_url`, `api_key`; logs errors instead of raising), add `is_enabled()` method, remove `__init__`
+        - [GREEN] Update `test_init_success`: add `assert service.is_enabled() is True`
+        - [GREEN] Verify: `pytest tests/test_services/test_sabnzbd_service.py -v`
+        - [GREEN] Update `src/bot/handlers/sabnzbd.py`: remove try/except in `__init__`, change None checks to `.is_enabled()` checks
+        - [GREEN] Update `src/bot/handlers/settings.py`: remove try/except in `__init__`, change truthiness checks to `.is_enabled()` at lines 579, 596, 599
+        - [GREEN] Update `test_sabnzbd_handler.py`: `test_handle_sabnzbd_not_available` — mock `is_enabled()` returning `False` instead of `side_effect=ValueError`; `test_get_handler_returns_empty_when_unavailable` — same approach
+        - [GREEN] Update `test_settings_handler.py`: `test_sabnzbd_service_none_when_valueerror` — assert `handler.sabnzbd_service is not None` and `.is_enabled() is False`; `test_handle_sabnzbd_pause_when_service_none` — set mock with `is_enabled()` returning `False` instead of `= None`
+        - [GREEN] Add `SABnzbdService._instance = None` to `reset_singletons` in `tests/conftest.py`
+        - [GREEN] Verify: `pytest --tb=short -q`
+    - **Success:** All tests pass, SABnzbdService is singleton, `is_enabled()` replaces ValueError, no handler try/except for SABnzbd init
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - Singleton `reset_singletons` must be added BEFORE running tests — the singleton persists across tests otherwise, causing enabled state leakage
+        - `_initialize()` handles all error cases (disabled, missing API key) by setting `_enabled = False` + logging instead of raising
+        - Handler tests that used `side_effect=ValueError` now use `is_enabled.return_value = False` on the mock — cleaner pattern
+    - **Key Changes:**
+        - `src/services/sabnzbd.py`: Full singleton conversion, added `is_enabled()`, removed ValueError raises
+        - `src/bot/handlers/sabnzbd.py`: Removed try/except init, changed None checks to `.is_enabled()` calls
+        - `src/bot/handlers/settings.py`: Removed try/except init, changed truthiness checks to `.is_enabled()` at 3 locations
+        - `tests/test_services/test_sabnzbd_service.py`: Added singleton test, rewrote 3 init tests (ValueError → is_enabled assertions)
+        - `tests/test_handlers/test_sabnzbd_handler.py`: Updated 2 tests (ValueError side_effect → is_enabled mock)
+        - `tests/test_handlers/test_settings_handler.py`: Rewrote 2 tests, added MagicMock import
+        - `tests/conftest.py`: Added `SABnzbdService._instance = None` to reset fixture
+    - **Notes:** The `self.config` attribute was removed from SABnzbdService — config is read once in `_initialize()` and stored as class attrs
+
+### Phase 3: Exports and Final Verification (1 task)
+
+**Goal:** Update `src/services/__init__.py` exports and run full verification.
+
+- [x] **3.1** Update service exports and run final verification
+    - **Context:**
+        - **Why:** `src/services/__init__.py` currently exports `scheduler` (instance) but not `JobScheduler` (class). Same gap for `TransmissionService` and `SABnzbdService`. Adding class exports improves discoverability and makes the singleton classes importable from the package.
+        - **Architecture:** Add class imports alongside existing instance imports. Add to `__all__`.
+        - **Key refs:** `src/services/__init__.py:1-20` (current exports)
+        - **Watch out:** Don't break existing imports — keep all current exports, only add new ones.
+    - **Scope:** Update exports, lint, full coverage run
+    - **Touches:** `src/services/__init__.py`
+    - **Action items:**
+        - [GREEN] Add `JobScheduler`, `TransmissionService`, `SABnzbdService` exports to `src/services/__init__.py`
+        - [GREEN] Run `flake8 .` — clean
+        - [GREEN] Run `pytest --cov=src --cov-report=term-missing` — all pass, no regressions
+        - [GREEN] Review: confirm no functional behavior changes beyond SABnzbd's `ValueError` → `is_enabled()`
+    - **Success:** Lint clean, all tests pass with coverage, exports updated
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - The generic `except Exception` branch in SABnzbdService._initialize() needed a dedicated test (corrupt config dict) to reach 100% coverage
+        - Adding `SABnzbdService` import to `__init__.py` triggered the singleton at import time with disabled config — works fine since `is_enabled()` returns False
+    - **Key Changes:**
+        - `src/services/__init__.py`: Added `JobScheduler`, `TransmissionService`, `transmission_service`, `SABnzbdService` exports
+        - `tests/test_services/test_sabnzbd_service.py`: Added `test_init_config_error` for coverage of exception branch
+    - **Notes:** All 1033 tests pass, 100% coverage, flake8 clean

--- a/docs/issues/issue-78/plan.md
+++ b/docs/issues/issue-78/plan.md
@@ -1,0 +1,262 @@
+# Standardize Singleton Pattern Across All Services (#78)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Convert `JobScheduler`, `TransmissionService`, and `SABnzbdService` to the standard `__new__()` + `_initialize()` singleton pattern used by `MediaService`, `HealthService`, `NotificationService`, and `TranslationService`. No functional behavior changes except SABnzbdService switches from raising `ValueError` on disabled to an `is_enabled()` check (matching TransmissionService's approach).
+
+**Architecture:** Three-layer architecture with singleton services. The `__new__()` + `_initialize()` pattern ensures only one instance exists per class. `_initialize()` is a classmethod that runs once on first instantiation to set up instance state. The `conftest.py` `reset_singletons` fixture resets `_instance = None` between tests.
+
+**Tech Stack:** Python 3.11, python-telegram-bot v20+, aiohttp, pytest
+
+---
+
+### Task 1: JobScheduler — Singleton Conversion (simplest)
+
+**Files:**
+- Modify: `src/services/scheduler.py`
+- Modify: `tests/test_services/test_scheduler.py`
+- Modify: `tests/conftest.py`
+
+**Step 1: RED — Add singleton test**
+
+Add `TestJobSchedulerSingleton` class to `tests/test_services/test_scheduler.py`:
+
+```python
+class TestJobSchedulerSingleton:
+    def test_singleton(self):
+        a = JobScheduler()
+        b = JobScheduler()
+        assert a is b
+```
+
+**Step 2: Verify RED**
+
+Run: `pytest tests/test_services/test_scheduler.py::TestJobSchedulerSingleton -v`
+Expected: FAIL (no singleton behavior yet)
+
+**Step 3: GREEN — Convert JobScheduler**
+
+In `src/services/scheduler.py`, convert the class:
+- Add `_instance = None` class variable
+- Add `__new__()` that checks `_instance`, calls `_initialize()` on first creation
+- Add `_initialize()` classmethod that sets `cls.jobs = {}` and `cls.running = False`
+- Remove `__init__`
+- Keep `scheduler = JobScheduler()` module-level instance
+
+**Step 4: Verify GREEN**
+
+Run: `pytest tests/test_services/test_scheduler.py -v`
+Expected: All tests PASS
+
+**Step 5: Update conftest**
+
+Add `JobScheduler._instance = None` to the `reset_singletons` fixture in `tests/conftest.py`.
+
+**Step 6: Verify full suite**
+
+Run: `pytest --tb=short -q`
+Expected: All tests PASS
+
+---
+
+### Task 2: TransmissionService — Singleton Conversion
+
+**Files:**
+- Modify: `src/services/transmission.py`
+- Modify: `tests/test_services/test_transmission_service.py`
+- Modify: `tests/conftest.py`
+
+**Step 1: RED — Add singleton test**
+
+Add `TestTransmissionServiceSingleton` class to `tests/test_services/test_transmission_service.py`:
+
+```python
+class TestTransmissionServiceSingleton:
+    def test_singleton(self):
+        a = TransmissionService()
+        b = TransmissionService()
+        assert a is b
+```
+
+**Step 2: Verify RED**
+
+Run: `pytest tests/test_services/test_transmission_service.py::TestTransmissionServiceSingleton -v`
+Expected: FAIL
+
+**Step 3: GREEN — Convert TransmissionService**
+
+In `src/services/transmission.py`, convert the class:
+- Add `_instance = None` class variable
+- Add `__new__()` that checks `_instance`, calls `_initialize()` on first creation
+- Add `_initialize()` classmethod that sets `cls._client = None` and `cls._config = config.get(...)`
+- Remove `__init__`
+- Keep `transmission_service = TransmissionService()` module-level instance
+
+**Step 4: Verify GREEN**
+
+Run: `pytest tests/test_services/test_transmission_service.py -v`
+Expected: All tests PASS
+
+**Step 5: Update conftest**
+
+Add `TransmissionService._instance = None` to the `reset_singletons` fixture in `tests/conftest.py`.
+
+**Step 6: Verify full suite**
+
+Run: `pytest --tb=short -q`
+Expected: All tests PASS
+
+---
+
+### Task 3: SABnzbdService — Singleton Conversion + Behavioral Change
+
+This is the most complex task. SABnzbdService currently raises `ValueError` if disabled. We change it to use `is_enabled()` like TransmissionService.
+
+**Files:**
+- Modify: `src/services/sabnzbd.py`
+- Modify: `src/bot/handlers/sabnzbd.py`
+- Modify: `src/bot/handlers/settings.py`
+- Modify: `tests/test_services/test_sabnzbd_service.py`
+- Modify: `tests/test_handlers/test_sabnzbd_handler.py`
+- Modify: `tests/test_handlers/test_settings_handler.py`
+- Modify: `tests/conftest.py`
+
+**Step 1: RED — Add singleton test**
+
+Add `TestSABnzbdServiceSingleton` class to `tests/test_services/test_sabnzbd_service.py`:
+
+```python
+class TestSABnzbdServiceSingleton:
+    def test_singleton(self, enabled_sabnzbd_config):
+        a = SABnzbdService()
+        b = SABnzbdService()
+        assert a is b
+```
+
+**Step 2: RED — Rewrite init disabled test**
+
+Rewrite `test_init_disabled_raises` → `test_init_disabled_not_enabled`:
+- Assert `service.is_enabled() is False` instead of `pytest.raises(ValueError)`
+
+**Step 3: Verify RED**
+
+Run: `pytest tests/test_services/test_sabnzbd_service.py::TestSABnzbdServiceSingleton -v`
+Expected: FAIL
+
+**Step 4: GREEN — Convert SABnzbdService**
+
+In `src/services/sabnzbd.py`, convert the class:
+- Add `_instance = None` class variable
+- Add `__new__()` that checks `_instance`, calls `_initialize()` on first creation
+- Add `_initialize()` classmethod:
+  - Set `cls._enabled = config.get('sabnzbd', {}).get('enable', False)`
+  - Set `cls.base_url = None`, `cls.api_key = None`
+  - If enabled: build `base_url` and `api_key` from config (wrapped in try/except for config errors → set `_enabled = False` + log)
+  - If `api_key` missing: log error + set `_enabled = False` (instead of raising)
+- Add `is_enabled()` method returning `bool(self._enabled)`
+- Remove `__init__` and `self.config` attribute
+- Remove `import aiohttp` from module-level if only used inside methods
+
+**Step 5: Update remaining service tests**
+
+- `test_init_success`: Add assertion `assert service.is_enabled() is True`
+- `test_init_no_api_key`: Assert `service.is_enabled() is False` instead of `pytest.raises(ValueError)`
+
+**Step 6: Verify GREEN**
+
+Run: `pytest tests/test_services/test_sabnzbd_service.py -v`
+Expected: All tests PASS
+
+**Step 7: Update sabnzbd handler**
+
+In `src/bot/handlers/sabnzbd.py`:
+- `__init__`: Remove try/except, just `self.sabnzbd_service = SABnzbdService()`
+- `get_handler()`: Change `if not self.sabnzbd_service:` → `if not self.sabnzbd_service.is_enabled():`
+- `handle_sabnzbd()`: Change `if not self.sabnzbd_service:` → `if not self.sabnzbd_service.is_enabled():`
+
+**Step 8: Update settings handler**
+
+In `src/bot/handlers/settings.py`:
+- `__init__` (around lines 49-52): Remove try/except, just `self.sabnzbd_service = SABnzbdService()`
+- `handle_sabnzbd_speed`: Change `if self.sabnzbd_service:` → `if self.sabnzbd_service.is_enabled():`
+- `handle_sabnzbd_pause_resume`: Change `self.sabnzbd_service` truth checks → `self.sabnzbd_service.is_enabled()`
+
+**Step 9: Update handler tests**
+
+In `tests/test_handlers/test_sabnzbd_handler.py`:
+- `test_handle_sabnzbd_not_available`: Change `side_effect=ValueError(...)` → mock with `is_enabled()` returning `False`
+- `test_get_handler_returns_empty_when_unavailable`: Same approach
+
+In `tests/test_handlers/test_settings_handler.py`:
+- `TestSabnzbdInitError::test_sabnzbd_service_none_when_valueerror`: Rewrite — mock returns instance with `is_enabled() = False`, assert `handler.sabnzbd_service is not None` and `handler.sabnzbd_service.is_enabled() is False`
+- `test_handle_sabnzbd_pause_when_service_none`: Change `settings_handler.sabnzbd_service = None` to setting a mock with `is_enabled()` returning `False`
+
+**Step 10: Update conftest**
+
+Add `SABnzbdService._instance = None` to the `reset_singletons` fixture in `tests/conftest.py`.
+
+**Step 11: Verify full suite**
+
+Run: `pytest --tb=short -q`
+Expected: All tests PASS
+
+---
+
+### Task 4: Update `src/services/__init__.py` Exports
+
+**Files:**
+- Modify: `src/services/__init__.py`
+
+**Step 1: Update exports**
+
+Add class exports alongside existing module-level instances:
+
+```python
+from .scheduler import scheduler, JobScheduler
+from .transmission import transmission_service, TransmissionService
+from .sabnzbd import SABnzbdService
+```
+
+Add all to `__all__`.
+
+**Step 2: Verify**
+
+Run: `pytest --tb=short -q`
+Expected: All tests PASS
+
+---
+
+### Task 5: Final Verification
+
+**Step 1: Lint**
+
+Run: `flake8 .`
+Expected: Clean
+
+**Step 2: Full coverage run**
+
+Run: `pytest --cov=src --cov-report=term-missing`
+Expected: All tests PASS, no regressions
+
+**Step 3: Review**
+
+Confirm no functional behavior changes beyond SABnzbd's `ValueError` → `is_enabled()`.
+
+---
+
+## Files Summary
+
+| File | Change |
+|------|--------|
+| `src/services/scheduler.py` | Add singleton pattern, keep module-level instance |
+| `src/services/transmission.py` | Add singleton pattern, keep module-level instance |
+| `src/services/sabnzbd.py` | Add singleton pattern + `is_enabled()`, remove ValueError |
+| `src/services/__init__.py` | Add new class exports |
+| `src/bot/handlers/sabnzbd.py` | Remove try/except, use `is_enabled()` |
+| `src/bot/handlers/settings.py` | Remove try/except, use `is_enabled()` |
+| `tests/conftest.py` | Add 3 singleton resets |
+| `tests/test_services/test_scheduler.py` | Add singleton test |
+| `tests/test_services/test_transmission_service.py` | Add singleton test |
+| `tests/test_services/test_sabnzbd_service.py` | Add singleton test, rewrite 3 init tests |
+| `tests/test_handlers/test_sabnzbd_handler.py` | Update 2 tests (ValueError → is_enabled mock) |
+| `tests/test_handlers/test_settings_handler.py` | Rewrite 2 tests (ValueError → is_enabled check) |

--- a/src/bot/handlers/sabnzbd.py
+++ b/src/bot/handlers/sabnzbd.py
@@ -19,16 +19,12 @@ class SabnzbdHandler:
     """Handler for SABnzbd-related commands"""
 
     def __init__(self):
-        try:
-            self.sabnzbd_service = SABnzbdService()
-            self.translation = TranslationService()
-        except Exception as e:
-            logger.error(f"Failed to initialize SABnzbdService: {e}")
-            self.sabnzbd_service = None
+        self.sabnzbd_service = SABnzbdService()
+        self.translation = TranslationService()
 
     def get_handler(self):
         """Get the conversation handler for SABnzbd"""
-        if not self.sabnzbd_service:
+        if not self.sabnzbd_service.is_enabled():
             logger.warning("SABnzbd service not available, skipping handler registration")
             return []
 
@@ -45,7 +41,7 @@ class SabnzbdHandler:
 
         log_user_interaction(logger, update.effective_user, "/sabnzbd")
 
-        if not self.sabnzbd_service:
+        if not self.sabnzbd_service.is_enabled():
             await update.message.reply_text(
                 self.translation.get_text("Sabnzbd.NotEnabled")
             )

--- a/src/bot/handlers/settings.py
+++ b/src/bot/handlers/settings.py
@@ -46,10 +46,7 @@ class SettingsHandler:
         self.translation = TranslationService()
         self.media_service = MediaService()
         self.transmission_service = TransmissionService()
-        try:
-            self.sabnzbd_service = SABnzbdService()
-        except ValueError:
-            self.sabnzbd_service = None
+        self.sabnzbd_service = SABnzbdService()
 
     def get_handler(self):
         """Get command handlers for settings operations"""
@@ -576,7 +573,7 @@ class SettingsHandler:
             )
         else:
             speed = int(query.data.replace("dl_sab_speed_", ""))
-            if self.sabnzbd_service:
+            if self.sabnzbd_service.is_enabled():
                 await self.sabnzbd_service.set_speed_limit(speed)
             enabled = config.get("sabnzbd", {}).get("enable", False)
             keyboard = get_sabnzbd_settings_keyboard(enabled)
@@ -593,10 +590,10 @@ class SettingsHandler:
         query = update.callback_query
         await query.answer()
 
-        if query.data == "dl_sab_pause" and self.sabnzbd_service:
+        if query.data == "dl_sab_pause" and self.sabnzbd_service.is_enabled():
             await self.sabnzbd_service.pause_queue()
             text = "⏸ Queue paused"
-        elif query.data == "dl_sab_resume" and self.sabnzbd_service:
+        elif query.data == "dl_sab_resume" and self.sabnzbd_service.is_enabled():
             await self.sabnzbd_service.resume_queue()
             text = "▶️ Queue resumed"
         else:

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -9,12 +9,18 @@ from .media import MediaService
 from .health import health_service
 from .translation import TranslationService
 from .notification import NotificationService
-from .scheduler import scheduler
+from .scheduler import scheduler, JobScheduler
+from .transmission import transmission_service, TransmissionService
+from .sabnzbd import SABnzbdService
 
 __all__ = [
     'MediaService',
     'health_service',
     'TranslationService',
     'NotificationService',
-    'scheduler'
+    'scheduler',
+    'JobScheduler',
+    'transmission_service',
+    'TransmissionService',
+    'SABnzbdService',
 ]

--- a/src/services/sabnzbd.py
+++ b/src/services/sabnzbd.py
@@ -18,20 +18,47 @@ logger = get_logger("addarr.services.sabnzbd")
 class SABnzbdService:
     """Service for handling SABnzbd operations"""
 
-    def __init__(self):
-        self.config = config
-        if not self.config.get('sabnzbd', {}).get('enable', False):
-            raise ValueError("SABnzbd is not enabled")
+    _instance = None
 
-        server_config = self.config['sabnzbd']['server']
-        auth_config = self.config['sabnzbd']['auth']
+    def __new__(cls):
+        """Ensure only one instance of SABnzbdService exists"""
+        if cls._instance is None:
+            cls._instance = super(SABnzbdService, cls).__new__(cls)
+            cls._initialize()
+        return cls._instance
 
-        protocol = "https" if server_config.get('ssl', False) else "http"
-        self.base_url = f"{protocol}://{server_config['addr']}:{server_config['port']}{server_config['path']}"
-        self.api_key = auth_config.get('apikey')
+    @classmethod
+    def _initialize(cls):
+        """Initialize service state on first instantiation."""
+        cls._enabled = False
+        cls.base_url = None
+        cls.api_key = None
 
-        if not self.api_key:
-            raise ValueError("SABnzbd API key not configured")
+        sabnzbd_config = config.get('sabnzbd', {})
+        if not sabnzbd_config.get('enable', False):
+            return
+
+        try:
+            server_config = sabnzbd_config['server']
+            auth_config = sabnzbd_config['auth']
+
+            protocol = "https" if server_config.get('ssl', False) else "http"
+            cls.base_url = f"{protocol}://{server_config['addr']}:{server_config['port']}{server_config['path']}"
+            cls.api_key = auth_config.get('apikey')
+
+            if not cls.api_key:
+                logger.error("SABnzbd API key not configured")
+                cls._enabled = False
+                return
+
+            cls._enabled = True
+        except Exception as e:
+            logger.error(f"Failed to initialize SABnzbd: {e}")
+            cls._enabled = False
+
+    def is_enabled(self) -> bool:
+        """Check if SABnzbd is enabled and properly configured."""
+        return bool(self._enabled)
 
     async def get_status(self) -> Dict[str, Any]:
         """Get SABnzbd queue status"""

--- a/src/services/scheduler.py
+++ b/src/services/scheduler.py
@@ -19,9 +19,20 @@ logger = get_logger("addarr.scheduler")
 class JobScheduler:
     """Service for scheduling and managing jobs"""
 
-    def __init__(self):
-        self.jobs: Dict[str, aiocron.Cron] = {}
-        self.running = False
+    _instance = None
+
+    def __new__(cls):
+        """Ensure only one instance of JobScheduler exists"""
+        if cls._instance is None:
+            cls._instance = super(JobScheduler, cls).__new__(cls)
+            cls._initialize()
+        return cls._instance
+
+    @classmethod
+    def _initialize(cls):
+        """Initialize scheduler state on first instantiation."""
+        cls.jobs: Dict[str, aiocron.Cron] = {}
+        cls.running = False
 
     def add_job(
         self,

--- a/src/services/transmission.py
+++ b/src/services/transmission.py
@@ -16,10 +16,20 @@ logger = get_logger("addarr.services.transmission")
 class TransmissionService:
     """Service class for Transmission operations"""
 
-    def __init__(self):
-        """Initialize Transmission service"""
-        self._client = None
-        self._config = config.get("transmission", {})
+    _instance = None
+
+    def __new__(cls):
+        """Ensure only one instance of TransmissionService exists"""
+        if cls._instance is None:
+            cls._instance = super(TransmissionService, cls).__new__(cls)
+            cls._initialize()
+        return cls._instance
+
+    @classmethod
+    def _initialize(cls):
+        """Initialize service state on first instantiation."""
+        cls._client = None
+        cls._config = config.get("transmission", {})
 
     @property
     def client(self) -> Optional[TransmissionClient]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,9 +197,18 @@ def reset_singletons():
     from src.services.health import HealthService
     from src.services.translation import TranslationService
     from src.services.notification import NotificationService
+    from src.services.scheduler import JobScheduler
+    from src.services.transmission import TransmissionService
+    from src.services.sabnzbd import SABnzbdService
     from src.bot.handlers.auth import AuthHandler
 
     # Reset singletons
+    JobScheduler._instance = None
+
+    TransmissionService._instance = None
+
+    SABnzbdService._instance = None
+
     MediaService._instance = None
     MediaService._radarr = None
     MediaService._sonarr = None

--- a/tests/test_handlers/test_sabnzbd_handler.py
+++ b/tests/test_handlers/test_sabnzbd_handler.py
@@ -21,8 +21,10 @@ from unittest.mock import patch, MagicMock, AsyncMock
 async def test_handle_sabnzbd_not_available(
     mock_sab_class, mock_ts_class, make_update, make_context
 ):
-    """When sabnzbd_service is None, reply with 'not enabled' message."""
-    mock_sab_class.side_effect = ValueError("SABnzbd is not enabled")
+    """When sabnzbd service is not enabled, reply with 'not enabled' message."""
+    mock_sab = MagicMock()
+    mock_sab.is_enabled.return_value = False
+    mock_sab_class.return_value = mock_sab
 
     mock_ts = MagicMock()
     mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
@@ -34,7 +36,7 @@ async def test_handle_sabnzbd_not_available(
     AuthHandler._authenticated_users = {12345}
 
     handler = SabnzbdHandler()
-    assert handler.sabnzbd_service is None
+    assert handler.sabnzbd_service.is_enabled() is False
 
     handler.translation = mock_ts
 
@@ -199,7 +201,9 @@ async def test_handle_speed_selection_no_query(
 @patch("src.bot.handlers.sabnzbd.SABnzbdService")
 def test_get_handler_returns_empty_when_unavailable(mock_sab_class, mock_ts_class):
     """get_handler returns empty list when service is not available."""
-    mock_sab_class.side_effect = ValueError("SABnzbd is not enabled")
+    mock_sab = MagicMock()
+    mock_sab.is_enabled.return_value = False
+    mock_sab_class.return_value = mock_sab
     mock_ts_class.return_value = MagicMock()
 
     from src.bot.handlers.sabnzbd import SabnzbdHandler

--- a/tests/test_handlers/test_settings_handler.py
+++ b/tests/test_handlers/test_settings_handler.py
@@ -1,7 +1,7 @@
 """Tests for src/bot/handlers/settings.py"""
 
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from telegram.ext import ConversationHandler
 
 from src.bot.states import States
@@ -626,12 +626,15 @@ class TestUsersFlow:
 class TestSabnzbdInitError:
     """SABnzbd service initialization error handling"""
 
-    def test_sabnzbd_service_none_when_valueerror(
+    def test_sabnzbd_service_disabled_when_not_enabled(
         self, mock_media_service, mock_translation_service
     ):
-        """SABnzbdService ValueError sets self.sabnzbd_service = None"""
+        """SABnzbdService with disabled config has is_enabled() == False"""
         from unittest.mock import patch, MagicMock
         from tests.conftest import MOCK_CONFIG_DATA
+
+        mock_sab = MagicMock()
+        mock_sab.is_enabled.return_value = False
 
         with (
             patch("src.bot.handlers.settings.TranslationService") as ts_cls,
@@ -641,7 +644,7 @@ class TestSabnzbdInitError:
             patch("src.bot.handlers.settings.TransmissionService"),
             patch(
                 "src.bot.handlers.settings.SABnzbdService",
-                side_effect=ValueError("SABnzbd not enabled"),
+                return_value=mock_sab,
             ),
         ):
             ts_cls.return_value = mock_translation_service
@@ -653,7 +656,8 @@ class TestSabnzbdInitError:
             from src.bot.handlers.settings import SettingsHandler
 
             handler = SettingsHandler()
-            assert handler.sabnzbd_service is None
+            assert handler.sabnzbd_service is not None
+            assert handler.sabnzbd_service.is_enabled() is False
 
 
 class TestDownloadsEdgeCases:
@@ -679,11 +683,13 @@ class TestDownloadsEdgeCases:
         assert "25%" in call_args.args[0]
 
     @pytest.mark.asyncio
-    async def test_handle_sabnzbd_pause_when_service_none(
+    async def test_handle_sabnzbd_pause_when_service_disabled(
         self, settings_handler, make_update, make_context
     ):
-        """Pause with sabnzbd_service=None shows not available message"""
-        settings_handler.sabnzbd_service = None
+        """Pause with sabnzbd_service disabled shows not available message"""
+        mock_sab = MagicMock()
+        mock_sab.is_enabled.return_value = False
+        settings_handler.sabnzbd_service = mock_sab
         update = make_update(callback_data="dl_sab_pause")
         context = make_context()
 

--- a/tests/test_services/test_sabnzbd_service.py
+++ b/tests/test_services/test_sabnzbd_service.py
@@ -55,32 +55,55 @@ def sabnzbd_service(enabled_sabnzbd_config):
 # ---------------------------------------------------------------------------
 
 
-class TestSABnzbdServiceInit:
-    def test_init_disabled_raises(self):
+class TestSABnzbdServiceSingleton:
+    def test_singleton(self, enabled_sabnzbd_config):
         from src.services.sabnzbd import SABnzbdService
 
-        with pytest.raises(ValueError, match="SABnzbd is not enabled"):
-            SABnzbdService()
+        a = SABnzbdService()
+        b = SABnzbdService()
+        assert a is b
+
+
+class TestSABnzbdServiceInit:
+    def test_init_disabled_not_enabled(self):
+        """When sabnzbd is disabled, service exists but is_enabled() is False."""
+        from src.services.sabnzbd import SABnzbdService
+
+        service = SABnzbdService()
+        assert service.is_enabled() is False
 
     def test_init_success(self, enabled_sabnzbd_config):
         from src.services.sabnzbd import SABnzbdService
 
         service = SABnzbdService()
+        assert service.is_enabled() is True
         assert service.api_key == "test-sabnzbd-key"
         assert "localhost" in service.base_url
         assert "8090" in service.base_url
 
     def test_init_no_api_key(self, enabled_sabnzbd_config):
-        """When api key is missing, should raise ValueError."""
+        """When api key is missing, is_enabled() returns False."""
         from src.services.sabnzbd import SABnzbdService
 
         original_apikey = _mock_config._config["sabnzbd"]["auth"]["apikey"]
         _mock_config._config["sabnzbd"]["auth"]["apikey"] = None
         try:
-            with pytest.raises(ValueError, match="API key not configured"):
-                SABnzbdService()
+            service = SABnzbdService()
+            assert service.is_enabled() is False
         finally:
             _mock_config._config["sabnzbd"]["auth"]["apikey"] = original_apikey
+
+    def test_init_config_error(self, enabled_sabnzbd_config):
+        """When config keys are missing/corrupt, is_enabled() returns False."""
+        from src.services.sabnzbd import SABnzbdService
+
+        original_server = _mock_config._config["sabnzbd"]["server"]
+        _mock_config._config["sabnzbd"]["server"] = "not-a-dict"
+        try:
+            service = SABnzbdService()
+            assert service.is_enabled() is False
+        finally:
+            _mock_config._config["sabnzbd"]["server"] = original_server
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services/test_scheduler.py
+++ b/tests/test_services/test_scheduler.py
@@ -26,6 +26,15 @@ def _make_mock_cron():
 # ---------------------------------------------------------------------------
 
 
+class TestJobSchedulerSingleton:
+    def test_singleton(self):
+        from src.services.scheduler import JobScheduler
+
+        a = JobScheduler()
+        b = JobScheduler()
+        assert a is b
+
+
 class TestAddJob:
     @patch("src.services.scheduler.aiocron")
     def test_add_job(self, mock_aiocron):

--- a/tests/test_services/test_transmission_service.py
+++ b/tests/test_services/test_transmission_service.py
@@ -37,6 +37,15 @@ def enabled_transmission_config():
 # ---------------------------------------------------------------------------
 
 
+class TestTransmissionServiceSingleton:
+    def test_singleton(self):
+        from src.services.transmission import TransmissionService
+
+        a = TransmissionService()
+        b = TransmissionService()
+        assert a is b
+
+
 class TestTransmissionServiceEnabled:
     def test_is_enabled_false(self):
         from src.services.transmission import TransmissionService


### PR DESCRIPTION
## Summary
- Convert `JobScheduler`, `TransmissionService`, and `SABnzbdService` to the `__new__()` + `_initialize()` singleton pattern used by all other services
- Replace `SABnzbdService` `ValueError` on disabled with `is_enabled()` check, matching `TransmissionService`'s approach
- Update `SabnzbdHandler` and `SettingsHandler` to use `.is_enabled()` instead of try/except + None checks

## Changes
- **Services:** `scheduler.py`, `transmission.py`, `sabnzbd.py` — added `_instance`, `__new__()`, `_initialize()` classmethod, removed `__init__`
- **Services exports:** `__init__.py` — added `JobScheduler`, `TransmissionService`, `transmission_service`, `SABnzbdService`
- **Handlers:** `sabnzbd.py` — removed try/except init, changed None checks to `.is_enabled()`; `settings.py` — same pattern at 4 locations
- **Tests:** Added 3 singleton tests, rewrote 5 init/handler tests (ValueError → is_enabled), added config error coverage test
- **Conftest:** Added `JobScheduler`, `TransmissionService`, `SABnzbdService` to `reset_singletons` fixture

## Test plan
- [x] All 1033 tests pass
- [x] 100% code coverage maintained
- [x] Flake8 clean
- [x] Translations valid
- [ ] CI pipeline passes (pytest, flake8, i18n validation, Docker build)

## Related issue
Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)