### PR TITLE
chore: add and improve Claude Code skills

### DIFF
--- a/.claude/commands/addarr-setup.md
+++ b/.claude/commands/addarr-setup.md
@@ -6,10 +6,14 @@ Argument: $ARGUMENTS
 
 ### Always load (all setups):
 - `addarr-testing`
+- `addarr-handlers`
+- `addarr-services`
 - `python-testing-pro`
 
 ### If argument is `dev` (or no argument):
 - `task-writer`
+- `find-bugs`
+- `code-simplifier`
 - `superpowers:test-driven-development`
 - `superpowers:writing-plans`
 - `superpowers:brainstorming`
@@ -17,6 +21,8 @@ Argument: $ARGUMENTS
 - `superpowers:verification-before-completion`
 
 ### If argument is `pr`:
+- `find-bugs`
+- `code-simplifier`
 - `superpowers:verification-before-completion`
 
 Also read these reference files into context (use the Read tool):

--- a/.claude/skills/addarr-handlers/SKILL.md
+++ b/.claude/skills/addarr-handlers/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: addarr-handlers
+description: Use when adding new Telegram bot handlers, conversation flows, callback routing, keyboards, or command handlers in Addarr. Covers handler class structure, ConversationHandler states, callback_data conventions, and keyboard construction.
+---
+
+# Addarr Handlers
+
+Reference for building new Telegram bot handlers in Addarr. For testing handler code, see @addarr-testing.
+
+## Quick Start Checklist
+
+When adding a new handler:
+
+1. Create handler class in `src/bot/handlers/<name>.py`
+2. Define any new states in `src/bot/states.py`
+3. Add keyboard functions to `src/bot/keyboards.py`
+4. Add translation keys to `translations/addarr.*.yml`
+5. Export from `src/bot/handlers/__init__.py`
+6. Register in `src/main.py:AddarrBot._add_handlers()`
+
+## Handler Class Template
+
+```python
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import (
+    CommandHandler, CallbackQueryHandler,
+    ConversationHandler, ContextTypes, filters
+)
+
+from src.config.settings import config
+from src.utils.logger import get_logger, log_user_interaction
+from src.bot.handlers.auth import require_auth
+from src.bot.keyboards import get_<name>_keyboard
+from src.services.<service> import <Service>Service
+from src.services.translation import TranslationService
+from src.bot.states import States
+
+logger = get_logger("addarr.<name>")
+
+
+class <Name>Handler:
+    """Handler for <description>"""
+
+    def __init__(self):
+        self.translation = TranslationService()
+        self.<service> = <Service>Service()
+
+    def get_handler(self):
+        """Return list of handlers to register"""
+        return [
+            ConversationHandler(
+                entry_points=[
+                    CommandHandler("<cmd>", self.handle_<cmd>),
+                    CallbackQueryHandler(self.handle_<action>, pattern="^<prefix>_"),
+                ],
+                states={
+                    States.<STATE>: [
+                        CallbackQueryHandler(
+                            self.handle_<action>,
+                            pattern="^<prefix>_"
+                        ),
+                    ],
+                },
+                fallbacks=[
+                    CommandHandler("cancel", self.handle_cancel),
+                    CallbackQueryHandler(self.handle_cancel, pattern="^menu_cancel$"),
+                ],
+                name="<name>_conversation",
+                persistent=False,
+                per_message=False,
+            ),
+        ]
+```
+
+**Critical:**
+- `get_handler()` returns a **list** (even for a single handler)
+- Always set `persistent=False, per_message=False`
+- Fallbacks always include `menu_cancel` pattern
+- Services injected as singletons in `__init__`
+
+## Method Signatures
+
+See [references/methods.md](references/methods.md) for entry point, callback, message, and cancel handler patterns with `@require_auth`, `await query.answer()`, and state return conventions.
+
+## Callback Data Conventions
+
+See [references/callbacks.md](references/callbacks.md) for naming format, extraction patterns, and the complete prefix registry.
+
+## Keyboard Construction
+
+See [references/keyboards.md](references/keyboards.md) for keyboard function patterns, button layout, translation integration, and photo-aware message editing.
+
+## Wiring a New Handler
+
+See [references/wiring.md](references/wiring.md) for state definitions, handler registration order, exports, and translation key format.
+
+## Common Mistakes
+
+See [references/anti-patterns.md](references/anti-patterns.md) for detailed examples with bad/good code.
+
+1. Forgetting `await query.answer()` — Telegram shows loading spinner indefinitely.
+2. Using `reply_text` on callback queries — Use `edit_text` or `edit_caption` instead.
+3. Forgetting photo-aware editing — `edit_text` crashes on photo messages, use `edit_caption`.
+4. Missing state return — Every handler method must return a state or `ConversationHandler.END`.
+5. Not clearing `context.user_data` on cancel — Stale data leaks into next conversation.
+6. Wrong pattern anchor — `^prefix_$` won't match `prefix_42`; `^exact` matches `exact_extra`.
+7. Registering handlers in wrong order — PTB matches first match. Specific patterns before general.
+8. Forgetting `@require_auth` on entry points — All command entry points need auth decorator.
+9. Ignoring `per_message=False` warning — It's informational, not an error. Safe to ignore.

--- a/.claude/skills/addarr-handlers/references/anti-patterns.md
+++ b/.claude/skills/addarr-handlers/references/anti-patterns.md
@@ -1,0 +1,230 @@
+# Handler Anti-Patterns
+
+Common mistakes when building Telegram bot handlers in Addarr.
+
+---
+
+## Missing `await query.answer()`
+
+**Don't** process a callback query without acknowledging it:
+
+```python
+# BAD - Telegram shows loading spinner indefinitely
+async def handle_action(self, update, context):
+    query = update.callback_query
+    action = query.data.replace("prefix_", "")
+    await query.message.edit_text("Done!")
+```
+
+**Instead**, always acknowledge first:
+
+```python
+# GOOD
+async def handle_action(self, update, context):
+    query = update.callback_query
+    await query.answer()  # Always first
+    action = query.data.replace("prefix_", "")
+    await query.message.edit_text("Done!")
+```
+
+**Why**: Telegram requires callback queries to be answered within a timeout. Without `answer()`, users see a perpetual loading spinner on the button.
+
+---
+
+## Using reply_text on Callback Updates
+
+**Don't** call `reply_text` when handling callback queries:
+
+```python
+# BAD - sends a new message instead of updating the existing one
+async def handle_callback(self, update, context):
+    query = update.callback_query
+    await query.answer()
+    await update.effective_message.reply_text("Result")
+```
+
+**Instead**, edit the existing message:
+
+```python
+# GOOD - updates the message in-place
+async def handle_callback(self, update, context):
+    query = update.callback_query
+    await query.answer()
+    await query.message.edit_text("Result", reply_markup=keyboard)
+```
+
+**Why**: Callback queries come from inline keyboard button presses. The user expects the message to update, not a new message to appear. Use `edit_text` or `edit_caption` (for photo messages).
+
+---
+
+## Forgetting Photo-Aware Editing
+
+**Don't** always use `edit_text` when editing messages that might have photos:
+
+```python
+# BAD - crashes with BadRequest if message has a photo
+await query.message.edit_text(text=new_text, reply_markup=keyboard)
+```
+
+**Instead**, check for photos:
+
+```python
+# GOOD
+if query.message.photo:
+    await query.message.edit_caption(caption=new_text, reply_markup=keyboard)
+else:
+    await query.message.edit_text(text=new_text, reply_markup=keyboard)
+```
+
+**Why**: Messages with images use `caption` not `text`. Calling `edit_text` on a photo message raises `telegram.error.BadRequest`. The media handler's card view sends photos, so any handler that edits those messages must handle both cases.
+
+---
+
+## Missing State Return
+
+**Don't** let handler methods fall through without returning a state:
+
+```python
+# BAD - returns None implicitly, breaks ConversationHandler
+async def handle_search(self, update, context):
+    results = await self.service.search(query)
+    if results:
+        await update.message.reply_text("Found!")
+        # Forgot to return next state!
+```
+
+**Instead**, always return explicitly on every path:
+
+```python
+# GOOD
+async def handle_search(self, update, context):
+    results = await self.service.search(query)
+    if results:
+        context.user_data["results"] = results
+        await update.message.reply_text("Found!")
+        return States.SELECTING
+    await update.message.reply_text("Nothing found.")
+    return ConversationHandler.END
+```
+
+**Why**: ConversationHandler uses the return value to determine the next state. Returning `None` keeps the conversation in the current state, which can cause handlers to fire on unexpected input.
+
+---
+
+## Not Clearing user_data on Cancel
+
+**Don't** end a conversation without cleaning up:
+
+```python
+# BAD - stale data from previous conversation leaks into next one
+async def handle_cancel(self, update, context):
+    await update.effective_message.reply_text("Cancelled.")
+    return ConversationHandler.END
+```
+
+**Instead**, clear user_data:
+
+```python
+# GOOD
+async def handle_cancel(self, update, context):
+    context.user_data.clear()
+    await update.effective_message.reply_text("Cancelled.")
+    return ConversationHandler.END
+```
+
+**Why**: `context.user_data` persists across conversations for the same user. If the user starts a movie search, cancels, then starts a series search, stale `search_type`, `search_results`, etc. from the movie flow will be present unless cleared.
+
+---
+
+## Wrong Pattern Anchor
+
+**Don't** use exact-match anchors on prefix patterns or forget them on exact matches:
+
+```python
+# BAD - won't match "select_42" because $ requires exact "select_"
+CallbackQueryHandler(handler, pattern="^select_$")
+
+# BAD - matches "menu_cancel_extra" when you only want "menu_cancel"
+CallbackQueryHandler(handler, pattern="^menu_cancel")
+```
+
+**Instead**, use anchors intentionally:
+
+```python
+# GOOD - prefix match (captures select_0, select_42, etc.)
+CallbackQueryHandler(handler, pattern="^select_")
+
+# GOOD - exact match
+CallbackQueryHandler(handler, pattern="^menu_cancel$")
+```
+
+**Why**: PTB uses regex matching. `^prefix_` matches anything starting with `prefix_`. `^exact_value$` matches only that exact string. Mixing these up causes handlers to either miss valid callbacks or fire on unintended ones.
+
+---
+
+## Registering Handlers in Wrong Order
+
+**Don't** register a general pattern before a specific one:
+
+```python
+# BAD - "^dl_" matches "dl_sab_speed" before the specific handler sees it
+states={
+    STATE: [
+        CallbackQueryHandler(handle_downloads, pattern="^dl_"),
+        CallbackQueryHandler(handle_sab_speed, pattern="^dl_sab_speed"),
+    ]
+}
+```
+
+**Instead**, put specific patterns first:
+
+```python
+# GOOD - specific pattern checked first
+states={
+    STATE: [
+        CallbackQueryHandler(handle_sab_speed, pattern="^dl_sab_speed"),
+        CallbackQueryHandler(handle_downloads, pattern="^dl_"),
+    ]
+}
+```
+
+**Why**: PTB tries handlers top-to-bottom within a state dict. The first matching handler wins. This also applies to handler registration order in `_add_handlers()` — more specific handlers must come before general ones. Issue #67 learned this with settings sub-menus.
+
+---
+
+## Forgetting @require_auth on Entry Points
+
+**Don't** create unprotected entry points:
+
+```python
+# BAD - anyone can trigger this, bypassing authentication
+async def handle_command(self, update, context):
+    await update.message.reply_text("Welcome!")
+```
+
+**Instead**, decorate all entry points:
+
+```python
+# GOOD
+@require_auth
+async def handle_command(self, update, context):
+    await update.message.reply_text("Welcome!")
+```
+
+**Why**: `@require_auth` checks if the user's ID is in the authenticated users set. Without it, unauthenticated users can access bot features. Note: `@require_auth` accesses `update.message.reply_text()` which only works for command handlers and message handlers, not bare callback queries from unauthenticated sessions.
+
+---
+
+## per_message=False Warning
+
+**Don't** worry about the `PTBUserWarning` when using `per_message=False` with `CallbackQueryHandler`:
+
+```python
+# This emits a PTBUserWarning - it's informational, NOT an error
+ConversationHandler(
+    ...,
+    per_message=False,  # Correct setting
+)
+```
+
+**Why**: PTB warns because `per_message=False` means callback queries from different messages can be handled by the same conversation. This is the intended behavior in Addarr — the warning confirms the setting is active. Issue #67 confirmed this is safe to ignore.

--- a/.claude/skills/addarr-handlers/references/callbacks.md
+++ b/.claude/skills/addarr-handlers/references/callbacks.md
@@ -1,0 +1,93 @@
+# Callback Data Conventions
+
+## Naming Format
+
+```
+<prefix>_<value>[_<value2>...]
+```
+
+All callback data is a flat string with underscore-delimited segments. Max 64 bytes (Telegram limit).
+
+## Prefix Registry
+
+| Prefix | Handler | Example | Description |
+|--------|---------|---------|-------------|
+| `menu_` | MediaHandler | `menu_movie`, `menu_series`, `menu_cancel` | Main menu actions |
+| `select_` | MediaHandler | `select_123` | Media selection by index |
+| `nav_` | MediaHandler | `nav_next_5`, `nav_prev_3` | Card view navigation |
+| `quality_` | MediaHandler | `quality_42` | Quality profile selection |
+| `season_` | MediaHandler | `season_5`, `season_confirm` | Season selection |
+| `listsel_` | MediaHandler | `listsel_3` | List view item selection |
+| `listpage_` | MediaHandler | `listpage_2`, `listpage_noop` | List view pagination |
+| `viewtoggle` | MediaHandler | `viewtoggle` | Toggle card/list view |
+| `lang_` | SettingsHandler | `lang_en-us` | Language selection |
+| `setquality_` | SettingsHandler | `setquality_radarr_42` | Default quality setting |
+| `svc_toggle_` | SettingsHandler | `svc_toggle_radarr` | Enable/disable service |
+| `dl_trans_` | SettingsHandler | `dl_trans_turtle` | Transmission settings |
+| `dl_sab_` | SettingsHandler | `dl_sab_speed`, `dl_sab_speed_25` | SABnzbd settings |
+| `settings_` | SettingsHandler | `settings_back` | Settings navigation |
+| `delete_` | DeleteHandler | `delete_movie_123` | Delete media |
+| `lib_` | LibraryHandler | `lib_movies`, `lib_page_2` | Library browsing |
+| `pref_` | PreferencesHandler | `pref_view_list` | Preference changes |
+
+## Pattern Matching in ConversationHandler
+
+```python
+# Exact match (use $ anchor)
+CallbackQueryHandler(self.handle_cancel, pattern="^menu_cancel$")
+
+# Prefix match (captures all with prefix)
+CallbackQueryHandler(self.handle_selection, pattern="^select_")
+
+# Multi-prefix match (regex OR)
+CallbackQueryHandler(self.handle_nav, pattern="^(nav_|listpage_)")
+```
+
+**Rules:**
+- Use `$` anchor for exact matches only
+- Prefix-only patterns (no `$`) match any suffix
+- More specific patterns must be registered before general ones
+- Within a state dict, PTB tries handlers top-to-bottom
+
+## Data Extraction Patterns
+
+### Single value
+```python
+# callback_data = "select_42"
+index = int(query.data.replace("select_", ""))  # 42
+```
+
+### Multi-part value
+```python
+# callback_data = "setquality_radarr_42"
+parts = query.data.split("_")
+# parts[0] = "setquality", parts[1] = "radarr", parts[2] = "42"
+service = parts[1]
+profile_id = int(parts[2])
+```
+
+### Boolean/toggle
+```python
+# callback_data = "svc_toggle_radarr"
+service_name = query.data.replace("svc_toggle_", "")
+current = config.get(service_name, {}).get("enable", False)
+config.update_nested(f"{service_name}.enable", not current)
+config.save()
+```
+
+### Noop pattern
+```python
+# callback_data = "listpage_noop" (disabled pagination button)
+suffix = query.data.replace("listpage_", "")
+if suffix == "noop":
+    await query.answer()  # Acknowledge but do nothing
+    return current_state
+page = int(suffix)
+```
+
+## Adding a New Prefix
+
+1. Choose a unique prefix not in the registry above
+2. Keep it short (callback_data max 64 bytes)
+3. Add the handler to the appropriate state in your ConversationHandler
+4. Document the prefix in this registry

--- a/.claude/skills/addarr-handlers/references/keyboards.md
+++ b/.claude/skills/addarr-handlers/references/keyboards.md
@@ -1,0 +1,125 @@
+# Keyboard Patterns
+
+## Keyboard Function Convention
+
+All keyboard functions live in `src/bot/keyboards.py`. Named `get_<feature>_keyboard()`.
+
+```python
+def get_<feature>_keyboard(<params>) -> InlineKeyboardMarkup:
+    """Get keyboard for <feature>"""
+    translation = TranslationService()
+    keyboard = [
+        [  # Row 1
+            InlineKeyboardButton(
+                f"🎬 {translation.get_text('Movie')}",
+                callback_data="prefix_value"
+            ),
+            InlineKeyboardButton(
+                f"📺 {translation.get_text('Series')}",
+                callback_data="prefix_value2"
+            ),
+        ],
+        [  # Row 2 (cancel)
+            InlineKeyboardButton(
+                f"❌ {translation.get_text('Cancel')}",
+                callback_data="menu_cancel"
+            ),
+        ],
+    ]
+    return InlineKeyboardMarkup(keyboard)
+```
+
+**Rules:**
+- Each function creates its own `TranslationService()` instance
+- Emojis go in the button text, NOT in translation keys
+- Format: `f"<emoji> {translation.get_text('Key')}"`
+- Cancel button always uses `callback_data="menu_cancel"`
+- Return `InlineKeyboardMarkup(keyboard)`
+
+## Dynamic Keyboard (From Data)
+
+```python
+def get_quality_keyboard(profiles: List[Dict]) -> InlineKeyboardMarkup:
+    """Build keyboard from quality profiles"""
+    translation = TranslationService()
+    keyboard = []
+
+    for profile in profiles:
+        keyboard.append([
+            InlineKeyboardButton(
+                profile["name"],
+                callback_data=f"quality_{profile['id']}"
+            )
+        ])
+
+    # Always add cancel row
+    keyboard.append([
+        InlineKeyboardButton(
+            f"❌ {translation.get_text('Cancel')}",
+            callback_data="menu_cancel"
+        )
+    ])
+    return InlineKeyboardMarkup(keyboard)
+```
+
+## Navigation Keyboard (Prev/Next)
+
+```python
+def get_navigation_keyboard(current_index: int, total: int) -> InlineKeyboardMarkup:
+    """Keyboard with prev/next and action buttons"""
+    translation = TranslationService()
+    nav_row = []
+
+    if current_index > 0:
+        nav_row.append(InlineKeyboardButton(
+            "⬅️", callback_data=f"nav_prev_{current_index - 1}"
+        ))
+    nav_row.append(InlineKeyboardButton(
+        f"{current_index + 1}/{total}", callback_data="nav_noop"
+    ))
+    if current_index < total - 1:
+        nav_row.append(InlineKeyboardButton(
+            "➡️", callback_data=f"nav_next_{current_index + 1}"
+        ))
+
+    keyboard = [
+        nav_row,
+        [InlineKeyboardButton(
+            f"✅ {translation.get_text('Add')}",
+            callback_data=f"select_{current_index}"
+        )],
+        [InlineKeyboardButton(
+            f"❌ {translation.get_text('Cancel')}",
+            callback_data="menu_cancel"
+        )],
+    ]
+    return InlineKeyboardMarkup(keyboard)
+```
+
+## Inline Handler Keyboard (No keyboards.py Function)
+
+For simple one-off keyboards, build inline in the handler:
+
+```python
+async def handle_confirm(self, update, context):
+    keyboard = [
+        [
+            InlineKeyboardButton("✅ Yes", callback_data="confirm_yes"),
+            InlineKeyboardButton("❌ No", callback_data="confirm_no"),
+        ]
+    ]
+    await query.message.edit_text(
+        text="Are you sure?",
+        reply_markup=InlineKeyboardMarkup(keyboard)
+    )
+```
+
+Use this only for simple yes/no or one-time keyboards. Reusable keyboards go in `keyboards.py`.
+
+## Button Layout Guidelines
+
+- **1 button per row**: Primary actions, selections from lists
+- **2 buttons per row**: Binary choices (yes/no, confirm/cancel)
+- **2-3 buttons per row**: Menu options with short labels
+- **Navigation row**: Always `[⬅️] [N/M] [➡️]` format
+- **Cancel button**: Always last row, always alone

--- a/.claude/skills/addarr-handlers/references/methods.md
+++ b/.claude/skills/addarr-handlers/references/methods.md
@@ -1,0 +1,184 @@
+# Handler Method Patterns
+
+## Entry Point (Command Handler)
+
+```python
+@require_auth
+async def handle_<command>(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Start the <feature> flow"""
+    if not update.effective_message or not update.effective_user:
+        return ConversationHandler.END
+
+    log_user_interaction(logger, update.effective_user, "/<command>")
+
+    # Initialize conversation state
+    context.user_data["<key>"] = value
+
+    await update.effective_message.reply_text(
+        text=self.translation.get_text("PromptKey"),
+        reply_markup=get_<name>_keyboard()
+    )
+    return States.<NEXT_STATE>
+```
+
+**Rules:**
+- Always decorate with `@require_auth`
+- Guard with `if not update.effective_message or not update.effective_user`
+- Log via `log_user_interaction(logger, update.effective_user, "/<cmd>")`
+- Return next state constant
+
+## Callback Handler
+
+```python
+async def handle_<action>(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle <action> callback"""
+    if not update.callback_query:
+        return ConversationHandler.END
+
+    query = update.callback_query
+    await query.answer()  # ALWAYS acknowledge first
+
+    # Extract data from callback
+    action = query.data.replace("<prefix>_", "")
+
+    # Business logic...
+    result = await self.<service>.do_something(action)
+
+    # Update message
+    await query.message.edit_text(
+        text=f"Result: {result}",
+        reply_markup=get_next_keyboard()
+    )
+    return States.<NEXT_STATE>
+```
+
+**Rules:**
+- Always `await query.answer()` before any other logic
+- Extract data by stripping prefix: `query.data.replace("prefix_", "")`
+- For multi-part data: `parts = query.data.split("_")`
+- Edit existing message, don't send new one
+
+## Photo-Aware Message Editing
+
+When a message might have an image (e.g., media cards):
+
+```python
+if query.message.photo:
+    await query.message.edit_caption(
+        caption=text,
+        reply_markup=reply_markup
+    )
+else:
+    await query.message.edit_text(
+        text=text,
+        reply_markup=reply_markup
+    )
+```
+
+## Message Handler (Text Input)
+
+```python
+async def handle_search(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle text search input"""
+    if not update.effective_message:
+        return ConversationHandler.END
+
+    query_text = update.message.text
+    search_type = context.user_data.get("search_type")
+
+    # Perform search
+    results = await self.media_service.search(search_type, query_text)
+
+    if not results:
+        await update.effective_message.reply_text(
+            self.translation.get_text("NoResults")
+        )
+        return ConversationHandler.END
+
+    # Store results and show first
+    context.user_data["search_results"] = results
+    context.user_data["current_index"] = 0
+    # ... show results
+    return States.SELECTING
+```
+
+## Cancel Handler
+
+```python
+async def handle_cancel(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Cancel current conversation"""
+    context.user_data.clear()
+
+    if update.callback_query:
+        await update.callback_query.answer()
+        await update.callback_query.message.edit_text(
+            self.translation.get_text("Cancel")
+        )
+    elif update.effective_message:
+        await update.effective_message.reply_text(
+            self.translation.get_text("Cancel")
+        )
+    return ConversationHandler.END
+```
+
+**Rules:**
+- Always clear `context.user_data`
+- Handle both callback and text message cancellation
+- Return `ConversationHandler.END`
+
+## Admin-Only Checks
+
+```python
+if config.get("security", {}).get("enableAdmin", False):
+    if update.effective_user.id not in config.get("admins", []):
+        await update.effective_message.reply_text("Access restricted.")
+        return ConversationHandler.END
+```
+
+## Context User Data
+
+```python
+# Store during conversation
+context.user_data["search_type"] = "movie"
+context.user_data["search_results"] = results
+context.user_data["current_index"] = 0
+context.user_data["selected_media"] = item
+
+# Retrieve with defaults
+results = context.user_data.get("search_results", [])
+index = context.user_data.get("current_index", 0)
+
+# Clear on cancel/end
+context.user_data.clear()
+```
+
+## Translation Access
+
+```python
+# Simple key lookup
+text = self.translation.get_text("Title")
+
+# With default fallback
+text = self.translation.get_text("Settings.LanguageChanged",
+    default=f"Language changed to {lang}")
+
+# With template variables
+text = self.translation.get_text("LibraryEmpty", subject="movies")
+```
+
+## Logging
+
+```python
+from src.utils.logger import get_logger, log_user_interaction
+
+logger = get_logger("addarr.<module_name>")
+
+# In handler methods
+log_user_interaction(logger, update.effective_user, "/movie")
+log_user_interaction(logger, update.effective_user, "search_movie", query)
+
+# Standard
+logger.info("Message")
+logger.error(f"Error: {e}")
+logger.warning("Warning")
+```

--- a/.claude/skills/addarr-handlers/references/wiring.md
+++ b/.claude/skills/addarr-handlers/references/wiring.md
@@ -1,0 +1,122 @@
+# Wiring a New Handler
+
+## Step 1: Define States
+
+Add new states to `src/bot/states.py`:
+
+```python
+class States:
+    # Existing states...
+    SEARCHING = 1
+    SELECTING = 2
+
+    # New states (use unique values)
+    MY_FEATURE_MENU = "my_feature_menu"
+    MY_FEATURE_ACTION = "my_feature_action"
+```
+
+**Convention:**
+- Media flow states: integers (`1, 2, 3, 4`)
+- Other flow states: descriptive strings (`"settings_menu"`, `"my_feature_menu"`)
+- Never reuse state values across different ConversationHandlers
+
+## Step 2: Add Translation Keys
+
+Add to all `translations/addarr.*.yml` files. At minimum, `addarr.en-us.yml`:
+
+```yaml
+en-us:
+  # PascalCase for simple terms
+  MyFeature: "My Feature"
+  MyFeaturePrompt: "🔍 Choose an option:"
+
+  # Dotted path for nested context
+  MyFeature.Success: "✅ Done!"
+  MyFeature.Error: "❌ Something went wrong"
+
+  # Variable interpolation with %{name}
+  MyFeature.Added: "Added %{title} successfully"
+```
+
+**Naming rules:**
+- PascalCase for keys: `MyFeature`, `SearchResults`
+- Dotted paths for grouping: `Settings.LanguageChanged`
+- Variables: `%{variable_name}`
+- Emojis in the value, not the key
+
+## Step 3: Export Handler
+
+Add to `src/bot/handlers/__init__.py`:
+
+```python
+from .my_feature import MyFeatureHandler
+
+__all__ = [
+    # existing...
+    "MyFeatureHandler",
+]
+```
+
+## Step 4: Register in main.py
+
+Add to `src/main.py:AddarrBot._add_handlers()`:
+
+```python
+def _add_handlers(self):
+    # ... existing handlers in order ...
+
+    # Add new handler (respect registration order)
+    my_feature = MyFeatureHandler()
+    for handler in my_feature.get_handler():
+        self.application.add_handler(handler)
+```
+
+**Registration order matters.** PTB matches the first matching handler. Current order:
+
+1. StartHandler
+2. AuthHandler
+3. MediaHandler
+4. SettingsHandler
+5. DeleteHandler
+6. LibraryHandler
+7. TransmissionHandler *(conditional)*
+8. SabnzbdHandler *(conditional)*
+9. HelpHandler
+10. PreferencesHandler
+11. SystemHandler
+
+**Placement rules:**
+- Handlers with unique command names (`/myfeature`) can go anywhere
+- Handlers that share callback prefixes with existing handlers must go after the handler that should take priority
+- Conditional handlers (config-gated) follow this pattern:
+
+```python
+if config.get("my_service", {}).get("enable", False):
+    my_feature = MyFeatureHandler()
+    for handler in my_feature.get_handler():
+        self.application.add_handler(handler)
+```
+
+## Step 5: Import in main.py
+
+Add the import at the top of `src/main.py`:
+
+```python
+from src.bot.handlers.my_feature import MyFeatureHandler
+```
+
+## Conversation Flow Design
+
+```
+Entry: /command or callback_data match
+       ↓
+State 1: Show prompt, wait for input
+       ↓
+State 2: Process input, show results
+       ↓
+State 3: Confirm action
+       ↓
+ConversationHandler.END
+```
+
+Each state transition returns the next state constant. Every path must eventually reach `ConversationHandler.END` (including error paths).

--- a/.claude/skills/addarr-services/SKILL.md
+++ b/.claude/skills/addarr-services/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: addarr-services
+description: Use when adding new services, API clients, or extending existing ones in Addarr. Covers singleton service pattern, BaseApiClient inheritance, config access, is_enabled() convention, and the service-to-API-client relationship.
+---
+
+# Addarr Services & API Clients
+
+Reference for building new services and API clients in Addarr. For testing these, see @addarr-testing.
+
+## Architecture Overview
+
+```
+Handler → Service → API Client → External API
+           ↑            ↑
+        Singleton    BaseApiClient
+        __new__()    _make_request()
+```
+
+- **Services** (`src/services/`) — Business logic, singleton pattern, aggregate API clients
+- **API Clients** (`src/api/`) — HTTP communication, inherit from `BaseApiClient`
+- Config accessed via `from src.config.settings import config`
+
+## Quick Start Checklist
+
+### New Service
+1. Create `src/services/<name>.py` with singleton pattern
+2. Export from `src/services/__init__.py`
+3. Inject into handler via `self.<service> = <Name>Service()`
+
+### New API Client
+1. Create `src/api/<name>.py` inheriting from `BaseApiClient`
+2. Implement `search()` abstract method
+3. Export from `src/api/__init__.py`
+4. Use from service: `self._client = <Name>Client()`
+
+## Service Template
+
+See [references/service-pattern.md](references/service-pattern.md) for the singleton class template with `__new__`, `_initialize`, `is_enabled()`, and async method patterns.
+
+## API Client Template
+
+See [references/api-client-pattern.md](references/api-client-pattern.md) for BaseApiClient inheritance, `__init__` validation, `search()` implementation, and `_make_request()` / `_request()` usage.
+
+## Config Access
+
+See [references/config-patterns.md](references/config-patterns.md) for nested dict access, URL construction, enable checks, and the config structure reference.
+
+## Common Mistakes
+
+See [references/anti-patterns.md](references/anti-patterns.md) for detailed examples with bad/good code.
+
+1. Raising from `_initialize` — Never propagate exceptions; set `_enabled = False` and log.
+2. Forgetting `is_enabled()` check — Calling methods on disabled services crashes.
+3. Using `__init__` for singleton state — Runs every instantiation, not just the first. Use `_initialize`.
+4. Creating sessions per request in BaseApiClient subclasses — Use `_get_session()` for pooling.
+5. Direct config indexing without enable check — `config["service"]` raises `KeyError` if missing.
+6. Double-slash URLs — Strip trailing slashes from path config with `rstrip("/")`.
+7. Incomplete singleton reset in tests — Must reset ALL class vars, not just `_instance`.
+8. Mixing API client and service layer conventions — API clients use f-string URLs, services use params dicts. See @addarr-testing patterns.md.

--- a/.claude/skills/addarr-services/references/anti-patterns.md
+++ b/.claude/skills/addarr-services/references/anti-patterns.md
@@ -1,0 +1,212 @@
+# Service & API Client Anti-Patterns
+
+Common mistakes when building services and API clients in Addarr.
+
+---
+
+## Raising from _initialize
+
+**Don't** let exceptions propagate from `_initialize`:
+
+```python
+# BAD - handler that does SABnzbdService() crashes if SABnzbd is disabled
+@classmethod
+def _initialize(cls):
+    sabnzbd_config = config.get('sabnzbd', {})
+    cls.api_key = sabnzbd_config['auth']['apikey']  # KeyError if missing!
+```
+
+**Instead**, catch exceptions and set `_enabled = False`:
+
+```python
+# GOOD
+@classmethod
+def _initialize(cls):
+    cls._enabled = False
+    try:
+        sabnzbd_config = config.get('sabnzbd', {})
+        if not sabnzbd_config.get('enable', False):
+            return
+        cls.api_key = sabnzbd_config.get('auth', {}).get('apikey')
+        if not cls.api_key:
+            logger.error("API key not configured")
+            return
+        cls._enabled = True
+    except Exception as e:
+        logger.error(f"Failed to initialize: {e}")
+        cls._enabled = False
+```
+
+**Why**: Handlers instantiate services in `__init__`. If `_initialize` raises, the handler can't be created and the bot fails to start. Setting `_enabled = False` lets the bot run with degraded functionality — handlers check `is_enabled()` before calling service methods. Issue #78 established this as the standard pattern.
+
+---
+
+## Forgetting is_enabled() Check
+
+**Don't** call service methods without checking enablement:
+
+```python
+# BAD - crashes if service is disabled/misconfigured
+async def handle_action(self, update, context):
+    status = await self.sabnzbd_service.get_status()
+```
+
+**Instead**, always check first:
+
+```python
+# GOOD
+async def handle_action(self, update, context):
+    if not self.sabnzbd_service.is_enabled():
+        await update.effective_message.reply_text("Service not available")
+        return ConversationHandler.END
+    status = await self.sabnzbd_service.get_status()
+```
+
+**Why**: A disabled service has `_client = None` and/or no API key configured. Calling methods on it produces `AttributeError` or `TypeError`. The `is_enabled()` pattern lets you fail gracefully with a user-friendly message.
+
+---
+
+## Using __init__ for Singleton State
+
+**Don't** put initialization logic in `__init__` for singleton services:
+
+```python
+# BAD - runs every time Service() is called, not just the first time
+class MyService:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        self._client = SomeClient()  # Creates new client EVERY instantiation!
+        self._enabled = True
+```
+
+**Instead**, use `_initialize` classmethod called from `__new__`:
+
+```python
+# GOOD - only runs once
+class MyService:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._initialize()
+        return cls._instance
+
+    @classmethod
+    def _initialize(cls):
+        cls._client = SomeClient()
+        cls._enabled = True
+```
+
+**Why**: Python calls `__init__` every time the class is called, even for singletons. `MyService()` in three handlers means `__init__` runs three times. Initializing clients or state in `__init__` creates duplicates and wastes resources. `_initialize()` in `__new__` runs exactly once.
+
+---
+
+## Creating Sessions Per Request in BaseApiClient Subclasses
+
+**Don't** create new `aiohttp.ClientSession` in methods of BaseApiClient subclasses:
+
+```python
+# BAD - bypasses session pooling, leaks connections
+async def get_status(self):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            return response.status == 200
+```
+
+**Instead**, use the inherited session management:
+
+```python
+# GOOD - uses pooled session from BaseApiClient
+async def get_status(self):
+    result = await self._request("system/status")
+    return result is not None
+```
+
+Or if you need direct session access:
+
+```python
+# GOOD - reuses managed session
+session = await self._get_session()
+async with session.get(url, headers=self._get_headers()) as response:
+    return response.status == 200
+```
+
+**Why**: `BaseApiClient._get_session()` manages a reusable `aiohttp.ClientSession` with proper timeout configuration. Creating sessions per request bypasses connection pooling, leaks connections, and ignores configured timeouts. Note: Standalone clients (SABnzbd, Transmission) that don't inherit from BaseApiClient do create sessions per request — that's acceptable for those.
+
+---
+
+## Direct Config Indexing Without Enable Check
+
+**Don't** access config with direct indexing before checking if the service is enabled:
+
+```python
+# BAD - KeyError if "myservice" doesn't exist in config
+server = config["myservice"]["server"]
+api_key = config["myservice"]["auth"]["apikey"]
+```
+
+**Instead**, use safe access with defaults:
+
+```python
+# GOOD
+service_config = config.get("myservice", {})
+if not service_config.get("enable", False):
+    return  # Service not enabled
+
+server = service_config.get("server", {})
+addr = server.get("addr")
+```
+
+**Why**: `config["key"]` raises `KeyError` if the key doesn't exist. Services that aren't configured won't have entries in `config.yaml`. Always use `.get(key, {})` for nested access until you've confirmed the service is enabled. `BaseApiClient.__init__` uses `config[service_name]` directly, but it's only called after the service is confirmed enabled.
+
+---
+
+## Double-Slash URLs
+
+**Don't** leave trailing slashes in path config that gets concatenated:
+
+```python
+# BAD - produces "http://localhost:7878//api/v3/..."
+path = server_config.get("path", "/")
+base_url = f"{protocol}://{addr}:{port}{path}"
+```
+
+**Instead**, strip trailing slashes:
+
+```python
+# GOOD
+path = server_config.get("path", "").rstrip("/")
+base_url = f"{protocol}://{addr}:{port}{path}"
+```
+
+**Why**: The `server.path` config value of `"/"` causes double-slash URLs. `BaseApiClient._build_base_url()` already handles this with `rstrip("/")`, but if you're building URLs manually in a standalone client, you must do it yourself. Issue #76 identified this as the root cause of URL issues.
+
+---
+
+## Incomplete Singleton Reset in Tests
+
+**Don't** only reset `_instance` when adding a new singleton:
+
+```python
+# BAD - only resets instance, not class-level state
+MyService._instance = None
+# Next test gets _instance = None but _enabled still True from previous test!
+```
+
+**Instead**, reset ALL class variables set in `_initialize`:
+
+```python
+# GOOD - in reset_singletons fixture
+MyService._instance = None
+MyService._enabled = False
+MyService._client = None
+```
+
+**Why**: Singleton class variables persist across tests. Resetting only `_instance` means the next test creates a new singleton but `_initialize()` runs again — however, conditional logic like `if cls._client is None` may skip re-initialization because the old value is still set. Three separate issues (#67, #78, #81) independently discovered this. See @addarr-testing fixtures.md for the full reset list.

--- a/.claude/skills/addarr-services/references/api-client-pattern.md
+++ b/.claude/skills/addarr-services/references/api-client-pattern.md
@@ -1,0 +1,202 @@
+# API Client Pattern
+
+## BaseApiClient Inheritance
+
+All media API clients (Radarr, Sonarr, Lidarr) inherit from `BaseApiClient` in `src/api/base.py`.
+
+### Template
+
+```python
+from typing import Dict, List, Optional
+from colorama import Fore
+
+from src.api.base import BaseApiClient
+from src.config.settings import config
+from src.utils.logger import get_logger
+
+logger = get_logger("addarr.<name>")
+
+
+class <Name>Client(BaseApiClient):
+    """<Name> API client"""
+
+    # Override if API version differs (default is "v3")
+    # API_VERSION = "v1"
+
+    def __init__(self):
+        """Initialize <Name> API client"""
+        service_config = config.get("<service_key>", {})
+        server_config = service_config.get("server", {})
+        auth_config = service_config.get("auth", {})
+
+        addr = server_config.get("addr")
+        port = server_config.get("port")
+
+        if not addr or not port:
+            logger.error(Fore.RED + "❌ <Name> server address or port not configured")
+            raise ValueError("<Name> server address or port not configured")
+
+        if not auth_config.get("apikey"):
+            logger.error(Fore.RED + "❌ <Name> API key not configured")
+            raise ValueError("<Name> API key not configured")
+
+        super().__init__("<service_key>")
+        logger.info(Fore.GREEN + f"✅ <Name> API client initialized: {self.base_url}")
+
+    async def search(self, term: str) -> List[Dict]:
+        """Search for <media type>"""
+        try:
+            logger.info(Fore.BLUE + f"🔍 Searching for: {term}")
+            results = await self._request(f"<endpoint>/lookup?term={term}")
+
+            if not results:
+                logger.warning(Fore.YELLOW + f"⚠️ No results for: {term}")
+                return []
+
+            logger.info(Fore.GREEN + f"✅ Found {len(results)} results")
+            return results
+        except Exception as e:
+            logger.error(Fore.RED + f"❌ Search failed: {str(e)}")
+            return []
+```
+
+### Init Validation
+
+The `__init__` pattern:
+1. Extract config sections (`server`, `auth`)
+2. Validate required fields (`addr`, `port`, `apikey`)
+3. Raise `ValueError` if validation fails (caught by service `_initialize`)
+4. Call `super().__init__(service_key)` which builds URL and sets up session management
+
+### What `super().__init__()` Provides
+
+`BaseApiClient.__init__(self, service_name)` sets up:
+- `self.config = config[service_name]` — service config section
+- `self.base_url` — built from `_build_base_url()` (protocol://addr:port/path)
+- `self.logger` — per-service logger
+- `self.request_timeout` — default 30s
+- `self._session = None` — lazy-loaded aiohttp session
+
+## Request Methods
+
+### `_make_request()` — Full control
+
+```python
+success, data, error = await self._make_request(
+    "endpoint/path",
+    method="GET",       # GET, POST, DELETE
+    data=None,          # JSON body for POST
+    title="Item Name",  # For error messages
+    timeout=60,         # Override default
+    max_retries=3       # Override default (2)
+)
+# Returns: Tuple[bool, Any, Optional[str]]
+```
+
+### `_request()` — Convenience wrapper
+
+```python
+result = await self._request("endpoint/path")
+# Returns: data on success, None on failure
+```
+
+Use `_request()` for simple GET calls where you just need the data. Use `_make_request()` when you need the success flag or error message.
+
+## Common Endpoint Patterns
+
+### GET with query params
+```python
+results = await self._request(f"movie/lookup?term={term}")
+```
+
+### GET by ID
+```python
+result = await self._request(f"movie/{movie_id}")
+```
+
+### GET list
+```python
+profiles = await self._request("qualityProfile")
+root_folders = await self._request("rootFolder")
+```
+
+### POST (add item)
+For complex POST requests that need custom response handling, use inline session:
+
+```python
+async def add_movie(self, tmdb_id, root_folder, quality_profile_id):
+    # Lookup first
+    lookup = await self._request(f"movie/lookup?term=tmdb:{tmdb_id}")
+    if not lookup:
+        return False, "Not found"
+
+    data = {
+        "tmdbId": lookup[0]["tmdbId"],
+        "title": lookup[0]["title"],
+        "qualityProfileId": quality_profile_id,
+        "rootFolderPath": root_folder,
+        "monitored": True,
+        "addOptions": {"searchForMovie": True}
+    }
+
+    session = await self._get_session()
+    url = f"{self.base_url}/api/{self.API_VERSION}/movie"
+    async with session.post(url, headers=self._get_headers(), json=data) as response:
+        # ... custom response parsing
+```
+
+### DELETE
+```python
+async def delete_movie(self, movie_id: int) -> bool:
+    session = await self._get_session()
+    url = f"{self.base_url}/api/{self.API_VERSION}/movie/{movie_id}?deleteFiles=true"
+    async with session.delete(url, headers=self._get_headers()) as response:
+        return response.status == 200
+```
+
+## check_status()
+
+Inherited from BaseApiClient — calls `system/status` endpoint:
+
+```python
+# Usually no override needed. BaseApiClient provides:
+async def check_status(self) -> bool:
+    success, _data, _error = await self._make_request("system/status")
+    return success
+```
+
+Override only if the service uses a different status endpoint.
+
+## API Version
+
+| Service | API_VERSION | Base Endpoint |
+|---------|-------------|---------------|
+| Radarr  | `v3`        | `/api/v3/`    |
+| Sonarr  | `v3`        | `/api/v3/`    |
+| Lidarr  | `v1`        | `/api/v1/`    |
+
+Override in subclass:
+```python
+class LidarrClient(BaseApiClient):
+    API_VERSION = "v1"
+```
+
+## Standalone Clients (No BaseApiClient)
+
+SABnzbd and Transmission don't inherit from BaseApiClient:
+
+- **SabnzbdClient**: Uses query-param-based API (`?mode=queue&apikey=...`), creates new session per request
+- **TransmissionClient**: Uses sync `requests.post()` with RPC protocol and session ID negotiation
+
+If your new API uses a non-REST pattern, consider a standalone client instead.
+
+## Return Type Conventions
+
+| Method | Returns |
+|--------|---------|
+| `search(term)` | `List[Dict]` (empty on failure) |
+| `get_<item>(id)` | `Optional[Dict]` (None on failure) |
+| `get_<items>()` | `List[Dict]` or `List[str]` (empty on failure) |
+| `add_<item>(...)` | `tuple[bool, str]` (success, message) |
+| `delete_<item>(id)` | `bool` |
+| `check_status()` | `bool` |

--- a/.claude/skills/addarr-services/references/config-patterns.md
+++ b/.claude/skills/addarr-services/references/config-patterns.md
@@ -1,0 +1,128 @@
+# Config Access Patterns
+
+## Import
+
+```python
+from src.config.settings import config
+```
+
+Always module-level import. `config` is a module-level singleton loaded from `config.yaml`.
+
+## Safe Nested Access
+
+```python
+# Chain .get() with empty dict defaults to avoid KeyError
+config.get("radarr", {}).get("enable", False)
+config.get("radarr", {}).get("server", {}).get("addr")
+config.get("sabnzbd", {}).get("auth", {}).get("apikey")
+```
+
+## Enable Check Pattern
+
+```python
+if config.get("service_key", {}).get("enable", False):
+    # Service is enabled, safe to access deeper config
+    client = ServiceClient()
+```
+
+## Direct Access (When Key is Guaranteed)
+
+BaseApiClient uses direct indexing because it's only called for enabled services:
+
+```python
+# In BaseApiClient.__init__
+self.config = config[service_name]          # e.g., config["radarr"]
+server = self.config["server"]              # guaranteed to exist
+api_key = self.config["auth"]["apikey"]     # guaranteed to exist
+```
+
+## URL Construction
+
+Standard pattern used by all services/clients:
+
+```python
+server_config = config.get("service_key", {}).get("server", {})
+protocol = "https" if server_config.get("ssl", False) else "http"
+addr = server_config.get("addr")
+port = server_config.get("port")
+path = server_config.get("path", "").rstrip("/")
+
+base_url = f"{protocol}://{addr}:{port}{path}"
+```
+
+## Config Updates
+
+```python
+# Update nested value
+config.update_nested("service.enable", True)
+config.update_nested("language", "en-us")
+
+# Save to disk
+config.save()
+```
+
+## Config Structure Reference
+
+```yaml
+telegram:
+  token: "bot_token"
+
+language: "en-us"
+
+security:
+  enableAdmin: false
+  enableAllowlist: false
+
+radarr:                    # Same structure for sonarr, lidarr
+  enable: true
+  server:
+    ssl: false
+    addr: "localhost"
+    port: 7878
+    path: ""
+  auth:
+    apikey: "abc123"
+  paths:
+    excludedRootFolders: []
+    narrowRootFolderNames: false
+
+transmission:
+  enable: false
+  server:
+    ssl: false
+    addr: "localhost"
+    port: 9091
+    path: "/transmission"
+  auth:
+    username: ""
+    password: ""
+
+sabnzbd:
+  enable: false
+  server:
+    ssl: false
+    addr: "localhost"
+    port: 8080
+    path: "/sabnzbd"
+  auth:
+    apikey: "xyz789"
+```
+
+## Path Constants
+
+Defined in `src/definitions.py`:
+
+| Constant | Value |
+|----------|-------|
+| `ROOT_DIR` | Project root |
+| `CONFIG_PATH` | `config.yaml` |
+| `CONFIG_EXAMPLE_PATH` | `config_example.yaml` |
+| `TRANSLATIONS_PATH` | `translations/` |
+| `CHATID_PATH` | `chatid.txt` |
+| `LOG_PATH` | `logs/addarr.log` |
+| `ADMIN_PATH` | `admin.txt` |
+| `ALLOWLIST_PATH` | `allowlist.txt` |
+| `DATA_PATH` | `data/` |
+| `PREFERENCES_PATH` | `user_preferences.json` |
+
+Helper functions: `is_admin(user_id)`, `is_allowed_user(user_id)`, `get_admins()`, `get_allowed_users()`

--- a/.claude/skills/addarr-services/references/service-pattern.md
+++ b/.claude/skills/addarr-services/references/service-pattern.md
@@ -1,0 +1,148 @@
+# Service Singleton Pattern
+
+## Template
+
+```python
+import aiohttp
+
+from src.config.settings import config
+from src.utils.logger import get_logger
+
+logger = get_logger("addarr.<name>")
+
+
+class <Name>Service:
+    """Service for <description>"""
+    _instance = None
+
+    def __new__(cls):
+        """Ensure only one instance exists"""
+        if cls._instance is None:
+            cls._instance = super(<Name>Service, cls).__new__(cls)
+            cls._initialize()
+        return cls._instance
+
+    @classmethod
+    def _initialize(cls):
+        """Initialize service state on first instantiation."""
+        cls._enabled = False
+        cls._client = None
+
+        service_config = config.get('<service_key>', {})
+        if not service_config.get('enable', False):
+            return
+
+        try:
+            # Initialize client or state
+            cls._client = <Name>Client()
+            cls._enabled = True
+            logger.info("✅ <Name>Service initialized")
+        except Exception as e:
+            logger.error(f"Failed to initialize <Name>Service: {e}")
+            cls._enabled = False
+
+    def is_enabled(self) -> bool:
+        """Check if service is enabled and properly configured."""
+        return bool(self._enabled)
+```
+
+## Key Rules
+
+### Singleton via `__new__`
+- `_instance` class variable holds the singleton
+- `__new__` checks `_instance is None` before creating
+- `_initialize()` is a `@classmethod` called once from `__new__`
+
+### `_initialize` Error Handling
+- **Never raise** from `_initialize` — set `_enabled = False` and log instead
+- This allows handlers to check `is_enabled()` rather than catching init exceptions
+- Pattern from issue #78: `try/except Exception` → `_enabled = False`
+
+### Class vs Instance Variables
+- All state in `_initialize` uses **class variables** (`cls._enabled`, `cls._client`)
+- These are accessed via `self._enabled` in instance methods (Python resolves to class)
+- `__init__` is rarely used (runs every time `<Name>Service()` is called, not just first time)
+
+### Testing Implications
+- `reset_singletons` fixture must reset `_instance = None` AND all class vars
+- Example: `_instance = None, _enabled = False, _client = None`
+- See @addarr-testing fixtures.md for the singleton reset warning
+
+## Async Methods
+
+```python
+async def get_status(self) -> Dict[str, Any]:
+    """Get service status"""
+    if not self.is_enabled():
+        return {"error": "Service not enabled"}
+
+    try:
+        result = await self._client.get_status()
+        return result
+    except Exception as e:
+        logger.error(f"Error getting status: {e}")
+        return {"error": str(e)}
+```
+
+**Rules:**
+- Always check `is_enabled()` first
+- Wrap in try/except, return sensible defaults on error
+- Delegate I/O to API client, don't make HTTP calls directly
+
+## Service with API Client Aggregation
+
+MediaService pattern — wraps multiple API clients:
+
+```python
+class MediaService:
+    _instance = None
+    _radarr = None
+    _sonarr = None
+    _lidarr = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(MediaService, cls).__new__(cls)
+            cls._initialize_clients()
+        return cls._instance
+
+    @classmethod
+    def _initialize_clients(cls):
+        if cls._radarr is None:
+            try:
+                if config.get("radarr", {}).get("enable"):
+                    cls._radarr = RadarrClient()
+            except Exception as e:
+                logger.error(f"Failed to initialize Radarr: {e}")
+                cls._radarr = None
+        # Repeat for sonarr, lidarr...
+
+    @property
+    def radarr(self):
+        return self._radarr
+
+    async def search_movies(self, query: str) -> List[Dict]:
+        if not self._radarr:
+            return []
+        return await self._radarr.search(query)
+```
+
+**Key Points:**
+- Each client is independently initialized (one failing doesn't block others)
+- Properties expose read-only access
+- Search methods delegate directly to client
+- Returns empty list if client unavailable
+
+## Pre-Instantiated Singletons
+
+Some services export a module-level instance (used in `__init__.py`):
+
+```python
+# In src/services/<name>.py
+<name>_service = <Name>Service()
+
+# In src/services/__init__.py
+from .<name> import <name>_service, <Name>Service
+```
+
+Used for services that need shared state (HealthService, TransmissionService). Most services just export the class.

--- a/.claude/skills/addarr-testing/SKILL.md
+++ b/.claude/skills/addarr-testing/SKILL.md
@@ -82,3 +82,7 @@ Override values via `MockConfig._set()`. See [references/patterns.md#config](ref
 3. Using `aioresponses` for Transmission — it uses sync `requests`, not `aiohttp`. See [references/anti-patterns.md#transmission-mocking](references/anti-patterns.md#transmission-mocking).
 4. Testing translated text literally — mock returns keys, not translated strings. See [references/anti-patterns.md#translation-testing](references/anti-patterns.md#translation-testing).
 5. Creating real `aiohttp.ClientSession` in tests — use `aioresponses` instead. See [references/anti-patterns.md#real-sessions](references/anti-patterns.md#real-sessions).
+6. Patching services at source module instead of import site — patch where the handler imports it. See [references/anti-patterns.md#patching-at-wrong-import-path](references/anti-patterns.md#patching-at-wrong-import-path).
+7. Not cleaning up reusable sessions between tests — mock state leaks. See [references/anti-patterns.md#not-cleaning-up-sessions-between-tests](references/anti-patterns.md#not-cleaning-up-sessions-between-tests).
+8. Registering too few mocks for retry scenarios — need N+1 mocks for N retries. See [references/anti-patterns.md#insufficient-retry-mocks](references/anti-patterns.md#insufficient-retry-mocks).
+9. Mocking `sys.exit` without stopping execution — use `pytest.raises(SystemExit)`. See [references/anti-patterns.md#mocking-sysexit-without-stopping-execution](references/anti-patterns.md#mocking-sysexit-without-stopping-execution).

--- a/.claude/skills/addarr-testing/references/anti-patterns.md
+++ b/.claude/skills/addarr-testing/references/anti-patterns.md
@@ -149,3 +149,115 @@ data["radarr"]["enable"] = False
 ```
 
 **Why**: Python creates separate name bindings for each `from X import Y`. Patching `src.config.settings.config` doesn't affect `src.services.media.config` if media.py did `from src.config.settings import config`. The `sys.modules` injection in conftest solves this by replacing the entire module before any imports happen.
+
+---
+
+## Patching at Wrong Import Path
+
+**Don't** patch a service at its source module when testing code that imports it:
+
+```python
+# BAD - patches the source, not where it's used
+with patch("src.services.media.MediaService"):
+    from src.bot.handlers.media import MediaHandler
+    handler = MediaHandler()  # Still gets the real MediaService!
+```
+
+**Instead**, patch at the import site — where the module under test imports it:
+
+```python
+# GOOD - patch where the handler imports it from
+with patch("src.bot.handlers.media.MediaService", return_value=mock_media_service):
+    from src.bot.handlers.media import MediaHandler
+    handler = MediaHandler()
+```
+
+**Why**: Python name bindings are per-module. When `media.py` does `from src.services.media import MediaService`, it creates a local binding. Patching the source module doesn't affect that local binding. You must patch at `src.bot.handlers.media.MediaService`. This applies to all services, not just config — three separate issues (#17, #67, #78) independently hit this.
+
+---
+
+## Not Cleaning Up Sessions Between Tests
+
+**Don't** skip session cleanup when testing API clients with reusable sessions:
+
+```python
+# BAD - session persists, mock state leaks to next test
+async def test_one(radarr_client, aio_mock, radarr_url):
+    aio_mock.get(f"{radarr_url}/api/v3/system/status", payload={"version": "5.0"})
+    await radarr_client.check_status()
+    # Session stays open with stale mock state
+```
+
+**Instead**, use an autouse cleanup fixture or close explicitly:
+
+```python
+# GOOD - autouse fixture closes session after each test
+@pytest.fixture(autouse=True)
+async def cleanup_session(radarr_client):
+    yield
+    await radarr_client.close()
+
+# GOOD - explicit cleanup for ad-hoc clients
+async def test_custom_client():
+    client = RadarrClient()
+    try:
+        result = await client.some_method()
+    finally:
+        await client.close()
+```
+
+**Why**: `BaseApiClient._get_session()` returns the existing session if one is open. Without cleanup, the next test inherits a session with stale mock state, causing mysterious failures. Two issues (#21, #76) hit this independently.
+
+---
+
+## Mocking sys.exit Without Stopping Execution
+
+**Don't** mock `sys.exit` as a simple MagicMock — execution continues past the exit call:
+
+```python
+# BAD - code after sys.exit() still runs
+@patch("sys.exit")
+def test_reset_config(mock_exit):
+    wizard._reset_config()
+    mock_exit.assert_called_once_with(0)
+    # But all code after sys.exit(0) in the function also executed!
+```
+
+**Instead**, use `pytest.raises(SystemExit)` to catch the real exit:
+
+```python
+# GOOD - actually stops execution at the exit point
+def test_reset_config():
+    with pytest.raises(SystemExit) as exc_info:
+        wizard._reset_config()
+    assert exc_info.value.code == 0
+```
+
+**Why**: `MagicMock()` replaces `sys.exit` with a no-op that returns `None`. The function's code after the exit call keeps running, which can trigger errors or false positives. `pytest.raises(SystemExit)` catches the actual exception that `sys.exit` raises.
+
+---
+
+## Insufficient Retry Mocks
+
+**Don't** register only one failure mock when the client has retry logic:
+
+```python
+# BAD - only 1 mock but client retries 2 times (needs 3 total)
+aio_mock.get(url, exception=aiohttp.ClientError("fail"))
+result = await client.check_status()
+# Raises ConnectionError on second attempt because no mock is registered
+```
+
+**Instead**, register one mock per attempt (initial + retries):
+
+```python
+# GOOD - 3 mocks for initial + 2 retries
+for _ in range(3):
+    aio_mock.get(url, exception=aiohttp.ClientError("fail"))
+
+with patch("asyncio.sleep", new_callable=AsyncMock):
+    result = await client.check_status()
+    assert result is False
+```
+
+**Why**: `aioresponses` mocks are consumed in FIFO order per URL. Each request consumes one mock. If the client retries twice after the initial failure, you need 3 mocks total. Also remember to patch `asyncio.sleep` to avoid real delays during retries.

--- a/.claude/skills/addarr-testing/references/fixtures.md
+++ b/.claude/skills/addarr-testing/references/fixtures.md
@@ -24,6 +24,8 @@ Resets all singleton `_instance` attributes after each test:
 - `NotificationService._instance` = None, `._bot` = None
 - `AuthHandler._authenticated_users` = set()
 
+> **When adding new singletons:** Reset ALL relevant class vars, not just `_instance`. Singletons often store state beyond the instance reference (e.g., `_preferences = {}`, `_enabled = False`, `_client = None`). If you only reset `_instance = None`, the new instance may inherit stale class-level state from the previous test. Three separate issues (#67, #78, #81) independently discovered this — always audit what class vars your singleton sets during `__new__`/`_initialize` and reset them all.
+
 ### mock_translation (autouse)
 
 Patches `TranslationService._load_translations` so tests don't need real YAML files. Does NOT patch `get_text` — tests that call code which uses `get_text` must either:

--- a/.claude/skills/addarr-testing/references/patterns.md
+++ b/.claude/skills/addarr-testing/references/patterns.md
@@ -327,3 +327,155 @@ mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
 ```
 
 This way assertions check for translation keys, not locale-specific text.
+
+---
+
+## Retry and Timeout Testing
+
+API clients inherit retry logic from `BaseApiClient`. Testing retries requires specific mock setup.
+
+### aioresponses FIFO Ordering
+
+`aioresponses` mocks are consumed in FIFO order per URL. Register one mock per attempt:
+
+```python
+async def test_retry_then_succeed(radarr_client, aio_mock, radarr_url):
+    url = f"{radarr_url}/api/v3/system/status"
+    # First attempt: failure (consumed first)
+    aio_mock.get(url, exception=aiohttp.ClientError("fail"))
+    # Second attempt: success (consumed second)
+    aio_mock.get(url, payload={"version": "5.0"})
+
+    result = await radarr_client.check_status()
+    assert result is True
+```
+
+For N retries, register N+1 mocks (1 initial + N retries). Example with 2 retries configured:
+
+```python
+async def test_all_retries_exhausted(radarr_client, aio_mock, radarr_url):
+    url = f"{radarr_url}/api/v3/system/status"
+    # Initial + 2 retries = 3 mocks
+    for _ in range(3):
+        aio_mock.get(url, exception=aiohttp.ClientError("fail"))
+
+    result = await radarr_client.check_status()
+    assert result is False
+```
+
+### Patching asyncio.sleep for Backoff
+
+Retry logic uses `asyncio.sleep` for backoff delays. Patch at module level to avoid real delays and verify backoff values:
+
+```python
+async def test_retry_backoff(radarr_client, aio_mock, radarr_url):
+    url = f"{radarr_url}/api/v3/system/status"
+    aio_mock.get(url, exception=aiohttp.ClientError("fail"))
+    aio_mock.get(url, payload={"version": "5.0"})
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        await radarr_client.check_status()
+        mock_sleep.assert_called_once_with(1)  # First backoff = 1s
+```
+
+### TimeoutError Handling
+
+`asyncio.TimeoutError` does NOT inherit from `aiohttp.ClientError` — they require separate handling but both are retryable:
+
+```python
+async def test_timeout_triggers_retry(radarr_client, aio_mock, radarr_url):
+    url = f"{radarr_url}/api/v3/system/status"
+    aio_mock.get(url, exception=asyncio.TimeoutError())
+    aio_mock.get(url, payload={"version": "5.0"})
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        result = await radarr_client.check_status()
+        assert result is True
+```
+
+### Updating Existing Tests for Retry
+
+When retry logic is added to a client, existing error tests need more mocks. A test that previously registered 1 failure mock now needs initial + retries:
+
+```python
+# BEFORE retry logic: 1 mock
+aio_mock.get(url, exception=aiohttp.ClientError("fail"))
+
+# AFTER retry logic (2 retries): 3 mocks
+for _ in range(3):
+    aio_mock.get(url, exception=aiohttp.ClientError("fail"))
+```
+
+---
+
+## Session Cleanup
+
+API clients reuse `aiohttp.ClientSession` for performance. Tests must close sessions to prevent mock state leaking across test boundaries.
+
+### Autouse Cleanup Fixture
+
+```python
+@pytest.fixture(autouse=True)
+async def cleanup_session(radarr_client):
+    yield
+    await radarr_client.close()
+```
+
+### Ad-hoc Client Instances
+
+Tests that create their own client instances (bypassing the shared fixture) must close explicitly:
+
+```python
+async def test_custom_client():
+    client = RadarrClient()
+    try:
+        result = await client.some_method()
+        assert result is not None
+    finally:
+        await client.close()
+```
+
+### Why This Matters
+
+`_get_session()` returns an existing session if one is open. If a previous test's session is still open with stale mock state, the next test inherits that state. The `cleanup_session` fixture ensures each test starts with a fresh session.
+
+---
+
+## API Client vs Service Layer Conventions
+
+The codebase has two distinct patterns for API interaction. Tests must match the convention of the layer under test.
+
+### API Client Layer
+
+- URLs built with f-strings and inline query params
+- Returns raw responses: `response.status == 200`
+- Error handling: catches `aiohttp.ClientError`
+- Mock with: `aioresponses` matching exact URL strings (including query params)
+
+```python
+# API client code style
+url = f"{self.base_url}/api/v3/movie/lookup?term={query}"
+async with self._session.get(url) as response:
+    if response.status == 200:
+        return await response.json()
+```
+
+### Service Layer
+
+- Uses params dicts passed to `session.get(url, params=...)`
+- Returns normalized shapes: `data.get('status', False)`
+- Error handling: checks parsed data structure, returns domain-specific defaults
+- Service tests often define their own response dicts inline (not from `sample_data.py`)
+
+```python
+# Service layer code style
+params = {"mode": "queue", "apikey": self._api_key, "output": "json"}
+data = await self._make_request(params=params)
+return {"total": data.get("noofslots", 0), "items": data.get("slots", [])}
+```
+
+### Testing Implications
+
+- API tests: mock exact URLs with `aioresponses`, assert on raw return values
+- Service tests: inject mock clients via class attributes, assert on normalized return shapes
+- SABnzbd API uses `mode=config&name=speedlimit&value=<pct>` query params — spaces in values become `+` encoding in mock URLs

--- a/.claude/skills/code-simplifier/SKILL.md
+++ b/.claude/skills/code-simplifier/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: code-simplifier
+description: Use when asked to simplify, clean up, or refactor code for clarity. Focuses on reducing complexity, eliminating redundant abstractions, and improving readability while preserving functionality. Complements the quick-pass simplify superpowers skill with deeper, focused refactoring.
+---
+
+# Code Simplifier
+
+Simplify and refine code for clarity, consistency, and maintainability while preserving exact functionality. Adapted from [Sentry's code-simplifier skill](https://github.com/getsentry/sentry-skills).
+
+**Relationship to `superpowers:simplify`:** The `simplify` skill is a quick post-change review pass (reuse, quality, efficiency). This skill is for deeper, focused refactoring sessions where you methodically simplify a file or feature area.
+
+## Refinement Principles
+
+### 1. Preserve Functionality
+
+Never change what the code does — only how it does it. All original features, outputs, and behaviors must remain intact.
+
+### 2. Apply Project Standards
+
+Follow Addarr conventions from CLAUDE.md:
+
+- Async throughout (`async/await`, `aiohttp`)
+- Singleton services (`__new__` + `_initialize`, not `__init__`)
+- Safe config access (`.get()` with defaults, not direct indexing)
+- `is_enabled()` checks before service method calls
+- `@require_auth` on all handler entry points
+- Centralized keyboards in `src/bot/keyboards.py`
+- Translation via `TranslationService().get_text(key, default=...)`
+- Flake8 with max line length 88
+
+### 3. Enhance Clarity
+
+Simplify code structure by:
+
+- Reducing unnecessary nesting (early returns, guard clauses)
+- Eliminating redundant abstractions used only once
+- Improving variable and function names for readability
+- Consolidating related logic
+- Removing comments that describe obvious code
+- Preferring explicit `if/elif/else` over nested ternaries
+- Choosing clarity over brevity — explicit code is better than dense one-liners
+
+### 4. Python-Specific Simplifications
+
+Common patterns to simplify in this codebase:
+
+```python
+# BEFORE: Verbose conditional assignment
+if condition:
+    value = "a"
+else:
+    value = "b"
+
+# AFTER: Inline conditional (when simple)
+value = "a" if condition else "b"
+```
+
+```python
+# BEFORE: Manual dict building
+result = {}
+for item in items:
+    result[item.id] = item.name
+
+# AFTER: Dict comprehension
+result = {item.id: item.name for item in items}
+```
+
+```python
+# BEFORE: Nested config access with repeated .get()
+server = config.get("radarr", {}).get("server", {})
+addr = server.get("addr", "")
+port = server.get("port", "")
+path = server.get("path", "")
+
+# AFTER: Unpack once
+server = config.get("radarr", {}).get("server", {})
+addr, port, path = server.get("addr", ""), server.get("port", ""), server.get("path", "")
+```
+
+```python
+# BEFORE: Redundant wrapper
+def is_not_empty(lst):
+    return len(lst) > 0
+
+if is_not_empty(results):
+    ...
+
+# AFTER: Direct check
+if results:
+    ...
+```
+
+### 5. Maintain Balance
+
+Avoid over-simplification that could:
+
+- Reduce code clarity or maintainability
+- Create overly clever solutions hard to understand
+- Combine too many concerns into single functions
+- Remove helpful abstractions that improve organization
+- Prioritize fewer lines over readability
+- Make the code harder to debug or extend
+
+### 6. Focus Scope
+
+Only refine code that has been recently modified or explicitly targeted, unless instructed to review broader scope.
+
+## Refinement Process
+
+1. **Identify** the target code sections (changed files or specified scope)
+2. **Analyze** for complexity reduction opportunities
+3. **Apply** project standards from CLAUDE.md and skill conventions
+4. **Ensure** all functionality remains unchanged
+5. **Verify** the refined code is simpler and more maintainable
+6. **Run tests** to confirm nothing broke: `pytest -x --tb=short`
+
+## Common Simplification Targets in Addarr
+
+| Pattern | Simplification |
+|---------|---------------|
+| Repeated `if photo: edit_caption else: edit_text` | Extract to helper or use existing utility |
+| Manual keyboard construction inline | Move to `src/bot/keyboards.py` function |
+| Duplicate error handling in handlers | Extract common error response pattern |
+| Verbose config access chains | Unpack config section once at top |
+| Repeated `is_enabled()` + error reply | Consider decorator or shared guard |
+| Multiple similar `CallbackQueryHandler` registrations | Look for pattern consolidation |
+
+## What NOT to Simplify
+
+- Singleton `__new__` + `_initialize` pattern (it's intentional, not redundant)
+- `is_enabled()` guard checks (safety-critical, must remain explicit)
+- `await query.answer()` calls (Telegram requirement)
+- `context.user_data.clear()` in cancel handlers (prevents state leaks)
+- State return values from handler methods (ConversationHandler requires them)

--- a/.claude/skills/find-bugs/SKILL.md
+++ b/.claude/skills/find-bugs/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: find-bugs
+description: Use when reviewing branch changes for bugs, security vulnerabilities, or code quality issues. Covers async Python, Telegram bot handlers, API clients, config access, and singleton patterns.
+---
+
+# Find Bugs
+
+Review changes on the current branch for bugs, security vulnerabilities, and code quality issues. Adapted from [Sentry's find-bugs skill](https://github.com/getsentry/sentry-skills) with Addarr-specific checks.
+
+## Phase 1: Complete Input Gathering
+
+1. Get the FULL diff: `git diff $(git merge-base HEAD development)...HEAD`
+2. If output is truncated, read each changed file individually until you have seen every changed line
+3. List all files modified in this branch before proceeding
+
+## Phase 2: Attack Surface Mapping
+
+For each changed file, identify and list:
+
+* All user inputs (Telegram message text, callback_data, command arguments)
+* All API calls (Radarr, Sonarr, Lidarr, SABnzbd, Transmission)
+* All authentication/authorization checks (`@require_auth`, user ID validation)
+* All config access patterns (safe `.get()` vs direct indexing)
+* All async operations (`await`, session management, `aiohttp` calls)
+* All singleton state mutations (class-level variables)
+
+## Phase 3: Security & Bug Checklist
+
+Check EVERY item for EVERY changed file:
+
+* [ ] **Injection**: Command injection via `subprocess`, template injection, YAML injection in config
+* [ ] **Authentication bypass**: Missing `@require_auth` on entry points, user ID spoofing
+* [ ] **Authorization/IDOR**: Access control on per-user operations (e.g., user_data isolation)
+* [ ] **Information disclosure**: API keys in logs, error messages leaking internal state, secrets in Telegram messages
+* [ ] **Race conditions**: TOCTOU in singleton initialization, concurrent user_data access
+* [ ] **Resource exhaustion**: Unbounded search results, missing timeouts on API calls, session leaks
+* [ ] **Business logic**: State machine violations (ConversationHandler states), numeric edge cases in quality/season selection
+* [ ] **Async bugs**: Missing `await`, unclosed sessions, fire-and-forget coroutines
+* [ ] **Singleton issues**: State in `__init__` vs `_initialize`, missing `is_enabled()` checks, incomplete reset
+* [ ] **Config safety**: Direct `config["key"]` indexing without enable check, missing `.get()` defaults
+* [ ] **Telegram API misuse**: Missing `query.answer()`, `reply_text` on callbacks, `edit_text` on photo messages
+* [ ] **Error handling**: Bare `except:`, swallowing exceptions silently, raising from `_initialize`
+
+## Phase 4: Verification
+
+For each potential issue:
+
+* Check if it's already handled elsewhere in the changed code
+* Search for existing tests covering the scenario
+* Read surrounding context to verify the issue is real
+* Check if the pattern matches existing code conventions (see `@addarr-services` and `@addarr-handlers` anti-patterns)
+
+## Phase 5: Pre-Conclusion Audit
+
+Before finalizing, you MUST:
+
+1. List every file you reviewed and confirm you read it completely
+2. List every checklist item and note whether you found issues or confirmed it's clean
+3. List any areas you could NOT fully verify and why
+4. Only then provide your final findings
+
+## Output Format
+
+**Prioritize**: security vulnerabilities > async/singleton bugs > Telegram API misuse > code quality
+
+**Skip**: stylistic/formatting issues, flake8 catches
+
+For each issue:
+
+* **File:Line** — Brief description
+* **Severity**: Critical / High / Medium / Low
+* **Problem**: What's wrong
+* **Evidence**: Why this is real (not already fixed, no existing test, etc.)
+* **Fix**: Concrete suggestion
+* **References**: Link to relevant anti-pattern in `@addarr-services` or `@addarr-handlers` if applicable
+
+If you find nothing significant, say so — don't invent issues.
+
+Do not make changes — just report findings.

--- a/.claude/skills/git-cleanup/SKILL.md
+++ b/.claude/skills/git-cleanup/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: git-cleanup
+description: Use when cleaning up accumulated local git branches and worktrees. Safely categorizes branches as merged, squash-merged, superseded, or active work with two confirmation gates before deletion.
+---
+
+# Git Cleanup
+
+Safely clean up accumulated git worktrees and local branches by categorizing them into: safely deletable (merged), potentially related (similar themes), and active work (keep). Adapted from [Trail of Bits' git-cleanup skill](https://github.com/trailofbits/skills).
+
+## When to Use
+
+- Accumulated many local branches and worktrees
+- Branches merged but not cleaned up locally
+- Remote branches deleted but local tracking branches remain
+
+## When NOT to Use
+
+- Remote branch management (local cleanup only)
+- Repository maintenance tasks like gc or prune
+
+## Core Principle: SAFETY FIRST
+
+**Never delete anything without explicit user confirmation.** Two-gate workflow: analysis review, then deletion confirmation.
+
+## Workflow
+
+### Phase 1: Comprehensive Analysis
+
+```bash
+# Get default branch
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD \
+  2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
+
+# Protected branches - never delete
+protected='^(main|master|development|release/.*)$'
+
+# List branches with tracking info + worktrees
+git branch -vv
+git worktree list
+
+# Sync remote state
+git fetch --prune
+
+# Merged branches and recent PR history
+git branch --merged "$default_branch"
+git log --oneline "$default_branch" | grep -iE "#[0-9]+" | head -30
+
+# Per-branch analysis
+for branch in $(git branch --format='%(refname:short)' \
+  | grep -vE "$protected"); do
+  echo "=== $branch ==="
+  git log --oneline "$default_branch".."$branch" 2>/dev/null | head -5
+  git log --oneline "origin/$branch".."$branch" 2>/dev/null | head -5 || echo "(no remote)"
+done
+```
+
+### Phase 2: Group Related Branches
+
+Before individual categorization, group by shared prefixes:
+
+```bash
+git branch --format='%(refname:short)' | sed 's/-[^-]*$//' | sort | uniq -c | sort -rn
+```
+
+For each group (2+ branches): compare commit histories, find merge evidence, identify the "final" branch, mark superseded branches.
+
+**SUPERSEDED requires evidence** — a PR merged the work into main, OR a newer branch contains all commits. Name prefix alone is NOT sufficient.
+
+### Phase 3: Categorize Remaining Branches
+
+| Category | Meaning | Delete Command |
+|----------|---------|----------------|
+| SAFE_TO_DELETE | Merged into default branch | `git branch -d` |
+| SQUASH_MERGED | Work incorporated via squash merge | `git branch -D` |
+| SUPERSEDED | Part of group, work verified in main | `git branch -D` |
+| REMOTE_GONE | Remote deleted, work NOT in main | Review needed |
+| UNPUSHED_WORK | Has commits not pushed to remote | Keep |
+| LOCAL_WORK | Untracked branch with unique commits | Keep |
+| SYNCED_WITH_REMOTE | Up to date with remote | Keep |
+
+### Phase 4: Dirty State Detection
+
+Check ALL worktrees for uncommitted changes:
+
+```bash
+git -C <worktree-path> status --porcelain
+git status --porcelain
+```
+
+Display warnings prominently for any dirty worktrees.
+
+### GATE 1: Present Complete Analysis
+
+Present ONE comprehensive view with related branch groups, individual branches by category, worktree status, and summary counts. Use `AskUserQuestion` with options:
+- Delete all recommended
+- Delete specific groups/categories
+- Pick individual branches
+
+**Do not proceed until user responds.**
+
+### GATE 2: Final Confirmation with Exact Commands
+
+Show the EXACT commands that will run with correct flags (`-d` for merged, `-D` for squash-merged/superseded). **This is the ONLY deletion confirmation needed.**
+
+### Phase 5: Execute
+
+Run each deletion as a **separate command** so partial failures don't block remaining deletions.
+
+### Phase 6: Report
+
+Show deleted branches, remaining branches, and any errors encountered.
+
+## Safety Rules
+
+1. **Never invoke automatically** — Only when user explicitly requests cleanup
+2. **Two confirmation gates only** — Analysis review, then deletion confirmation
+3. **Correct delete flags** — `-d` for merged, `-D` for squash-merged/superseded
+4. **Never touch protected branches** — main, master, development, release/*
+5. **Block dirty worktree removal** — Refuse without explicit data loss acknowledgment
+6. **Group related branches** — Don't scatter them across categories
+
+## Squash-Merged Branches
+
+`git branch -d` will ALWAYS fail for squash-merged branches because git cannot detect the work was incorporated. Plan to use `git branch -D` from the start — don't try `-d` first.

--- a/.claude/skills/task-writer/SKILL.md
+++ b/.claude/skills/task-writer/SKILL.md
@@ -141,6 +141,18 @@ Task complete
 | Architectural uncertainty?     | Stop and ask before implementing          |
 | Trivial (1-line change)?       | Don't create task, just do it             |
 
+## Test Count Estimation
+
+Historical data shows test counts in plans are consistently underestimated by 1.5-2x:
+
+| Issue | Planned Tests | Actual Tests | Ratio |
+|-------|--------------|--------------|-------|
+| #79 (task 2.1) | 8 | 15 | 1.9x |
+| #79 (task 2.2) | 13 | 17 | 1.3x |
+| #81 | baseline | +extra coverage tests | ~1.5x |
+
+**Rule of thumb:** When listing `[RED]` action items, the obvious test cases cover ~60-70% of what you'll actually write. Edge cases (error paths, boundary conditions, format variations) add another 30-40%. Plan for ~1.5x the obvious test count when estimating task size.
+
 ## Self-Verification
 
 Before finalizing tasks, check:
@@ -151,6 +163,7 @@ Before finalizing tasks, check:
 4. Are approval gates only at natural boundaries?
 5. Is the task count appropriate for the feature size?
 6. **Can this task be picked up after context loss?** (Context block complete?)
+7. **Are test counts realistic?** (Apply 1.5x multiplier to obvious test cases)
 
 ## Output
 


### PR DESCRIPTION
## Summary

- **Cross-referenced 11 TASKS.md files** against existing skills to identify recurring patterns not captured in documentation
- **Created 5 new skills** for feature development, code review, and repository maintenance
- **Updated 2 existing skills** with learnings from completed issues

### New Skills

| Skill | Source | Purpose |
|-------|--------|---------|
| `addarr-handlers` | Custom | Handler class structure, ConversationHandler states, callback routing, keyboards, 9 anti-patterns |
| `addarr-services` | Custom | Singleton pattern, BaseApiClient inheritance, config access, is_enabled(), 7 anti-patterns |
| `find-bugs` | [Sentry](https://github.com/getsentry/sentry-skills) | Addarr-specific bug/security review with async, singleton, and Telegram API checks |
| `code-simplifier` | [Sentry](https://github.com/getsentry/sentry-skills) | Focused code refactoring for Python/Addarr (complements `superpowers:simplify`) |
| `git-cleanup` | [Trail of Bits](https://github.com/trailofbits/skills) | Safe branch/worktree cleanup with two confirmation gates |

### Updated Skills

- **addarr-testing**: +4 anti-patterns (import path patching, session leakage, sys.exit mocking, insufficient retry mocks), +3 test patterns (retry/timeout, session cleanup, API vs service conventions), singleton reset warning
- **task-writer**: test count estimation section with historical data (plans underestimate by 1.5-2x)

### Setup Changes

- `/addarr-setup` always loads `addarr-handlers` and `addarr-services`
- `dev` and `pr` setups additionally load `find-bugs` and `code-simplifier`
- `git-cleanup` is on-demand only (not auto-loaded)

## Test plan

- [ ] Verify `/addarr-setup` loads all expected skills for `dev` mode
- [ ] Verify `/addarr-setup pr` loads find-bugs and code-simplifier
- [ ] Invoke `find-bugs` skill on a branch with changes and verify checklist output
- [ ] Invoke `code-simplifier` on a file and verify it respects Addarr conventions
- [ ] Invoke `git-cleanup` and verify two-gate confirmation workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)