### PR TITLE
ci: add caching, concurrency, coverage artifact, and dep audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
@@ -20,6 +24,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          cache: "pip"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -37,6 +42,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          cache: "pip"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -53,15 +59,44 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          cache: "pip"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-test.txt
       - name: Run tests with 100% coverage enforcement
-        run: pytest --cov=src --cov-report=term-missing --cov-fail-under=100 --tb=short
+        run: pytest --cov=src --cov-report=term-missing --cov-report=html:coverage-html --cov-fail-under=100 --tb=short
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage-html/
+          retention-days: 14
+
+  security:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Install pip-audit
+        run: pip install pip-audit
+      - name: Run dependency audit
+        run: pip-audit
 
   docker-build:
     name: Docker Build
+    needs: [test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Improve CI pipeline performance and observability with pip caching, concurrency control, coverage artifacts, and dependency auditing
- Gate Docker build on test success to avoid wasting runner time on broken builds

## Changes
- **Concurrency control**: Cancel in-progress runs when new commits are pushed to the same PR
- **Pip caching**: Add `cache: 'pip'` to all 4 Python setup steps for faster dependency installs
- **Coverage artifact**: Upload HTML coverage report as a downloadable artifact (14-day retention)
- **Dependency audit**: New `pip-audit` job (informational, `continue-on-error: true` — won't block auto-approve)
- **Docker gating**: Docker Build now `needs: [test]` so it only runs after tests pass

## Test plan
- [ ] Confirm 5 jobs appear: Lint, Validate Translations, Test, Dependency Audit, Docker Build
- [ ] Confirm Docker Build waits for Test to complete
- [ ] Confirm pip cache populates on first run and restores on re-run
- [ ] Confirm coverage-report artifact is downloadable from the Actions tab
- [ ] Push a second commit quickly and confirm the first run is cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)