### PR TITLE
test: add coverage for 5 previously excluded files (#80)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,16 +1,9 @@
 [run]
 source = src
 omit =
-    # Root — entry points, no unit tests
     src/__init__.py
-    src/main.py
-    src/setup/wizard.py
-    # Config — reads from disk at import time
+    # Config — reads from disk at import time, mocked at sys.modules level
     src/config/settings.py
-    # Utils — interactive/display, no unit tests
-    src/utils/config_handler.py
-    src/utils/prerun.py
-    src/utils/splash.py
 
 [report]
 fail_under = 100

--- a/docs/issues/issue-80/TASKS.md
+++ b/docs/issues/issue-80/TASKS.md
@@ -1,0 +1,219 @@
+# Issue #80: Add Tests for Files Excluded from Coverage Measurement
+
+## Summary
+
+Close the coverage gap by adding tests for 5 files currently excluded from `.coveragerc`, gap-filling 2 existing test files, and removing the exclusions. ~140 new tests across 4 new + 2 existing test files.
+
+---
+
+### Phase 1: Simple Utility Tests (2 tasks)
+
+**Goal:** Cover the two simplest source files — pure display functions and a YAML file handler.
+
+- [x] **1.1** Test splash screen utilities (`splash.py`)
+    - **Context:**
+        - **Why:** `src/utils/splash.py` (134 lines, 5 functions) is excluded from coverage with zero tests. All functions are pure display — print to stdout or return strings. Simplest starting point.
+        - **Architecture:** Functions use `colorama` for formatting and `config.get()` for reading settings. Config is already mocked via conftest's `MockConfig` injection into `sys.modules["src.config.settings"]`.
+        - **Key refs:** `src/utils/splash.py:16-134` — five functions: `get_splash_screen()`, `show_splash_screen()`, `show_version()`, `show_welcome_screen()`, `show_token_help()`
+        - **Watch out:** `show_welcome_screen()` reads three config values (`logging.debug`, `security.enableAdmin`, `language`) — test both enabled and disabled branches. Use `capsys` not `mock_open` for stdout capture. Patch `platform.python_version()` and `platform.platform()` for deterministic output.
+    - **Scope:** Create `tests/test_utils/test_splash.py` covering all 5 functions, both branches of config-dependent output
+    - **Touches:** `tests/test_utils/test_splash.py` (new)
+    - **Action items:**
+        - [RED] Write tests for `get_splash_screen` return value (non-empty, contains REFRESH EDITION)
+        - [RED] Write tests for `show_splash_screen` stdout output (capsys)
+        - [RED] Write tests for `show_version` output (version string, repo URL)
+        - [RED] Write tests for `show_welcome_screen` — default config (debug disabled, admin disabled, language en-us), enabled variants, platform info, CLI commands, Telegram commands, resource URLs
+        - [RED] Write tests for `show_token_help` — BotFather instructions, config example, wiki URL
+        - [GREEN] All tests should pass immediately against existing source — verify 100% coverage
+    - **Success:** `pytest tests/test_utils/test_splash.py --cov=src/utils/splash --cov-report=term-missing --no-cov-on-fail -q` shows 100%, ~17 tests pass
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - Coverage CLI needs a temp .coveragerc to verify files currently in the omit list — the default `.coveragerc` omits `splash.py`, so `--cov=src/utils/splash` reports 0%. Used `/tmp/coveragerc_splash` with explicit `source`/`include` to confirm 100%.
+        - All 5 functions are pure display (return string or print to stdout), so no mocking needed beyond `platform.*` and `config` for deterministic output.
+        - Flake8 E741 catches `l` as ambiguous variable name in list comprehensions — use `line` instead.
+    - **Key Changes:**
+        - Created `tests/test_utils/test_splash.py` — 29 tests across 5 test classes
+        - Covers: `get_splash_screen`, `show_splash_screen`, `show_version`, `show_welcome_screen` (default config, debug enabled, admin enabled, custom language, CLI commands, Telegram commands, resource URLs), `show_token_help`
+    - **Notes:** Coverage verification for omitted files requires temp .coveragerc until task 4.3 removes the omit entries
+
+- [x] **1.2** Test config handler utilities (`config_handler.py`)
+    - **Context:**
+        - **Why:** `src/utils/config_handler.py` (118 lines) is excluded from coverage with zero tests. `ConfigHandler` manages YAML config file operations — used by `PreRunChecker` and `SetupWizard`.
+        - **Architecture:** Class-based with `__init__(colors)` accepting a colors object (colorama or dummy). Uses `ruamel.yaml` for YAML, `shutil.copy2` for file ops, `os.makedirs` for backup dir. Global `config_handler = ConfigHandler(None)` instance at module level.
+        - **Key refs:** `src/utils/config_handler.py:26-117` — `ConfigHandler` class with 6 methods: `__init__`, `create_from_example`, `create_backup`, `load_config`, `save_config`, `update_value`
+        - **Watch out:** Use `tmp_path` for real file I/O instead of mocking file operations — tests are more reliable with actual files. Mock `datetime.now()` for deterministic backup timestamps. The `colors` param can be `None` (global instance) — test that error paths still work with a mock colors object.
+    - **Scope:** Create `tests/test_utils/test_config_handler.py` covering all methods + global instance
+    - **Touches:** `tests/test_utils/test_config_handler.py` (new)
+    - **Action items:**
+        - [RED] Write tests for `__init__` — sets paths correctly
+        - [RED] Write tests for `create_from_example` — copies file, backs up existing, handles errors
+        - [RED] Write tests for `create_backup` — timestamped backup, creates dir, returns "" when no config
+        - [RED] Write tests for `load_config` — valid YAML returns dict, errors return {}
+        - [RED] Write tests for `save_config` — backs up then writes, error returns False
+        - [RED] Write tests for `update_value` — single key, nested keys, creates intermediate keys
+        - [RED] Write tests for global `config_handler` instance
+        - [GREEN] All tests pass against existing source — verify 100% coverage
+    - **Success:** `pytest tests/test_utils/test_config_handler.py --cov=src/utils/config_handler --cov-report=term-missing --no-cov-on-fail -q` shows 100%, ~22 tests pass
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - `tmp_path` fixture makes file I/O tests clean — no mocking of `open`/`shutil` needed, just wire handler paths to tmp_path
+        - `update_value` is a static-like method (only uses `config` param, not `self`) — can call with `None` as self for isolated testing
+        - `ruamel.yaml` YAML() preserves comments/formatting — `load_config` returns CommentedMap (dict-compatible), not plain dict
+    - **Key Changes:**
+        - Created `tests/test_utils/test_config_handler.py` — 25 tests across 7 test classes
+        - Covers: `__init__`, `create_from_example` (copy, backup existing, error), `create_backup` (timestamp, dir creation, no config, content preservation), `load_config` (valid, missing, invalid YAML), `save_config` (write, backup, error), `update_value` (single key, nested, intermediate creation, sibling preservation), global instance
+    - **Notes:** The `colors` mock uses empty strings for Fore attributes — production uses colorama Fore constants
+
+---
+
+### Phase 2: PreRunChecker Tests (1 task)
+
+**Goal:** Cover the pre-run dependency and config checking module.
+
+- [x] **2.1** Test PreRunChecker and ColorHandler (`prerun.py`)
+    - **Context:**
+        - **Why:** `src/utils/prerun.py` (209 lines) is excluded from coverage with zero tests. Contains `ColorHandler` (colorama fallback) and `PreRunChecker` (dependency checking, config existence, user prompts). Most complex utility module due to subprocess calls and interactive input loops.
+        - **Architecture:** `ColorHandler` tries `from colorama import Fore, Style, init` and falls back to `DummyFore`/`DummyStyle` on ImportError. `PreRunChecker` lazy-imports `config_handler` and `SetupWizard` inside methods. Uses `subprocess.run` for `pip list` and `subprocess.check_call` for `pip install`. User prompts via `builtins.input()`.
+        - **Key refs:** `src/utils/prerun.py:18-47` (ColorHandler), `src/utils/prerun.py:50-204` (PreRunChecker), `src/utils/prerun.py:207-208` (global instance)
+        - **Watch out:** `check_config_exists` lazy-imports `config_handler` from `.config_handler` (relative) and `SetupWizard` from `src.setup` — must patch at those import paths. The `while True` input loops need `side_effect` sequences with invalid inputs followed by valid ones to test the loop. `parse_requirements` reads a real file path — use `tmp_path` to create test requirements files. `get_installed_packages` calls `subprocess.run` — mock to avoid real pip calls.
+    - **Scope:** Create `tests/test_utils/test_prerun.py` covering ColorHandler, PreRunChecker (all 5 methods), and global instance
+    - **Touches:** `tests/test_utils/test_prerun.py` (new)
+    - **Action items:**
+        - [RED] Write tests for `ColorHandler.__init__` — with colorama (real import), with ImportError (DummyFore/DummyStyle)
+        - [RED] Write tests for `ColorHandler.reload` — successful reload, ImportError no-op
+        - [RED] Write tests for `DummyFore`/`DummyStyle` attributes are empty strings
+        - [RED] Write tests for `PreRunChecker.__init__` — colors, root_dir, config_path
+        - [RED] Write tests for `parse_requirements` — reads file, strips versions (`>=`, `<=`, `==`), strips comments, skips blanks, lowercases, FileNotFoundError returns core_deps, merges with core deps
+        - [RED] Write tests for `get_installed_packages` — parses JSON, normalizes names (hyphen/underscore), subprocess error returns empty set
+        - [RED] Write tests for `check_dependencies` — all installed, missing+install, missing+decline, install failure, colorama reload trigger, empty requirements, invalid input loop
+        - [RED] Write tests for `check_config_exists` — config exists, missing+wizard, missing+create_from_example fails, missing+decline, invalid input loop, sets config_handler.colors
+        - [RED] Write tests for `run_checks` — both pass, deps fail, config fail
+        - [RED] Write test for global `prerun_checker` instance
+        - [GREEN] All tests pass against existing source — verify 100% coverage
+    - **Success:** `pytest tests/test_utils/test_prerun.py --cov=src/utils/prerun --cov-report=term-missing --no-cov-on-fail -q` shows 100%, ~35 tests pass
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - `patch.dict("sys.modules", {"colorama": None})` forces ImportError on `from colorama import ...` — cleaner than patching builtins.__import__
+        - Lazy imports inside methods (`from .config_handler import config_handler`) must be patched at the source module (`src.utils.config_handler.config_handler`), not at the caller
+        - `while True` input loops need `side_effect` lists with invalid entries followed by a valid terminator (`["invalid", "x", "n"]`) to test the re-prompt path
+        - `subprocess.CalledProcessError(1, "pip")` requires both returncode and cmd args
+    - **Key Changes:**
+        - Created `tests/test_utils/test_prerun.py` — 41 tests across 10 test classes
+        - Covers: DummyFore/DummyStyle, ColorHandler init/reload (with and without colorama), PreRunChecker init, parse_requirements (versions, comments, blanks, lowercase, core deps merge, dedup, FileNotFoundError), get_installed_packages (JSON parse, normalization, errors), check_dependencies (all installed, install yes/no, failure, colorama reload, invalid input, hyphen/underscore matching), check_config_exists (exists, wizard, create_from_example fail, decline, invalid input), run_checks (all combos), global instance
+    - **Notes:** `check_config_exists` patches `os.path.exists` globally — safe because only the checker's config_path is checked in the function
+
+---
+
+### Phase 3: AddarrBot Tests (1 task)
+
+**Goal:** Cover the main bot application module — the most complex target.
+
+- [x] **3.1** Test AddarrBot class and entry points (`main.py`)
+    - **Context:**
+        - **Why:** `src/main.py` (258 lines) is excluded from coverage with zero tests. Contains `AddarrBot` class (init, initialize, _add_handlers, start, stop), `main()` async entry point, and `run_bot()` sync wrapper. Heaviest mock surface area due to 11 handler classes and Application builder chain.
+        - **Architecture:** `AddarrBot.initialize()` calls `show_welcome_screen`, `check_config`, health checks, builds `Application` via builder pattern, adds handlers, then `application.initialize()`. Error handling: `InvalidToken` triggers `os.execl` restart (MUST patch), `NetworkError` and generic exceptions use error handler functions. `_add_handlers()` conditionally registers Transmission/SABnzbd based on `config.get("transmission/sabnzbd", {}).get("enable", False)`. `start()` has a `while self._running` loop — break by setting `_running=False` via `asyncio.sleep` side_effect. `main()` registers signal handlers with Windows fallback (`NotImplementedError`).
+        - **Key refs:** `src/main.py:46-204` (AddarrBot class), `src/main.py:206-242` (main), `src/main.py:245-257` (run_bot)
+        - **Watch out:** `os.execl` replaces the process — MUST be patched. `asyncio.run` cannot nest inside pytest-asyncio — test `run_bot()` by patching `asyncio.run`. The `while self._running` loop in `start()` needs a side_effect on `asyncio.sleep` that sets `_running=False` after first call. `main()` uses `asyncio.get_running_loop()` which returns the pytest event loop — mock the loop object. Signal handler registration uses `loop.add_signal_handler` which raises `NotImplementedError` on Windows — test both paths.
+    - **Scope:** Create `tests/test_main.py` covering AddarrBot lifecycle, handler registration, error paths, main(), run_bot()
+    - **Touches:** `tests/test_main.py` (new)
+    - **Action items:**
+        - [RED] Write tests for `AddarrBot.__init__` — application None, _running False, health_checker is health_service
+        - [RED] Write tests for `initialize()` — happy path (full lifecycle), health checks fail (continues), missing token (ValueError), InvalidToken+restart (os.execl), InvalidToken+re-raise, NetworkError, generic exception, outer exception logging
+        - [RED] Write tests for `_add_handlers()` — all 9 always-on handlers registered, Transmission disabled/enabled, SABnzbd disabled/enabled, both enabled, handler error re-raises
+        - [RED] Write tests for `start()` — starts app+polling+health checker, sets _running, while-loop breaks, error re-raises
+        - [RED] Write tests for `stop()` — full shutdown, application is None, updater not running, error swallowed
+        - [RED] Write tests for `main()` — start_bot error path (stop+sys.exit), signal handler registration, Windows fallback (NotImplementedError), KeyboardInterrupt, generic exception
+        - [RED] Write tests for `run_bot()` — calls asyncio.run, KeyboardInterrupt, generic exception
+        - [GREEN] All tests pass against existing source — verify 100% coverage
+    - **Success:** `pytest tests/test_main.py --cov=src/main --cov-report=term-missing --no-cov-on-fail -q` shows 100%, ~50 tests pass
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - `patch.multiple("src.main", **dict)` requires SHORT attribute names (`StartHandler`), not dotted paths (`src.main.StartHandler`) — the module target is already the first arg
+        - Breaking `while self._running` loops in tests: use `asyncio.sleep` side_effect that sets `_running=False` on first call
+        - `os.execl` replaces the process entirely — when mocked, execution continues past it so the outer `except` may catch unexpected flow; use `try/except` wrapper in test
+        - For `main()` signal handler tests, mock `asyncio.get_running_loop` to return a mock loop and verify `add_signal_handler` calls; simulate Windows with `NotImplementedError` side_effect
+        - Line 213 (`await bot.start()`) required a separate test where `initialize` succeeds but `start` fails to reach that line
+    - **Key Changes:**
+        - Created `tests/test_main.py` — 31 tests across 8 test classes
+        - Covers: `AddarrBot.__init__`, `initialize()` (happy path, health fail, missing token, InvalidToken+restart, InvalidToken+reraise, NetworkError, generic exception), `_add_handlers()` (9 always-on, transmission/sabnzbd enabled/disabled, both enabled, handler error), `start()` (app+polling, running flag, error), `stop()` (full shutdown, None app, updater not running, error swallowed), `main()` (start_bot init error, start error, signal registration, Windows fallback, KeyboardInterrupt, generic exception), `run_bot()` (asyncio.run, KeyboardInterrupt, generic exception)
+    - **Notes:** The `HANDLER_PATCHES` dict is reused across test classes via `patch.multiple` — if new handlers are added to main.py, add them to this dict
+
+---
+
+### Phase 4: Gap-Fill + Coverage Config (3 tasks)
+
+**Goal:** Fill remaining coverage gaps in existing test files and remove `.coveragerc` exclusions.
+
+- [x] **4.1** Gap-fill wizard tests (`test_wizard.py`)
+    - **Context:**
+        - **Why:** `src/setup/wizard.py` is at ~68% coverage — existing tests cover `__init__`, `run`, `_async_setup`, partial `_reset_config`, partial `configure_services`, and `main()`. Missing: `_update_config_value`, `_create_directories`, `_configure_service`, `_configure_required_value`, `_backup_config`, `_reset_config` success/example-missing/exception paths, `configure_services` Transmission auth + SABnzbd branches.
+        - **Architecture:** All wizard methods follow the same pattern as existing tests — `@patch("src.setup.wizard.config_handler")` for init, mock questionary for user input, `AsyncMock` for async service config functions.
+        - **Key refs:** `src/setup/wizard.py:64-66` (_update_config_value), `src/setup/wizard.py:126-134` (_create_directories), `src/setup/wizard.py:136-159` (_configure_service), `src/setup/wizard.py:161-168` (_configure_required_value), `src/setup/wizard.py:170-177` (_backup_config), `src/setup/wizard.py:206-227` (_reset_config success/error paths), `src/setup/wizard.py:258-289` (configure_services Transmission auth + SABnzbd)
+        - **Watch out:** `_reset_config` success path calls `self.run()` recursively — mock it to prevent infinite loop. `_configure_service` line 146 `if enabled:` is always True (enabled is hardcoded to True on line 141) but the except block on line 154 catches config errors and sets `enable=False`. `configure_services` Transmission auth needs 7 sequential `questionary.confirm.ask()` calls — use `side_effect` list carefully.
+    - **Scope:** Add ~15 tests to existing `tests/test_setup/test_wizard.py`
+    - **Touches:** `tests/test_setup/test_wizard.py` (append)
+    - **Action items:**
+        - [RED] Write tests for `_update_config_value` — delegates to config_handler.update_value
+        - [RED] Write tests for `_create_directories` — creates log dir and translations dir
+        - [RED] Write tests for `_configure_service` — arr service (enables + features), non-arr (no features), exception (sets enable=False)
+        - [RED] Write tests for `_configure_required_value` — arr service passes default_config, non-arr passes None
+        - [RED] Write tests for `_backup_config` — delegates to create_backup
+        - [RED] Write tests for `_reset_config` — success (loads example, saves, calls run), missing example (sys.exit(1)), generic exception (sys.exit(1))
+        - [RED] Write tests for `configure_services` — Transmission with auth (username/password), SABnzbd config
+        - [GREEN] All tests pass — verify 100% coverage of wizard.py
+    - **Success:** `pytest tests/test_setup/test_wizard.py --cov=src/setup/wizard --cov-report=term-missing --no-cov-on-fail -q` shows 100%, ~15 new tests pass
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - `_configure_required_value` passes `self.config` (the current dict) to `configure_required_value`, then assigns the return value back — can't assert exact first arg since it's the mutable dict at call time; verify via `call_args` instead
+        - `_reset_config` success path calls `self.run()` recursively — MUST mock `wizard.run` to prevent infinite loop
+        - For Transmission auth in `configure_services`, `questionary.confirm` returns the same mock each time — use `ask.side_effect` list to sequence Yes/No answers across all 6 confirm calls
+        - `_create_directories` can be verified by mocking `Path` since actual dir creation isn't needed in tests
+    - **Key Changes:**
+        - Added 12 tests to `tests/test_setup/test_wizard.py` across 6 new test classes
+        - Covers: `_update_config_value`, `_create_directories`, `_configure_service` (arr/non-arr/exception), `_configure_required_value` (arr/non-arr), `_reset_config` success/missing-example/exception, `configure_services` Transmission auth + SABnzbd
+    - **Notes:** wizard.py now at 100% coverage (was 69%)
+
+- [x] **4.2** Gap-fill service_config tests (`test_service_config.py`)
+    - **Context:**
+        - **Why:** `src/setup/service_config.py` is at ~98% — missing line 174: the SABnzbd skip-validation return path (when connection fails and user declines retry for SABnzbd).
+        - **Architecture:** Same mock pattern as existing `test_retry_then_skip` (line 162-180 of existing tests) but with `service="sabnzbd"` instead of `"radarr"`.
+        - **Key refs:** `src/setup/service_config.py:174-189` — SABnzbd branch inside the `if not retry:` block, returns config with `enable: False` and `onlyAdmin: True`
+        - **Watch out:** The existing `test_retry_then_skip` only tests with `"radarr"` (hits the else branch on line 190). Need to test `"sabnzbd"` which hits the if branch on line 174.
+    - **Scope:** Add 1-2 tests to existing `tests/test_setup/test_service_config.py`
+    - **Touches:** `tests/test_setup/test_service_config.py` (append)
+    - **Action items:**
+        - [RED] Write `test_sabnzbd_retry_then_skip` — validation fails, retry=False, returns SABnzbd config with `enable: False`, `onlyAdmin: True`
+        - [GREEN] Test passes — verify 100% coverage of service_config.py
+    - **Success:** `pytest tests/test_setup/test_service_config.py --cov=src/setup/service_config --cov-report=term-missing --no-cov-on-fail -q` shows 100%
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - Statement coverage was already 100% but branch coverage was 96% — two missing branches: `83->86` (unknown service fallthrough in `get_default_service_config`) and `172->95` (retry=True loop back in `get_valid_service_config`)
+        - Branch coverage reveals gaps that statement coverage misses — always check with `--cov-branch`
+        - For retry loop testing, side_effect lists must account for all questionary calls across all iterations (e.g., 3 confirm calls: ssl1, retry, ssl2)
+    - **Key Changes:**
+        - Added `test_unknown_service_fallthrough` to `TestGetDefaultServiceConfig` — covers `83->86` branch
+        - Added `test_sabnzbd_retry_then_skip` to `TestGetValidServiceConfig` — covers SABnzbd skip-validation path
+        - Added `test_validation_fail_retry_then_succeed` to `TestGetValidServiceConfig` — covers `172->95` retry loop branch
+    - **Notes:** 21 tests total (was 18), 100% statement + branch coverage (52 stmts, 22 branches, 0 missing)
+
+- [x] **4.3** Update `.coveragerc` and verify full suite
+    - **Context:**
+        - **Why:** With all tests in place, remove the 5 file exclusions from `.coveragerc` so coverage measurement includes them. The `fail_under = 100` setting will enforce they stay covered.
+        - **Architecture:** Simple config edit — remove 5 lines from the `omit` list. Keep `src/__init__.py` (empty) and `src/config/settings.py` (reads from disk, mocked at sys.modules level).
+        - **Key refs:** `.coveragerc:3-13` — current omit list
+        - **Watch out:** Run full test suite AFTER the edit — if any line is uncovered, `fail_under = 100` will fail the run. This is the final verification gate.
+    - **Scope:** Edit `.coveragerc`, run full suite
+    - **Touches:** `.coveragerc`
+    - **Action items:**
+        - [GREEN] Remove `src/main.py`, `src/setup/wizard.py`, `src/utils/config_handler.py`, `src/utils/prerun.py`, `src/utils/splash.py` from the omit list
+        - [GREEN] Run `pytest --cov=src --cov-report=term-missing --tb=short` — must show 100% coverage, all tests pass
+        - [GREEN] Run `flake8 .` — no lint errors
+    - **Success:** Full test suite passes with 100% coverage, no regressions, no lint errors
+    - **Completed:** 2026-03-02
+    - **Learnings:**
+        - Removing 5 files from omit exposed 568 additional statements to coverage measurement — all already at 100% from tasks 1.1-4.2
+        - `fail_under = 100` in `.coveragerc` acts as an enforcement gate — any regression will fail CI
+    - **Key Changes:**
+        - Removed 5 file exclusions from `.coveragerc` omit list: `src/main.py`, `src/setup/wizard.py`, `src/utils/config_handler.py`, `src/utils/prerun.py`, `src/utils/splash.py`
+        - Kept `src/__init__.py` (empty) and `src/config/settings.py` (sys.modules-level mock)
+    - **Notes:** Full suite: 1380 tests, 4723 statements, 100% coverage, 0 lint errors, 12s runtime

--- a/docs/issues/issue-80/plan.md
+++ b/docs/issues/issue-80/plan.md
@@ -1,0 +1,347 @@
+# Add Tests for Files Excluded from Coverage Measurement (#80)
+
+## Context
+
+The project reports 100% test coverage, but 7 files are excluded from `.coveragerc`'s `omit` list. Issue #79 added setup module tests, but `wizard.py` is still excluded at ~68% coverage. Four files have zero tests. This work closes the gap so the 100% metric reflects actual full coverage.
+
+**Files currently omitted from coverage** (`.coveragerc`):
+- `src/__init__.py` — empty init, keep excluded
+- `src/config/settings.py` — reads from disk at import time, keep excluded
+- `src/main.py` — 258 lines, zero tests ← **add tests**
+- `src/setup/wizard.py` — ~68% covered ← **gap-fill**
+- `src/utils/config_handler.py` — 118 lines, zero tests ← **add tests**
+- `src/utils/prerun.py` — 209 lines, zero tests ← **add tests**
+- `src/utils/splash.py` — 134 lines, zero tests ← **add tests**
+
+## Scope
+
+**New test files (4):**
+| Test file | Source file | Lines |
+|---|---|---|
+| `tests/test_utils/test_splash.py` | `src/utils/splash.py` | 134 |
+| `tests/test_utils/test_config_handler.py` | `src/utils/config_handler.py` | 118 |
+| `tests/test_utils/test_prerun.py` | `src/utils/prerun.py` | 209 |
+| `tests/test_main.py` | `src/main.py` | 258 |
+
+**Gap-fill existing tests (2):**
+| Test file | Current coverage | Target |
+|---|---|---|
+| `tests/test_setup/test_wizard.py` | ~68% | 100% |
+| `tests/test_setup/test_service_config.py` | ~98% | 100% |
+
+**Config update (1):**
+- `.coveragerc` — remove 5 files from omit list
+
+## Approach
+
+Four phases ordered by complexity. Since we're testing existing code, tests should pass on first run — we verify each file reaches 100% coverage before moving on.
+
+---
+
+## Phase 1 — Simple Utility Tests (`splash.py`, `config_handler.py`)
+
+### Task 1.1: `tests/test_utils/test_splash.py`
+
+**Source analysis** (`src/utils/splash.py` — 134 lines, 5 functions):
+- `get_splash_screen()` → returns f-string with colorama codes
+- `show_splash_screen()` → prints `get_splash_screen()`
+- `show_version()` → prints version info with colorama formatting
+- `show_welcome_screen()` → reads `config.get("logging")`, `config.get("security")`, `config.get("language")` — prints system info and commands
+- `show_token_help()` → prints BotFather instructions
+
+**Mock strategy:**
+- `capsys` for stdout capture
+- `config` already mocked via conftest (uses `config.get("logging", {})`, etc.)
+- `patch("src.utils.splash.platform")` for deterministic Python version / OS strings
+
+**Tests (~17):**
+- `get_splash_screen` returns non-empty string containing "ADDARR" and "REFRESH EDITION"
+- `show_splash_screen` prints splash to stdout (capsys)
+- `show_version` output contains "1.0.0", repo URL
+- `show_welcome_screen` — debug disabled shows "Disabled", admin disabled shows "Disabled", language shows "en-us"
+- `show_welcome_screen` — debug enabled shows "Enabled" (override config)
+- `show_welcome_screen` — admin enabled shows "Enabled" (override config)
+- `show_welcome_screen` — custom language shows correct value
+- `show_welcome_screen` — platform info appears in output
+- `show_welcome_screen` — all CLI commands listed
+- `show_welcome_screen` — all Telegram commands listed
+- `show_welcome_screen` — resource URLs listed
+- `show_token_help` — contains "Invalid Telegram Bot Token"
+- `show_token_help` — contains BotFather instructions
+- `show_token_help` — contains config.yaml example
+- `show_token_help` — contains setup wizard suggestion
+- `show_token_help` — contains wiki URL
+
+### Task 1.2: `tests/test_utils/test_config_handler.py`
+
+**Source analysis** (`src/utils/config_handler.py` — 118 lines):
+- `ConfigHandler.__init__(colors)` — sets paths relative to root_dir
+- `create_from_example()` → copies example, creates backup if exists, returns bool
+- `create_backup()` → timestamped backup in `backup/` dir, returns path or ""
+- `load_config()` → reads YAML from config_path, returns dict or {} on error
+- `save_config(config)` → backup then write, returns bool
+- `update_value(config, path, value)` → nested dict traversal with setdefault
+- `config_handler` — global instance with `colors=None`
+
+**Mock strategy:**
+- `tmp_path` for real file I/O (create actual YAML files, verify copies/backups)
+- Mock `colors` object with `Fore.GREEN`, `Fore.RED`, `Fore.YELLOW` attributes
+- `patch("src.utils.config_handler.datetime")` for deterministic backup timestamps
+
+**Tests (~22):**
+- `__init__` sets `config_path`, `config_example_path`, `root_dir` correctly
+- `create_from_example` — no existing config: copies example, returns True
+- `create_from_example` — existing config: creates backup first, then copies
+- `create_from_example` — missing example: catches exception, returns False
+- `create_backup` — config exists: creates timestamped backup, returns path
+- `create_backup` — creates backup dir if missing
+- `create_backup` — config doesn't exist: returns ""
+- `create_backup` — timestamp format matches `%Y%m%d_%H%M%S`
+- `load_config` — valid YAML: returns dict
+- `load_config` — file not found: returns {}
+- `load_config` — invalid YAML: returns {}
+- `save_config` — creates backup then writes, returns True
+- `save_config` — write error: returns False
+- `update_value` — single key path
+- `update_value` — nested key path (2 levels)
+- `update_value` — deeply nested path (3+ levels)
+- `update_value` — creates missing intermediate keys via setdefault
+- Global `config_handler` is a `ConfigHandler` instance
+- Global `config_handler` has `colors=None`
+
+---
+
+## Phase 2 — PreRunChecker Tests (`prerun.py`)
+
+### Task 2.1: `tests/test_utils/test_prerun.py`
+
+**Source analysis** (`src/utils/prerun.py` — 209 lines):
+
+*ColorHandler (lines 18-47):*
+- `__init__` — tries `from colorama import Fore, Style, init`; on ImportError uses DummyFore/DummyStyle
+- `reload()` — same logic, re-imports colorama
+
+*PreRunChecker (lines 50-204):*
+- `__init__` — creates ColorHandler, sets root_dir and config_path
+- `check_config_exists()` — lazy imports `config_handler`, checks `os.path.exists`, prompts user, optionally launches SetupWizard
+- `parse_requirements(filename)` — reads requirements.txt, strips versions, merges with core_deps
+- `get_installed_packages()` — calls `subprocess.run` with `pip list --format=json`, normalizes names
+- `check_dependencies()` — compares required vs installed, prompts install if missing
+- `run_checks()` — calls check_dependencies then check_config_exists
+
+*Global: `prerun_checker = PreRunChecker()`*
+
+**Mock strategy:**
+- `patch("src.utils.prerun.subprocess")` for pip calls
+- `patch("builtins.input")` for user prompts
+- `tmp_path` or `mock_open` for requirements.txt
+- `patch("src.utils.prerun.os.path.exists")` for config file checks
+- Lazy import patches for `config_handler` and `SetupWizard`
+
+**Tests (~35):**
+
+*ColorHandler:*
+- `__init__` with colorama available — `Fore` and `Style` are real colorama objects
+- `__init__` with colorama ImportError — uses DummyFore, DummyStyle
+- DummyFore attributes are empty strings
+- DummyStyle.RESET_ALL is empty string
+- `reload()` with colorama available — reloads successfully
+- `reload()` with ImportError — no-op (doesn't crash)
+
+*PreRunChecker.__init__:*
+- Sets `colors` to a ColorHandler instance
+- Sets `root_dir` and `config_path` correctly
+
+*parse_requirements:*
+- Reads requirements.txt, returns package list
+- Strips `>=`, `<=`, `==` version specifiers
+- Strips inline `#` comments
+- Skips empty lines and comment lines
+- Converts to lowercase
+- FileNotFoundError returns core_deps
+- Merges with core deps and deduplicates
+
+*get_installed_packages:*
+- Parses JSON pip output into set
+- Normalizes: adds both hyphen and underscore variants
+- subprocess error returns empty set
+
+*check_dependencies:*
+- All installed → returns True
+- Missing packages, user says "y" → installs via subprocess, returns True
+- Missing packages, user says "n" → returns False
+- Install failure (CalledProcessError) → returns False
+- Missing includes colorama → calls `self.colors.reload()`
+- Empty requirements → returns False
+- Invalid input loops until y/n
+
+*check_config_exists:*
+- Config exists → returns True
+- Config missing, user says "y", wizard succeeds → returns True
+- Config missing, user says "y", create_from_example fails → returns False
+- Config missing, user says "n" → returns False
+- Invalid input loops until y/n
+- Sets config_handler.colors
+
+*run_checks:*
+- Both pass → returns True
+- Dependencies fail → returns False (doesn't call check_config_exists)
+- Config fail → returns False
+
+*Global:*
+- `prerun_checker` is a PreRunChecker instance
+
+---
+
+## Phase 3 — AddarrBot Tests (`main.py`)
+
+### Task 3.1: `tests/test_main.py`
+
+**Source analysis** (`src/main.py` — 258 lines):
+
+*AddarrBot class:*
+- `__init__` — sets `application=None`, `_running=False`, `health_checker=health_service`
+- `initialize()` — show_welcome_screen, check_config, health checks, get token, build Application, add_handlers, application.initialize(), handles InvalidToken (os.execl restart), NetworkError, generic exceptions
+- `_add_handlers()` — instantiates 11 handler classes, conditionally adds Transmission/SABnzbd based on config
+- `start()` — start application, set _running=True, create health check task, start polling, while _running loop
+- `stop()` — set _running=False, stop health checker, stop updater, stop + shutdown application
+
+*main() async:*
+- Creates bot, defines start_bot inner function, gets/creates event loop, adds signal handlers (with Windows fallback), runs start_bot, handles KeyboardInterrupt + generic exceptions
+
+*run_bot() sync:*
+- Calls asyncio.run(main()), handles KeyboardInterrupt + generic exceptions
+
+**Mock strategy:**
+- `patch("src.main.Application")` — mock builder chain: `Application.builder().token().build()` returns mock app
+- Patch all 11 handler classes via `@patch("src.main.StartHandler")` etc.
+- `patch("src.main.health_service")` and `patch("src.main.display_health_status")`
+- `patch("src.main.show_welcome_screen")`, `patch("src.main.check_config")`
+- `patch("src.main.handle_token_error")`, `patch("src.main.handle_missing_token_error")`, etc.
+- `patch("src.main.config")` for token/service enable overrides
+- `patch("os.execl")` — MUST patch to avoid process replacement
+- `patch("sys.exit")` for fatal error paths
+- For `start()` while-loop: set `_running = False` via side_effect on `asyncio.sleep`
+
+**Tests (~50):**
+
+*AddarrBot.__init__:*
+- application is None, _running is False, health_checker is health_service
+
+*AddarrBot.initialize():*
+- Happy path: calls show_welcome_screen, check_config, health checks, builds app, adds handlers, initializes
+- Health checks fail → logs warning but continues
+- Missing token → calls handle_missing_token_error, raises ValueError
+- InvalidToken + handle_token_error returns True → calls os.execl (patched)
+- InvalidToken + handle_token_error returns False → re-raises
+- NetworkError → calls handle_network_error, re-raises
+- Generic exception in app.initialize → calls handle_initialization_error, re-raises
+- Outer exception → logs and re-raises
+
+*AddarrBot._add_handlers():*
+- All handlers registered (11 handler classes instantiated)
+- Transmission disabled → TransmissionHandler not instantiated
+- Transmission enabled → TransmissionHandler registered
+- SABnzbd disabled → SabnzbdHandler not instantiated
+- SABnzbd enabled → SabnzbdHandler registered
+- Both Transmission and SABnzbd enabled
+- Handler error → logs and re-raises
+
+*AddarrBot.start():*
+- Starts application, sets _running, starts health checker, starts polling
+- Error during start → logs and re-raises
+- While loop breaks when _running set to False
+
+*AddarrBot.stop():*
+- Happy path: stops health checker, updater, application, shutdown
+- application is None → no-op
+- updater not running → skips updater.stop
+- Error during shutdown → logs debug, doesn't re-raise
+
+*main():*
+- Creates bot, calls initialize and start
+- start_bot exception → calls bot.stop, sys.exit(1)
+- Signal handlers registered (SIGINT, SIGTERM)
+- Windows fallback when add_signal_handler raises NotImplementedError
+- KeyboardInterrupt → calls bot.stop
+- Generic exception → sys.exit(1)
+
+*run_bot():*
+- Calls asyncio.run(main())
+- KeyboardInterrupt → logs shutdown
+- Generic exception → sys.exit(1)
+
+---
+
+## Phase 4 — Gap-Fill + Coverage Config
+
+### Task 4.1: Gap-fill `tests/test_setup/test_wizard.py`
+
+**Missing coverage** (wizard.py lines not covered by existing tests):
+
+- `_update_config_value` (line 66) — delegates to config_handler.update_value
+- `_create_directories` (lines 127-134) — creates log dir and translations dir
+- `_configure_service` (lines 136-159) — enables service, calls get_valid_service_config, handles arr features, catches exceptions
+- `_configure_required_value` (lines 161-168) — gets default config for arr services, calls configure_required_value
+- `_backup_config` (line 177) — delegates to create_backup
+- `_reset_config` success path (lines 206-223) — loads example, saves, calls self.run()
+- `_reset_config` missing example_path (lines 208-210) — sys.exit(1)
+- `_reset_config` generic exception (lines 225-227) — sys.exit(1)
+- `configure_services` Transmission auth branch (lines 264-269) — questionary for username/password
+- `configure_services` SABnzbd branch (lines 272-279) — enables and configures SABnzbd
+
+**Tests (~15):**
+- `_update_config_value` delegates to config_handler.update_value
+- `_create_directories` creates both directories
+- `_configure_service` happy path: enables, gets valid config, configures features for arr
+- `_configure_service` non-arr service: skips arr features
+- `_configure_service` exception: prints error, sets enable=False
+- `_configure_required_value` for arr service: passes default_config
+- `_configure_required_value` for non-arr service: default_config=None
+- `_backup_config` delegates to create_backup
+- `_reset_config` success: loads example, saves, calls run()
+- `_reset_config` missing example: sys.exit(1)
+- `_reset_config` generic exception: sys.exit(1)
+- `configure_services` Transmission with auth: sets username/password
+- `configure_services` SABnzbd: enables and configures
+- `configure_services` no services selected: just saves
+
+### Task 4.2: Gap-fill `tests/test_setup/test_service_config.py`
+
+**Missing coverage** (service_config.py line 174):
+- SABnzbd skip-validation return path — when validation fails and user declines retry for SABnzbd service
+
+**Tests (~2):**
+- `test_sabnzbd_retry_then_skip` — validation fails, retry=False → returns SABnzbd config with `enable: False`
+- `test_sabnzbd_skip_has_only_admin` — verify skipped SABnzbd config includes `onlyAdmin: True`
+
+### Task 4.3: Update `.coveragerc`
+
+Remove from omit:
+- `src/main.py`
+- `src/setup/wizard.py`
+- `src/utils/config_handler.py`
+- `src/utils/prerun.py`
+- `src/utils/splash.py`
+
+Keep omitted:
+- `src/__init__.py` — empty init
+- `src/config/settings.py` — reads from disk at import time, mocked via conftest
+
+---
+
+## Verification
+
+After each task:
+```bash
+pytest tests/<new-test-file> --cov=src/<target> --cov-report=term-missing --no-cov-on-fail -q
+```
+
+Final verification (after Task 4.3):
+```bash
+pytest --cov=src --cov-report=term-missing --tb=short
+# Must show: 100% coverage, all tests pass, no regressions
+flake8 .
+```
+
+## Estimated Total: ~140 new tests

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,607 @@
+"""Tests for src/main.py"""
+
+import signal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from telegram.error import InvalidToken, NetworkError
+
+from src.main import AddarrBot, main, run_bot
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bot():
+    """Fresh AddarrBot with mocked application."""
+    b = AddarrBot()
+    return b
+
+
+def _mock_handler_class():
+    """Create a mock handler class whose get_handler() returns [MagicMock()]."""
+    cls = MagicMock()
+    cls.return_value.get_handler.return_value = [MagicMock()]
+    return cls
+
+
+def _make_mock_application():
+    """Create a mock Application with builder chain and async methods."""
+    app = MagicMock()
+    app.initialize = AsyncMock()
+    app.start = AsyncMock()
+    app.stop = AsyncMock()
+    app.shutdown = AsyncMock()
+    app.add_handler = MagicMock()
+    app.updater = MagicMock()
+    app.updater.start_polling = AsyncMock()
+    app.updater.stop = AsyncMock()
+    app.updater.running = True
+    return app
+
+
+@pytest.fixture
+def mock_app():
+    """A fully mocked Application."""
+    return _make_mock_application()
+
+
+def _make_handler_patches():
+    """Create fresh mock handler classes (avoids shared mutable state)."""
+    return {
+        "StartHandler": _mock_handler_class(),
+        "AuthHandler": _mock_handler_class(),
+        "MediaHandler": _mock_handler_class(),
+        "SettingsHandler": _mock_handler_class(),
+        "DeleteHandler": _mock_handler_class(),
+        "LibraryHandler": _mock_handler_class(),
+        "TransmissionHandler": _mock_handler_class(),
+        "SabnzbdHandler": _mock_handler_class(),
+        "HelpHandler": _mock_handler_class(),
+        "PreferencesHandler": _mock_handler_class(),
+        "SystemHandler": _mock_handler_class(),
+    }
+
+
+# ---- AddarrBot.__init__ ----
+
+
+class TestAddarrBotInit:
+    """Tests for AddarrBot constructor."""
+
+    def test_application_is_none(self, bot):
+        """application starts as None."""
+        assert bot.application is None
+
+    def test_running_is_false(self, bot):
+        """_running starts as False."""
+        assert bot._running is False
+
+    def test_health_checker_is_health_service(self, bot):
+        """health_checker is the global health_service singleton."""
+        from src.services.health import health_service
+        assert bot.health_checker is health_service
+
+
+# ---- AddarrBot.initialize ----
+
+
+class TestInitialize:
+    """Tests for AddarrBot.initialize()."""
+
+    @pytest.mark.asyncio
+    @patch("src.main.show_welcome_screen")
+    @patch("src.main.check_config")
+    @patch("src.main.health_service")
+    @patch("src.main.display_health_status", return_value=True)
+    @patch("src.main.Application")
+    async def test_happy_path(
+        self, mock_app_cls, mock_display, mock_hs, mock_cc, mock_sw
+    ):
+        """Full initialization lifecycle succeeds."""
+        mock_hs.run_health_checks = AsyncMock(return_value={})
+        app = _make_mock_application()
+        mock_app_cls.builder.return_value.token.return_value.build.return_value = app
+
+        bot = AddarrBot()
+        with patch.multiple("src.main", **_make_handler_patches()):
+            await bot.initialize()
+
+        mock_sw.assert_called_once()
+        mock_cc.assert_called_once()
+        mock_hs.run_health_checks.assert_awaited_once()
+        app.initialize.assert_awaited_once()
+        assert bot.application is app
+
+    @pytest.mark.asyncio
+    @patch("src.main.show_welcome_screen")
+    @patch("src.main.check_config")
+    @patch("src.main.health_service")
+    @patch("src.main.display_health_status", return_value=False)
+    @patch("src.main.Application")
+    async def test_health_checks_fail_continues(
+        self, mock_app_cls, mock_display, mock_hs, mock_cc, mock_sw
+    ):
+        """Initialization continues even when health checks fail."""
+        mock_hs.run_health_checks = AsyncMock(return_value={})
+        app = _make_mock_application()
+        mock_app_cls.builder.return_value.token.return_value.build.return_value = app
+
+        bot = AddarrBot()
+        with patch.multiple("src.main", **_make_handler_patches()):
+            await bot.initialize()
+
+        # Still initialized despite health failure
+        assert bot.application is app
+
+    @pytest.mark.asyncio
+    @patch("src.main.show_welcome_screen")
+    @patch("src.main.check_config")
+    @patch("src.main.health_service")
+    @patch("src.main.display_health_status", return_value=True)
+    @patch("src.main.handle_missing_token_error")
+    @patch("src.main.config")
+    async def test_missing_token_raises(
+        self, mock_cfg, mock_hte, mock_display, mock_hs, mock_cc, mock_sw
+    ):
+        """Raises ValueError when token is not configured."""
+        mock_hs.run_health_checks = AsyncMock(return_value={})
+        mock_cfg.get.return_value = {}  # No telegram config
+
+        bot = AddarrBot()
+        with pytest.raises(ValueError, match="Telegram bot token"):
+            await bot.initialize()
+        mock_hte.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("src.main.show_welcome_screen")
+    @patch("src.main.check_config")
+    @patch("src.main.health_service")
+    @patch("src.main.display_health_status", return_value=True)
+    @patch("src.main.handle_token_error", return_value=True)
+    @patch("src.main.os.execl")
+    @patch("src.main.Application")
+    async def test_invalid_token_restart(
+        self, mock_app_cls, mock_execl, mock_hte,
+        mock_display, mock_hs, mock_cc, mock_sw
+    ):
+        """os.execl is called when token error is handled successfully."""
+        mock_hs.run_health_checks = AsyncMock(return_value={})
+        app = _make_mock_application()
+        app.initialize = AsyncMock(side_effect=InvalidToken("bad token"))
+        mock_app_cls.builder.return_value.token.return_value.build.return_value = app
+
+        bot = AddarrBot()
+        with patch.multiple("src.main", **_make_handler_patches()):
+            # os.execl replaces process; the outer except catches the
+            # fact that os.execl is mocked and doesn't actually exit.
+            # The call to os.execl is what we're verifying.
+            try:
+                await bot.initialize()
+            except Exception:
+                pass
+        mock_execl.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("src.main.show_welcome_screen")
+    @patch("src.main.check_config")
+    @patch("src.main.health_service")
+    @patch("src.main.display_health_status", return_value=True)
+    @patch("src.main.handle_token_error", return_value=False)
+    @patch("src.main.Application")
+    async def test_invalid_token_reraise(
+        self, mock_app_cls, mock_hte,
+        mock_display, mock_hs, mock_cc, mock_sw
+    ):
+        """Raises InvalidToken when handle_token_error returns False."""
+        mock_hs.run_health_checks = AsyncMock(return_value={})
+        app = _make_mock_application()
+
+        from telegram.error import InvalidToken
+        app.initialize = AsyncMock(side_effect=InvalidToken("bad"))
+        mock_app_cls.builder.return_value.token.return_value.build.return_value = app
+
+        bot = AddarrBot()
+        with pytest.raises(InvalidToken):
+            with patch.multiple("src.main", **_make_handler_patches()):
+                await bot.initialize()
+
+    @pytest.mark.asyncio
+    @patch("src.main.show_welcome_screen")
+    @patch("src.main.check_config")
+    @patch("src.main.health_service")
+    @patch("src.main.display_health_status", return_value=True)
+    @patch("src.main.handle_network_error")
+    @patch("src.main.Application")
+    async def test_network_error(
+        self, mock_app_cls, mock_hne,
+        mock_display, mock_hs, mock_cc, mock_sw
+    ):
+        """Raises NetworkError after calling handle_network_error."""
+        mock_hs.run_health_checks = AsyncMock(return_value={})
+        app = _make_mock_application()
+
+        app.initialize = AsyncMock(side_effect=NetworkError("timeout"))
+        mock_app_cls.builder.return_value.token.return_value.build.return_value = app
+
+        bot = AddarrBot()
+        with pytest.raises(NetworkError):
+            with patch.multiple("src.main", **_make_handler_patches()):
+                await bot.initialize()
+        mock_hne.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("src.main.show_welcome_screen")
+    @patch("src.main.check_config")
+    @patch("src.main.health_service")
+    @patch("src.main.display_health_status", return_value=True)
+    @patch("src.main.handle_initialization_error")
+    @patch("src.main.Application")
+    async def test_generic_init_exception(
+        self, mock_app_cls, mock_hie,
+        mock_display, mock_hs, mock_cc, mock_sw
+    ):
+        """Raises generic exception after calling handle_initialization_error."""
+        mock_hs.run_health_checks = AsyncMock(return_value={})
+        app = _make_mock_application()
+        app.initialize = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_app_cls.builder.return_value.token.return_value.build.return_value = app
+
+        bot = AddarrBot()
+        with pytest.raises(RuntimeError, match="boom"):
+            with patch.multiple("src.main", **_make_handler_patches()):
+                await bot.initialize()
+        mock_hie.assert_called_once()
+
+
+# ---- AddarrBot._add_handlers ----
+
+
+class TestAddHandlers:
+    """Tests for AddarrBot._add_handlers()."""
+
+    def test_always_on_handlers_registered(self, bot, mock_app):
+        """All 9 always-on handlers are registered."""
+        bot.application = mock_app
+        with patch.multiple("src.main", **_make_handler_patches()):
+            bot._add_handlers()
+
+        # 9 always-on handlers (Start, Auth, Media, Settings, Delete,
+        # Library, Help, Preferences, System) each return [handler]
+        assert mock_app.add_handler.call_count == 9
+
+    @patch("src.main.config")
+    def test_transmission_enabled(self, mock_cfg, bot, mock_app):
+        """Transmission handler registered when enabled."""
+        def cfg_get(key, default=None):
+            if key == "transmission":
+                return {"enable": True}
+            if key == "sabnzbd":
+                return {"enable": False}
+            return default
+        mock_cfg.get.side_effect = cfg_get
+
+        bot.application = mock_app
+        with patch.multiple("src.main", **_make_handler_patches()):
+            bot._add_handlers()
+
+        # 9 always-on + 1 transmission
+        assert mock_app.add_handler.call_count == 10
+
+    @patch("src.main.config")
+    def test_sabnzbd_enabled(self, mock_cfg, bot, mock_app):
+        """SABnzbd handler registered when enabled."""
+        def cfg_get(key, default=None):
+            if key == "transmission":
+                return {"enable": False}
+            if key == "sabnzbd":
+                return {"enable": True}
+            return default
+        mock_cfg.get.side_effect = cfg_get
+
+        bot.application = mock_app
+        with patch.multiple("src.main", **_make_handler_patches()):
+            bot._add_handlers()
+
+        # 9 always-on + 1 sabnzbd
+        assert mock_app.add_handler.call_count == 10
+
+    @patch("src.main.config")
+    def test_both_optional_enabled(self, mock_cfg, bot, mock_app):
+        """Both Transmission and SABnzbd registered when enabled."""
+        def cfg_get(key, default=None):
+            if key == "transmission":
+                return {"enable": True}
+            if key == "sabnzbd":
+                return {"enable": True}
+            return default
+        mock_cfg.get.side_effect = cfg_get
+
+        bot.application = mock_app
+        with patch.multiple("src.main", **_make_handler_patches()):
+            bot._add_handlers()
+
+        # 9 + 2
+        assert mock_app.add_handler.call_count == 11
+
+    def test_handler_error_reraises(self, bot, mock_app):
+        """Exception during handler registration is re-raised."""
+        bot.application = mock_app
+        broken_handler = MagicMock()
+        broken_handler.return_value.get_handler.side_effect = RuntimeError(
+            "handler init failed"
+        )
+        patches = {**_make_handler_patches(), "StartHandler": broken_handler}
+        with pytest.raises(RuntimeError, match="handler init failed"):
+            with patch.multiple("src.main", **patches):
+                bot._add_handlers()
+
+
+# ---- AddarrBot.start ----
+
+
+class TestStart:
+    """Tests for AddarrBot.start()."""
+
+    @pytest.mark.asyncio
+    async def test_starts_app_and_polling(self, bot, mock_app):
+        """Starts application, polling, and health checker."""
+        bot.application = mock_app
+        bot.health_checker = MagicMock()
+        bot.health_checker.start = AsyncMock()
+
+        # Break out of while loop after first sleep
+        async def stop_after_first_sleep(_):
+            bot._running = False
+
+        with patch("src.main.asyncio.sleep", side_effect=stop_after_first_sleep):
+            with patch("src.main.asyncio.create_task"):
+                await bot.start()
+
+        mock_app.start.assert_awaited_once()
+        mock_app.updater.start_polling.assert_awaited_once()
+        assert bot._running is False  # Loop exited
+
+    @pytest.mark.asyncio
+    async def test_sets_running_true(self, bot, mock_app):
+        """Sets _running to True before entering loop."""
+        bot.application = mock_app
+        bot.health_checker = MagicMock()
+        bot.health_checker.start = AsyncMock()
+
+        running_values = []
+
+        async def capture_and_stop(_):
+            running_values.append(bot._running)
+            bot._running = False
+
+        with patch("src.main.asyncio.sleep", side_effect=capture_and_stop):
+            with patch("src.main.asyncio.create_task"):
+                await bot.start()
+
+        # _running was True when sleep was first called
+        assert running_values[0] is True
+
+    @pytest.mark.asyncio
+    async def test_error_reraises(self, bot, mock_app):
+        """Exception during start is re-raised."""
+        bot.application = mock_app
+        mock_app.start = AsyncMock(side_effect=RuntimeError("start failed"))
+
+        with pytest.raises(RuntimeError, match="start failed"):
+            await bot.start()
+
+
+# ---- AddarrBot.stop ----
+
+
+class TestStop:
+    """Tests for AddarrBot.stop()."""
+
+    @pytest.mark.asyncio
+    async def test_full_shutdown(self, bot, mock_app):
+        """Stops health checker, updater, application, and shuts down."""
+        bot.application = mock_app
+        bot._running = True
+        bot.health_checker = MagicMock()
+        bot.health_checker.stop = AsyncMock()
+
+        await bot.stop()
+
+        assert bot._running is False
+        bot.health_checker.stop.assert_awaited_once()
+        mock_app.updater.stop.assert_awaited_once()
+        mock_app.stop.assert_awaited_once()
+        mock_app.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_application_is_none(self, bot):
+        """No-op when application is None."""
+        bot.application = None
+        await bot.stop()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_updater_not_running(self, bot, mock_app):
+        """Skips updater.stop() when updater is not running."""
+        bot.application = mock_app
+        mock_app.updater.running = False
+        bot.health_checker = MagicMock()
+        bot.health_checker.stop = AsyncMock()
+
+        await bot.stop()
+
+        mock_app.updater.stop.assert_not_awaited()
+        mock_app.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_error_swallowed(self, bot, mock_app):
+        """Exceptions during shutdown are swallowed."""
+        bot.application = mock_app
+        bot.health_checker = MagicMock()
+        bot.health_checker.stop = AsyncMock(
+            side_effect=RuntimeError("health stop failed")
+        )
+
+        # Should not raise
+        await bot.stop()
+
+
+# ---- main() ----
+
+
+class TestMain:
+    """Tests for the main() async entry point."""
+
+    @pytest.mark.asyncio
+    @patch("src.main.AddarrBot")
+    async def test_start_bot_start_error_stops_and_exits(self, mock_bot_cls):
+        """When bot.start() raises, bot is stopped and sys.exit(1) called."""
+        mock_bot = MagicMock()
+        mock_bot.initialize = AsyncMock()  # succeeds
+        mock_bot.start = AsyncMock(side_effect=RuntimeError("start fail"))
+        mock_bot.stop = AsyncMock()
+        mock_bot_cls.return_value = mock_bot
+
+        with pytest.raises(SystemExit) as exc_info:
+            await main()
+
+        mock_bot.stop.assert_awaited()
+        assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    @patch("src.main.AddarrBot")
+    async def test_start_bot_error_stops_and_exits(self, mock_bot_cls):
+        """When start_bot raises, bot is stopped and sys.exit(1) called."""
+        mock_bot = MagicMock()
+        mock_bot.initialize = AsyncMock(side_effect=RuntimeError("init fail"))
+        mock_bot.stop = AsyncMock()
+        mock_bot.start = AsyncMock()
+        mock_bot_cls.return_value = mock_bot
+
+        with pytest.raises(SystemExit) as exc_info:
+            await main()
+
+        mock_bot.stop.assert_awaited()
+        assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    @patch("src.main.AddarrBot")
+    async def test_signal_handler_registration(self, mock_bot_cls):
+        """Signal handlers are registered for SIGINT and SIGTERM."""
+        mock_bot = MagicMock()
+        mock_bot.initialize = AsyncMock(
+            side_effect=RuntimeError("stop early")
+        )
+        mock_bot.stop = AsyncMock()
+        mock_bot_cls.return_value = mock_bot
+
+        mock_loop = MagicMock()
+        mock_loop.add_signal_handler = MagicMock()
+
+        with (
+            patch("src.main.asyncio.get_running_loop", return_value=mock_loop),
+            pytest.raises(SystemExit),
+        ):
+            await main()
+
+        # SIGINT and SIGTERM handlers registered
+        assert mock_loop.add_signal_handler.call_count == 2
+        sig_args = [
+            c.args[0] for c in mock_loop.add_signal_handler.call_args_list
+        ]
+        assert signal.SIGINT in sig_args
+        assert signal.SIGTERM in sig_args
+
+    @pytest.mark.asyncio
+    @patch("src.main.AddarrBot")
+    async def test_windows_signal_fallback(self, mock_bot_cls):
+        """Falls back to signal.signal on Windows (NotImplementedError)."""
+        mock_bot = MagicMock()
+        mock_bot.initialize = AsyncMock(
+            side_effect=RuntimeError("stop early")
+        )
+        mock_bot.stop = AsyncMock()
+        mock_bot_cls.return_value = mock_bot
+
+        mock_loop = MagicMock()
+        mock_loop.add_signal_handler.side_effect = NotImplementedError
+
+        with (
+            patch(
+                "src.main.asyncio.get_running_loop", return_value=mock_loop
+            ),
+            patch("src.main.signal.signal") as mock_signal,
+            pytest.raises(SystemExit),
+        ):
+            await main()
+
+        # Fell back to signal.signal for both SIGINT and SIGTERM
+        assert mock_signal.call_count == 2
+        sig_args = [c.args[0] for c in mock_signal.call_args_list]
+        assert signal.SIGINT in sig_args
+        assert signal.SIGTERM in sig_args
+
+    @pytest.mark.asyncio
+    @patch("src.main.AddarrBot")
+    async def test_keyboard_interrupt_stops_bot(self, mock_bot_cls):
+        """KeyboardInterrupt triggers bot.stop()."""
+        mock_bot = MagicMock()
+        mock_bot.stop = AsyncMock()
+        mock_bot_cls.return_value = mock_bot
+
+        # Make start_bot raise KeyboardInterrupt at the top-level try
+        with (
+            patch(
+                "src.main.asyncio.get_running_loop",
+                side_effect=KeyboardInterrupt,
+            ),
+        ):
+            await main()
+
+        mock_bot.stop.assert_awaited()
+
+    @pytest.mark.asyncio
+    @patch("src.main.AddarrBot")
+    async def test_generic_exception_exits(self, mock_bot_cls):
+        """Generic exception at top level triggers sys.exit(1)."""
+        mock_bot = MagicMock()
+        mock_bot_cls.return_value = mock_bot
+
+        with (
+            patch(
+                "src.main.asyncio.get_running_loop",
+                side_effect=RuntimeError("fatal"),
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            await main()
+
+        assert exc_info.value.code == 1
+
+
+# ---- run_bot() ----
+
+
+class TestRunBot:
+    """Tests for the run_bot() sync entry point."""
+
+    @patch("src.main.asyncio.run")
+    def test_calls_asyncio_run(self, mock_run):
+        """run_bot() calls asyncio.run(main())."""
+        run_bot()
+        mock_run.assert_called_once()
+
+    @patch("src.main.asyncio.run", side_effect=KeyboardInterrupt)
+    def test_keyboard_interrupt(self, mock_run):
+        """KeyboardInterrupt is caught gracefully."""
+        run_bot()  # Should not raise
+
+    @patch("src.main.asyncio.run", side_effect=RuntimeError("fatal"))
+    def test_generic_exception_exits(self, mock_run):
+        """Generic exception triggers sys.exit(1)."""
+        with pytest.raises(SystemExit) as exc_info:
+            run_bot()
+        assert exc_info.value.code == 1

--- a/tests/test_setup/test_service_config.py
+++ b/tests/test_setup/test_service_config.py
@@ -98,6 +98,16 @@ class TestGetDefaultServiceConfig:
             assert config["tags"]["default"] == ["telegram"]
             assert config["adminRestrictions"] is False
 
+    def test_unknown_service_fallthrough(self):
+        """Unknown arr service gets base config without service-specific fields."""
+        config = get_default_service_config("bazarr")
+        assert config["enable"] is False
+        assert config["server"]["addr"] == "localhost"
+        assert config["server"]["port"] == "8090"
+        assert "metadataProfileId" not in config
+        assert "minimumAvailability" not in config.get("features", {})
+        assert "seasonFolder" not in config.get("features", {})
+
 
 # ---------------------------------------------------------------------------
 # get_valid_service_config tests
@@ -248,3 +258,57 @@ class TestGetValidServiceConfig:
         assert result["auth"]["apikey"] == ""
         # password should not have been called
         mock_q.password.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sabnzbd_retry_then_skip(self):
+        """SABnzbd validation fails, user declines retry, returns disabled config."""
+        with patch("src.setup.service_config.questionary") as mock_q, \
+             patch("src.setup.service_config.validate_service_connection",
+                   new_callable=AsyncMock, return_value=False), \
+             patch("src.setup.service_config.get_valid_port",
+                   new_callable=AsyncMock, return_value=8090):
+
+            mock_q.text.return_value = _mock_questionary_ask("myserver")
+            confirm_mock = MagicMock()
+            confirm_mock.ask_async = AsyncMock(side_effect=[False, False])
+            mock_q.confirm.return_value = confirm_mock
+            mock_q.password.return_value = _mock_questionary_ask("sab-key")
+
+            result = await get_valid_service_config("sabnzbd")
+
+        assert result["enable"] is False
+        assert result["onlyAdmin"] is True
+        assert result["server"]["addr"] == "myserver"
+        assert result["server"]["port"] == 8090
+        assert result["server"]["ssl"] is False
+        assert result["auth"]["apikey"] == "sab-key"
+
+    @pytest.mark.asyncio
+    async def test_validation_fail_retry_then_succeed(self):
+        """Validation fails, user retries, succeeds on second attempt."""
+        with patch("src.setup.service_config.questionary") as mock_q, \
+             patch("src.setup.service_config.validate_service_connection",
+                   new_callable=AsyncMock, side_effect=[False, True]), \
+             patch("src.setup.service_config.get_valid_port",
+                   new_callable=AsyncMock, return_value=7878):
+
+            text_mock = MagicMock()
+            text_mock.ask_async = AsyncMock(
+                side_effect=["localhost", "localhost"]
+            )
+            mock_q.text.return_value = text_mock
+            confirm_mock = MagicMock()
+            confirm_mock.ask_async = AsyncMock(
+                side_effect=[False, True, False]
+            )
+            mock_q.confirm.return_value = confirm_mock
+            password_mock = MagicMock()
+            password_mock.ask_async = AsyncMock(
+                side_effect=["key", "key"]
+            )
+            mock_q.password.return_value = password_mock
+
+            result = await get_valid_service_config("radarr")
+
+        assert result["server"]["addr"] == "localhost"
+        assert result["auth"]["apikey"] == "key"

--- a/tests/test_setup/test_wizard.py
+++ b/tests/test_setup/test_wizard.py
@@ -334,3 +334,344 @@ class TestMain:
         main()
 
         mock_instance.run.assert_called_once_with(True)
+
+
+# ---------------------------------------------------------------------------
+# Gap-fill: _update_config_value (line 66)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateConfigValue:
+    """Tests for _update_config_value."""
+
+    @patch("src.setup.wizard.config_handler")
+    def test_delegates_to_config_handler(self, mock_handler):
+        """_update_config_value calls config_handler.update_value."""
+        mock_handler.load_config.return_value = {"key": "old"}
+
+        wizard = SetupWizard()
+        wizard._update_config_value(["key"], "new")
+
+        mock_handler.update_value.assert_called_once_with(
+            wizard.config, ["key"], "new"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Gap-fill: _create_directories (lines 128-134)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDirectories:
+    """Tests for _create_directories."""
+
+    @patch("src.setup.wizard.config_handler")
+    @patch("src.setup.wizard.Path")
+    @patch("src.setup.wizard.LOG_PATH", "/fake/logs/addarr.log")
+    def test_creates_log_and_translations_dirs(self, mock_path, mock_handler):
+        """Creates the log directory and translations directory."""
+        mock_handler.load_config.return_value = {}
+
+        wizard = SetupWizard()
+        wizard._create_directories()
+
+        # Should create two directories: log dir and translations
+        assert mock_path.call_count == 2
+        dir_args = [c.args[0] for c in mock_path.call_args_list]
+        assert "/fake/logs" in dir_args
+        assert "translations" in dir_args
+        # Both should call mkdir with parents=True, exist_ok=True
+        for call_obj in mock_path.return_value.mkdir.call_args_list:
+            assert call_obj == (
+                (), {"parents": True, "exist_ok": True}
+            )
+
+
+# ---------------------------------------------------------------------------
+# Gap-fill: _configure_service (lines 138-159)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureService:
+    """Tests for _configure_service."""
+
+    @pytest.mark.asyncio
+    @patch("src.setup.wizard.config_handler")
+    @patch("src.setup.wizard.get_default_service_config")
+    @patch("src.setup.wizard.get_valid_service_config", new_callable=AsyncMock)
+    @patch("src.setup.wizard.configure_arr_features", new_callable=AsyncMock)
+    async def test_arr_service_with_features(
+        self, mock_features, mock_valid, mock_default, mock_handler
+    ):
+        """Arr services (radarr/sonarr/lidarr) get features configured."""
+        mock_handler.load_config.return_value = {}
+        mock_default.return_value = {"enable": False}
+        mock_valid.return_value = {
+            "server": {"addr": "localhost"},
+            "auth": {"apikey": "key"},
+        }
+        mock_features.return_value = {"search": True}
+
+        wizard = SetupWizard()
+        await wizard._configure_service("radarr")
+
+        mock_valid.assert_awaited_once_with("radarr")
+        mock_features.assert_awaited_once_with("radarr")
+        assert wizard.config["radarr"]["enable"] is True
+        assert wizard.config["radarr"]["features"] == {"search": True}
+
+    @pytest.mark.asyncio
+    @patch("src.setup.wizard.config_handler")
+    @patch("src.setup.wizard.get_default_service_config")
+    @patch("src.setup.wizard.get_valid_service_config", new_callable=AsyncMock)
+    @patch("src.setup.wizard.configure_arr_features", new_callable=AsyncMock)
+    async def test_non_arr_service_no_features(
+        self, mock_features, mock_valid, mock_default, mock_handler
+    ):
+        """Non-arr services (transmission) skip features configuration."""
+        mock_handler.load_config.return_value = {}
+        mock_default.return_value = {"enable": False}
+        mock_valid.return_value = {"host": "localhost", "port": 9091}
+
+        wizard = SetupWizard()
+        await wizard._configure_service("transmission")
+
+        mock_valid.assert_awaited_once_with("transmission")
+        mock_features.assert_not_awaited()
+        assert wizard.config["transmission"]["enable"] is True
+
+    @pytest.mark.asyncio
+    @patch("src.setup.wizard.config_handler")
+    @patch("src.setup.wizard.get_default_service_config")
+    @patch("src.setup.wizard.get_valid_service_config", new_callable=AsyncMock)
+    async def test_exception_disables_service(
+        self, mock_valid, mock_default, mock_handler, capsys
+    ):
+        """Exception during config sets enable=False."""
+        mock_handler.load_config.return_value = {}
+        mock_default.return_value = {"enable": False}
+        mock_valid.side_effect = Exception("connection failed")
+
+        wizard = SetupWizard()
+        await wizard._configure_service("radarr")
+
+        assert wizard.config["radarr"]["enable"] is False
+        captured = capsys.readouterr()
+        assert "Error configuring radarr" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Gap-fill: _configure_required_value (lines 163-168)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureRequiredValue:
+    """Tests for _configure_required_value."""
+
+    @pytest.mark.asyncio
+    @patch("src.setup.wizard.config_handler")
+    @patch("src.setup.wizard.configure_required_value", new_callable=AsyncMock)
+    @patch("src.setup.wizard.get_default_service_config")
+    async def test_arr_service_passes_default_config(
+        self, mock_default, mock_crv, mock_handler
+    ):
+        """Arr services pass default_config to configure_required_value."""
+        mock_handler.load_config.return_value = {}
+        mock_default.return_value = {"server": {"addr": "localhost"}}
+        mock_crv.return_value = {"radarr": {"updated": True}}
+
+        wizard = SetupWizard()
+        await wizard._configure_required_value("radarr", "apikey")
+
+        mock_default.assert_called_once_with("radarr")
+        # First arg is wizard.config at call time ({}), not return value
+        mock_crv.assert_awaited_once()
+        call_args = mock_crv.call_args
+        assert call_args.args[1] == "radarr"
+        assert call_args.args[2] == "apikey"
+        assert call_args.kwargs["default_config"] == {
+            "server": {"addr": "localhost"}
+        }
+        # Return value is assigned to wizard.config
+        assert wizard.config == {"radarr": {"updated": True}}
+
+    @pytest.mark.asyncio
+    @patch("src.setup.wizard.config_handler")
+    @patch("src.setup.wizard.configure_required_value", new_callable=AsyncMock)
+    async def test_non_arr_service_passes_none(self, mock_crv, mock_handler):
+        """Non-arr services pass default_config=None."""
+        mock_handler.load_config.return_value = {}
+        mock_crv.return_value = {"transmission": {"updated": True}}
+
+        wizard = SetupWizard()
+        await wizard._configure_required_value("transmission", "host")
+
+        mock_crv.assert_awaited_once()
+        call_args = mock_crv.call_args
+        assert call_args.args[1] == "transmission"
+        assert call_args.args[2] == "host"
+        assert call_args.kwargs["default_config"] is None
+        assert wizard.config == {"transmission": {"updated": True}}
+
+
+# ---------------------------------------------------------------------------
+# Gap-fill: _reset_config success path (lines 207-223)
+# ---------------------------------------------------------------------------
+
+
+class TestResetConfigSuccess:
+    """Tests for _reset_config success and error paths."""
+
+    @patch("src.setup.wizard.config_handler")
+    @patch("src.setup.wizard.questionary")
+    @patch("src.setup.wizard.create_backup", return_value="/backup/config.yaml")
+    @patch("src.setup.wizard.os.path.exists", return_value=True)
+    @patch("builtins.open", new_callable=MagicMock)
+    @patch("src.setup.wizard.yaml")
+    def test_success_loads_example_saves_and_runs(
+        self, mock_yaml, mock_open, mock_exists, mock_backup,
+        mock_q, mock_handler
+    ):
+        """Success path: backup, load example, save, run()."""
+        mock_handler.load_config.return_value = {}
+        mock_handler.save_config = MagicMock()
+
+        mock_confirm = MagicMock()
+        mock_confirm.ask.return_value = True
+        mock_q.confirm.return_value = mock_confirm
+        mock_q.Style = MagicMock()
+
+        mock_yaml.load.return_value = {"telegram": {"token": ""}}
+
+        wizard = SetupWizard()
+        # Mock run() to prevent recursive loop
+        wizard.run = MagicMock()
+
+        wizard._reset_config()
+
+        mock_backup.assert_called_once()
+        mock_yaml.load.assert_called_once()
+        mock_handler.save_config.assert_called_once()
+        wizard.run.assert_called_once()
+
+    @patch("src.setup.wizard.config_handler")
+    @patch("src.setup.wizard.questionary")
+    @patch("src.setup.wizard.create_backup", return_value="/backup/config.yaml")
+    @patch("src.setup.wizard.os.path.exists", return_value=False)
+    def test_missing_example_exits_one(
+        self, mock_exists, mock_backup, mock_q, mock_handler
+    ):
+        """Exits with code 1 when config_example.yaml not found."""
+        mock_handler.load_config.return_value = {}
+
+        mock_confirm = MagicMock()
+        mock_confirm.ask.return_value = True
+        mock_q.confirm.return_value = mock_confirm
+        mock_q.Style = MagicMock()
+
+        wizard = SetupWizard()
+
+        with pytest.raises(SystemExit) as exc_info:
+            wizard._reset_config()
+
+        assert exc_info.value.code == 1
+
+    @patch("src.setup.wizard.config_handler")
+    @patch("src.setup.wizard.questionary")
+    @patch("src.setup.wizard.create_backup", return_value="/backup/config.yaml")
+    @patch("src.setup.wizard.os.path.exists", return_value=True)
+    @patch("builtins.open", side_effect=Exception("read error"))
+    def test_exception_exits_one(
+        self, mock_open, mock_exists, mock_backup,
+        mock_q, mock_handler
+    ):
+        """Generic exception during reset calls sys.exit(1)."""
+        mock_handler.load_config.return_value = {}
+
+        mock_confirm = MagicMock()
+        mock_confirm.ask.return_value = True
+        mock_q.confirm.return_value = mock_confirm
+        mock_q.Style = MagicMock()
+
+        wizard = SetupWizard()
+
+        with pytest.raises(SystemExit) as exc_info:
+            wizard._reset_config()
+
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Gap-fill: configure_services Transmission auth + SABnzbd (lines 259-279)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureServicesGapFill:
+    """Gap-fill tests for Transmission auth and SABnzbd paths."""
+
+    @patch("src.setup.wizard.config_handler")
+    @patch("src.setup.wizard.show_splash_screen")
+    @patch("src.setup.wizard.questionary")
+    def test_transmission_with_auth(self, mock_q, mock_splash, mock_handler):
+        """Transmission auth configures username and password."""
+        mock_handler.load_config.return_value = {}
+        mock_handler.save_config = MagicMock()
+
+        # Sequence: radarr=No, sonarr=No, lidarr=No,
+        # transmission=Yes, auth=Yes, sabnzbd=No
+        confirm_mock = MagicMock()
+        confirm_mock.ask.side_effect = [
+            False, False, False,  # skip media services
+            True,   # configure transmission
+            True,   # enable auth
+            False,  # skip sabnzbd
+        ]
+        mock_q.confirm.return_value = confirm_mock
+
+        # Username and password prompts
+        text_mock = MagicMock()
+        text_mock.ask.return_value = "admin"
+        mock_q.text.return_value = text_mock
+
+        password_mock = MagicMock()
+        password_mock.ask.return_value = "secret123"
+        mock_q.password.return_value = password_mock
+
+        wizard = SetupWizard()
+        wizard.configure_services()
+
+        assert wizard.config["transmission"]["enable"] is True
+        assert wizard.config["transmission"]["authentication"] is True
+        assert wizard.config["transmission"]["username"] == "admin"
+        assert wizard.config["transmission"]["password"] == "secret123"
+
+    @patch("src.setup.wizard.config_handler")
+    @patch("src.setup.wizard.show_splash_screen")
+    @patch("src.setup.wizard.questionary")
+    @patch("src.setup.wizard.asyncio")
+    def test_sabnzbd_config(self, mock_asyncio, mock_q, mock_splash, mock_handler):
+        """SABnzbd configuration gets valid config via asyncio.run."""
+        mock_handler.load_config.return_value = {}
+        mock_handler.save_config = MagicMock()
+
+        # Sequence: radarr=No, sonarr=No, lidarr=No,
+        # transmission=No, sabnzbd=Yes
+        confirm_mock = MagicMock()
+        confirm_mock.ask.side_effect = [
+            False, False, False,  # skip media services
+            False,  # skip transmission
+            True,   # configure sabnzbd
+        ]
+        mock_q.confirm.return_value = confirm_mock
+
+        mock_asyncio.run.return_value = {
+            "server": {"addr": "localhost", "port": 8090},
+            "auth": {"apikey": "sab-key"},
+        }
+
+        wizard = SetupWizard()
+        wizard.configure_services()
+
+        mock_asyncio.run.assert_called_once()
+        assert wizard.config["sabnzbd"]["enable"] is True
+        assert wizard.config["sabnzbd"]["auth"]["apikey"] == "sab-key"

--- a/tests/test_utils/test_config_handler.py
+++ b/tests/test_utils/test_config_handler.py
@@ -1,0 +1,259 @@
+"""Tests for src/utils/config_handler.py"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.utils.config_handler import ConfigHandler, config_handler
+
+
+@pytest.fixture
+def colors():
+    """Mock colors object with Fore attributes."""
+    c = MagicMock()
+    c.Fore.GREEN = ""
+    c.Fore.RED = ""
+    c.Fore.YELLOW = ""
+    return c
+
+
+@pytest.fixture
+def handler(tmp_path, colors):
+    """ConfigHandler wired to tmp_path for safe file I/O."""
+    h = ConfigHandler(colors)
+    h.root_dir = str(tmp_path)
+    h.config_path = str(tmp_path / "config.yaml")
+    h.config_example_path = str(tmp_path / "config_example.yaml")
+    return h
+
+
+@pytest.fixture
+def example_yaml(tmp_path):
+    """Create a config_example.yaml in tmp_path."""
+    path = tmp_path / "config_example.yaml"
+    path.write_text("telegram:\n  token: ''\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def config_yaml(tmp_path):
+    """Create a config.yaml in tmp_path."""
+    path = tmp_path / "config.yaml"
+    path.write_text("telegram:\n  token: 'old-token'\n", encoding="utf-8")
+    return path
+
+
+# ---- __init__ ----
+
+
+class TestConfigHandlerInit:
+    """Tests for ConfigHandler.__init__."""
+
+    def test_sets_colors(self, colors):
+        """Stores the colors object."""
+        h = ConfigHandler(colors)
+        assert h.colors is colors
+
+    def test_sets_root_dir(self):
+        """root_dir points to the project root (3 levels up from this file)."""
+        h = ConfigHandler(None)
+        assert os.path.isabs(h.root_dir)
+
+    def test_sets_config_paths(self):
+        """config_path and config_example_path are under root_dir."""
+        h = ConfigHandler(None)
+        assert h.config_path.endswith("config.yaml")
+        assert h.config_example_path.endswith("config_example.yaml")
+
+    def test_none_colors_accepted(self):
+        """colors=None is valid (used by global instance)."""
+        h = ConfigHandler(None)
+        assert h.colors is None
+
+
+# ---- create_from_example ----
+
+
+class TestCreateFromExample:
+    """Tests for create_from_example."""
+
+    def test_copies_example_to_config(self, handler, example_yaml):
+        """Copies config_example.yaml to config.yaml."""
+        result = handler.create_from_example()
+        assert result is True
+        assert os.path.exists(handler.config_path)
+        content = open(handler.config_path, encoding="utf-8").read()
+        assert "telegram" in content
+
+    def test_backs_up_existing_config(self, handler, example_yaml, config_yaml):
+        """Creates backup when config.yaml already exists."""
+        result = handler.create_from_example()
+        assert result is True
+        backup_dir = os.path.join(handler.root_dir, "backup")
+        assert os.path.isdir(backup_dir)
+        backups = os.listdir(backup_dir)
+        assert len(backups) == 1
+        assert backups[0].startswith("config_")
+
+    def test_returns_false_on_error(self, handler, capsys):
+        """Returns False when example file doesn't exist."""
+        # example_yaml fixture not created — copy will fail
+        result = handler.create_from_example()
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Error creating config" in captured.out
+
+
+# ---- create_backup ----
+
+
+class TestCreateBackup:
+    """Tests for create_backup."""
+
+    def test_creates_timestamped_backup(self, handler, config_yaml):
+        """Creates backup file with timestamp in name."""
+        result = handler.create_backup()
+        assert result != ""
+        assert os.path.exists(result)
+        assert "config_" in os.path.basename(result)
+        assert result.endswith(".yaml")
+
+    def test_creates_backup_dir(self, handler, config_yaml):
+        """Creates the backup/ directory if it doesn't exist."""
+        backup_dir = os.path.join(handler.root_dir, "backup")
+        assert not os.path.exists(backup_dir)
+        handler.create_backup()
+        assert os.path.isdir(backup_dir)
+
+    def test_returns_empty_when_no_config(self, handler):
+        """Returns empty string when config.yaml does not exist."""
+        result = handler.create_backup()
+        assert result == ""
+
+    @patch("src.utils.config_handler.datetime")
+    def test_timestamp_format(self, mock_dt, handler, config_yaml):
+        """Backup filename uses YYYYMMDD_HHMMSS format."""
+        mock_dt.now.return_value.strftime.return_value = "20260302_120000"
+        result = handler.create_backup()
+        assert "config_20260302_120000.yaml" in result
+
+    def test_backup_preserves_content(self, handler, config_yaml):
+        """Backup file has identical content to original."""
+        result = handler.create_backup()
+        original = open(handler.config_path, encoding="utf-8").read()
+        backup = open(result, encoding="utf-8").read()
+        assert original == backup
+
+
+# ---- load_config ----
+
+
+class TestLoadConfig:
+    """Tests for load_config."""
+
+    def test_loads_valid_yaml(self, handler, config_yaml):
+        """Returns parsed dict from valid YAML file."""
+        result = handler.load_config()
+        assert isinstance(result, dict)
+        assert "telegram" in result
+        assert result["telegram"]["token"] == "old-token"
+
+    def test_returns_empty_dict_on_missing_file(self, handler, capsys):
+        """Returns {} when config file doesn't exist."""
+        result = handler.load_config()
+        assert result == {}
+        captured = capsys.readouterr()
+        assert "Error loading config" in captured.out
+
+    def test_returns_empty_dict_on_invalid_yaml(self, handler, tmp_path, capsys):
+        """Returns {} on malformed YAML."""
+        bad = tmp_path / "config.yaml"
+        bad.write_text("{{invalid yaml: [", encoding="utf-8")
+        result = handler.load_config()
+        assert result == {}
+
+
+# ---- save_config ----
+
+
+class TestSaveConfig:
+    """Tests for save_config."""
+
+    def test_saves_config_to_file(self, handler, config_yaml):
+        """Writes config dict as YAML to config_path."""
+        data = {"telegram": {"token": "new-token"}}
+        result = handler.save_config(data)
+        assert result is True
+        loaded = handler.load_config()
+        assert loaded["telegram"]["token"] == "new-token"
+
+    def test_creates_backup_before_save(self, handler, config_yaml):
+        """Backs up existing config before overwriting."""
+        handler.save_config({"key": "val"})
+        backup_dir = os.path.join(handler.root_dir, "backup")
+        assert os.path.isdir(backup_dir)
+        assert len(os.listdir(backup_dir)) == 1
+
+    def test_returns_false_on_error(self, handler, config_yaml, capsys):
+        """Returns False when write fails."""
+        with patch("builtins.open", side_effect=PermissionError("denied")):
+            result = handler.save_config({"key": "val"})
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Error saving configuration" in captured.out
+
+
+# ---- update_value ----
+
+
+class TestUpdateValue:
+    """Tests for update_value."""
+
+    def test_single_key(self):
+        """Updates a top-level key."""
+        config = {"language": "en-us"}
+        ConfigHandler.update_value(None, config, ["language"], "de-de")
+        assert config["language"] == "de-de"
+
+    def test_nested_keys(self):
+        """Updates a deeply nested key."""
+        config = {"telegram": {"token": "old"}}
+        ConfigHandler.update_value(None, config, ["telegram", "token"], "new")
+        assert config["telegram"]["token"] == "new"
+
+    def test_creates_intermediate_keys(self):
+        """Creates missing intermediate dicts via setdefault."""
+        config = {}
+        ConfigHandler.update_value(
+            None, config, ["radarr", "server", "addr"], "localhost"
+        )
+        assert config["radarr"]["server"]["addr"] == "localhost"
+
+    def test_preserves_sibling_keys(self):
+        """Updating one nested key doesn't affect siblings."""
+        config = {"telegram": {"token": "abc", "password": "secret"}}
+        ConfigHandler.update_value(
+            None, config, ["telegram", "token"], "xyz"
+        )
+        assert config["telegram"]["token"] == "xyz"
+        assert config["telegram"]["password"] == "secret"
+
+
+# ---- global config_handler instance ----
+
+
+class TestGlobalInstance:
+    """Tests for the module-level config_handler."""
+
+    def test_is_config_handler_instance(self):
+        """Global instance is a ConfigHandler."""
+        assert isinstance(config_handler, ConfigHandler)
+
+    def test_colors_is_none(self):
+        """Global instance has colors=None (set later by PreRunChecker)."""
+        assert config_handler.colors is None
+
+    def test_has_config_path(self):
+        """Global instance has config_path set."""
+        assert config_handler.config_path.endswith("config.yaml")

--- a/tests/test_utils/test_prerun.py
+++ b/tests/test_utils/test_prerun.py
@@ -1,0 +1,473 @@
+"""Tests for src/utils/prerun.py"""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from src.utils.prerun import ColorHandler, PreRunChecker, prerun_checker
+
+
+# ---- DummyFore / DummyStyle ----
+
+
+class TestDummyClasses:
+    """Tests for DummyFore and DummyStyle fallback classes."""
+
+    def test_dummy_fore_attributes_are_empty_strings(self):
+        """DummyFore.RED/GREEN/YELLOW/CYAN are all empty strings."""
+        dummy = ColorHandler.DummyFore()
+        assert dummy.RED == ""
+        assert dummy.GREEN == ""
+        assert dummy.YELLOW == ""
+        assert dummy.CYAN == ""
+
+    def test_dummy_style_reset_all_is_empty_string(self):
+        """DummyStyle.RESET_ALL is an empty string."""
+        dummy = ColorHandler.DummyStyle()
+        assert dummy.RESET_ALL == ""
+
+
+# ---- ColorHandler.__init__ ----
+
+
+class TestColorHandlerInit:
+    """Tests for ColorHandler initialization."""
+
+    def test_with_colorama_available(self):
+        """When colorama is importable, Fore/Style are real colorama objects."""
+        handler = ColorHandler()
+        # colorama is installed in test env
+        from colorama import Fore, Style
+        assert handler.Fore is Fore
+        assert handler.Style is Style
+
+    def test_with_colorama_import_error(self):
+        """When colorama import fails, falls back to DummyFore/DummyStyle."""
+        with patch.dict("sys.modules", {"colorama": None}):
+            handler = ColorHandler()
+        assert isinstance(handler.Fore, ColorHandler.DummyFore)
+        assert isinstance(handler.Style, ColorHandler.DummyStyle)
+
+
+# ---- ColorHandler.reload ----
+
+
+class TestColorHandlerReload:
+    """Tests for ColorHandler.reload."""
+
+    def test_reload_with_colorama(self):
+        """Successful reload updates Fore/Style."""
+        handler = ColorHandler()
+        handler.Fore = None  # clobber
+        handler.reload()
+        from colorama import Fore
+        assert handler.Fore is Fore
+
+    def test_reload_with_import_error(self):
+        """ImportError during reload is a no-op (Fore/Style unchanged)."""
+        handler = ColorHandler()
+        original_fore = handler.Fore
+        with patch.dict("sys.modules", {"colorama": None}):
+            handler.reload()
+        # Fore should be unchanged
+        assert handler.Fore is original_fore
+
+
+# ---- PreRunChecker.__init__ ----
+
+
+class TestPreRunCheckerInit:
+    """Tests for PreRunChecker initialization."""
+
+    def test_colors_is_color_handler(self):
+        """colors attribute is a ColorHandler instance."""
+        checker = PreRunChecker()
+        assert isinstance(checker.colors, ColorHandler)
+
+    def test_root_dir_is_absolute(self):
+        """root_dir is an absolute path."""
+        checker = PreRunChecker()
+        import os
+        assert os.path.isabs(checker.root_dir)
+
+    def test_config_path_ends_with_config_yaml(self):
+        """config_path ends with config.yaml."""
+        checker = PreRunChecker()
+        assert checker.config_path.endswith("config.yaml")
+
+
+# ---- parse_requirements ----
+
+
+class TestParseRequirements:
+    """Tests for parse_requirements."""
+
+    def test_reads_packages_from_file(self, tmp_path):
+        """Parses package names from requirements file."""
+        req_file = tmp_path / "requirements.txt"
+        req_file.write_text("requests\naiohttp\n")
+        checker = PreRunChecker()
+        result = checker.parse_requirements(str(req_file))
+        assert "requests" in result
+        assert "aiohttp" in result
+
+    def test_strips_version_specifiers(self, tmp_path):
+        """Strips >=, <=, == version specifiers."""
+        req_file = tmp_path / "requirements.txt"
+        req_file.write_text(
+            "requests>=2.28.0\naiohttp<=3.9.0\nflask==2.3.0\n"
+        )
+        checker = PreRunChecker()
+        result = checker.parse_requirements(str(req_file))
+        assert "requests" in result
+        assert "aiohttp" in result
+        assert "flask" in result
+        # No version strings
+        assert not any(">=" in p for p in result)
+        assert not any("<=" in p for p in result)
+        assert not any("==" in p for p in result)
+
+    def test_strips_inline_comments(self, tmp_path):
+        """Strips inline # comments from lines."""
+        req_file = tmp_path / "requirements.txt"
+        req_file.write_text("requests  # HTTP library\n")
+        checker = PreRunChecker()
+        result = checker.parse_requirements(str(req_file))
+        assert "requests" in result
+        assert not any("#" in p for p in result)
+
+    def test_skips_comment_lines(self, tmp_path):
+        """Lines starting with # are skipped entirely."""
+        req_file = tmp_path / "requirements.txt"
+        req_file.write_text("# This is a comment\nrequests\n")
+        checker = PreRunChecker()
+        result = checker.parse_requirements(str(req_file))
+        assert "requests" in result
+        assert len([p for p in result if p.startswith("#")]) == 0
+
+    def test_skips_blank_lines(self, tmp_path):
+        """Empty lines are skipped."""
+        req_file = tmp_path / "requirements.txt"
+        req_file.write_text("requests\n\n\naiohttp\n")
+        checker = PreRunChecker()
+        result = checker.parse_requirements(str(req_file))
+        assert "requests" in result
+        assert "aiohttp" in result
+
+    def test_lowercases_package_names(self, tmp_path):
+        """Package names are lowercased."""
+        req_file = tmp_path / "requirements.txt"
+        req_file.write_text("Flask\nDjango\n")
+        checker = PreRunChecker()
+        result = checker.parse_requirements(str(req_file))
+        assert "flask" in result
+        assert "django" in result
+
+    def test_file_not_found_returns_core_deps(self, capsys):
+        """FileNotFoundError returns core_deps list."""
+        checker = PreRunChecker()
+        result = checker.parse_requirements("/nonexistent/requirements.txt")
+        assert "colorama" in result
+        assert "python-telegram-bot" in result
+        assert "pyyaml" in result
+        assert "ruamel.yaml" in result
+        captured = capsys.readouterr()
+        assert "requirements.txt not found" in captured.out
+
+    def test_merges_with_core_deps(self, tmp_path):
+        """Result includes both file packages and core deps."""
+        req_file = tmp_path / "requirements.txt"
+        req_file.write_text("custom-package\n")
+        checker = PreRunChecker()
+        result = checker.parse_requirements(str(req_file))
+        # File package
+        assert "custom-package" in result
+        # Core deps
+        assert "colorama" in result
+        assert "python-telegram-bot" in result
+
+    def test_deduplicates(self, tmp_path):
+        """Duplicate packages between file and core_deps are deduplicated."""
+        req_file = tmp_path / "requirements.txt"
+        req_file.write_text("colorama\npyyaml\n")
+        checker = PreRunChecker()
+        result = checker.parse_requirements(str(req_file))
+        assert result.count("colorama") == 1
+        assert result.count("pyyaml") == 1
+
+
+# ---- get_installed_packages ----
+
+
+class TestGetInstalledPackages:
+    """Tests for get_installed_packages."""
+
+    @patch("src.utils.prerun.subprocess.run")
+    def test_parses_json_output(self, mock_run):
+        """Parses pip list JSON and returns package names."""
+        mock_run.return_value.stdout = json.dumps([
+            {"name": "requests", "version": "2.28.0"},
+            {"name": "aiohttp", "version": "3.9.0"},
+        ])
+        checker = PreRunChecker()
+        result = checker.get_installed_packages()
+        assert "requests" in result
+        assert "aiohttp" in result
+
+    @patch("src.utils.prerun.subprocess.run")
+    def test_normalizes_hyphen_underscore(self, mock_run):
+        """Adds both hyphen and underscore variants."""
+        mock_run.return_value.stdout = json.dumps([
+            {"name": "python-telegram-bot", "version": "20.0"},
+        ])
+        checker = PreRunChecker()
+        result = checker.get_installed_packages()
+        assert "python-telegram-bot" in result
+        assert "python_telegram_bot" in result
+
+    @patch("src.utils.prerun.subprocess.run")
+    def test_lowercases_names(self, mock_run):
+        """Package names are lowercased."""
+        mock_run.return_value.stdout = json.dumps([
+            {"name": "Flask", "version": "2.3.0"},
+        ])
+        checker = PreRunChecker()
+        result = checker.get_installed_packages()
+        assert "flask" in result
+
+    @patch("src.utils.prerun.subprocess.run")
+    def test_subprocess_error_returns_empty_set(self, mock_run, capsys):
+        """Returns empty set on subprocess failure."""
+        mock_run.side_effect = Exception("pip failed")
+        checker = PreRunChecker()
+        result = checker.get_installed_packages()
+        assert result == set()
+        captured = capsys.readouterr()
+        assert "Error getting installed packages" in captured.out
+
+
+# ---- check_dependencies ----
+
+
+class TestCheckDependencies:
+    """Tests for check_dependencies."""
+
+    def test_all_installed_returns_true(self):
+        """Returns True when all packages are installed."""
+        checker = PreRunChecker()
+        checker.parse_requirements = MagicMock(return_value=["requests"])
+        checker.get_installed_packages = MagicMock(
+            return_value={"requests"}
+        )
+        assert checker.check_dependencies() is True
+
+    def test_empty_requirements_returns_false(self, capsys):
+        """Returns False when parse_requirements returns empty list."""
+        checker = PreRunChecker()
+        checker.parse_requirements = MagicMock(return_value=[])
+        result = checker.check_dependencies()
+        assert result is False
+        captured = capsys.readouterr()
+        assert "No dependencies found" in captured.out
+
+    @patch("builtins.input", return_value="y")
+    @patch("src.utils.prerun.subprocess.check_call")
+    def test_missing_packages_install_yes(self, mock_install, mock_input):
+        """Installs missing packages when user says yes."""
+        checker = PreRunChecker()
+        checker.parse_requirements = MagicMock(return_value=["missing-pkg"])
+        checker.get_installed_packages = MagicMock(return_value=set())
+        result = checker.check_dependencies()
+        assert result is True
+        mock_install.assert_called_once()
+
+    @patch("builtins.input", return_value="n")
+    def test_missing_packages_decline(self, mock_input, capsys):
+        """Returns False when user declines to install."""
+        checker = PreRunChecker()
+        checker.parse_requirements = MagicMock(return_value=["missing-pkg"])
+        checker.get_installed_packages = MagicMock(return_value=set())
+        result = checker.check_dependencies()
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Cannot continue without required dependencies" in captured.out
+
+    @patch("builtins.input", return_value="y")
+    @patch("src.utils.prerun.subprocess.check_call",
+           side_effect=subprocess.CalledProcessError(1, "pip"))
+    def test_install_failure(self, mock_install, mock_input, capsys):
+        """Returns False when pip install fails."""
+        checker = PreRunChecker()
+        checker.parse_requirements = MagicMock(return_value=["missing-pkg"])
+        checker.get_installed_packages = MagicMock(return_value=set())
+        result = checker.check_dependencies()
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Failed to install dependencies" in captured.out
+
+    @patch("builtins.input", return_value="y")
+    @patch("src.utils.prerun.subprocess.check_call")
+    def test_colorama_reload_triggered(self, mock_install, mock_input):
+        """Reloads colorama when it was among the missing packages."""
+        checker = PreRunChecker()
+        checker.parse_requirements = MagicMock(return_value=["colorama"])
+        checker.get_installed_packages = MagicMock(return_value=set())
+        checker.colors.reload = MagicMock()
+        result = checker.check_dependencies()
+        assert result is True
+        checker.colors.reload.assert_called_once()
+
+    @patch("builtins.input", side_effect=["invalid", "x", "n"])
+    def test_invalid_input_loop(self, mock_input, capsys):
+        """Loops on invalid input until valid y/n is given."""
+        checker = PreRunChecker()
+        checker.parse_requirements = MagicMock(return_value=["missing-pkg"])
+        checker.get_installed_packages = MagicMock(return_value=set())
+        result = checker.check_dependencies()
+        assert result is False
+        captured = capsys.readouterr()
+        assert captured.out.count("Please answer with 'y' or 'n'") == 2
+
+    def test_hyphen_underscore_matching(self):
+        """Packages match despite hyphen/underscore differences."""
+        checker = PreRunChecker()
+        checker.parse_requirements = MagicMock(
+            return_value=["python-telegram-bot"]
+        )
+        checker.get_installed_packages = MagicMock(
+            return_value={"python_telegram_bot"}
+        )
+        assert checker.check_dependencies() is True
+
+
+# ---- check_config_exists ----
+
+
+class TestCheckConfigExists:
+    """Tests for check_config_exists."""
+
+    @patch("os.path.exists", return_value=True)
+    def test_config_exists_returns_true(self, mock_exists):
+        """Returns True when config.yaml exists."""
+        checker = PreRunChecker()
+        with patch("src.utils.config_handler.config_handler"):
+            result = checker.check_config_exists()
+        assert result is True
+
+    @patch("os.path.exists", return_value=True)
+    def test_sets_config_handler_colors(self, mock_exists):
+        """Sets config_handler.colors to checker's colors."""
+        checker = PreRunChecker()
+        with patch(
+            "src.utils.config_handler.config_handler"
+        ) as mock_ch:
+            checker.check_config_exists()
+        assert mock_ch.colors is checker.colors
+
+    @patch("os.path.exists", return_value=False)
+    @patch("builtins.input", return_value="y")
+    def test_missing_config_runs_wizard(self, mock_input, mock_exists):
+        """Runs SetupWizard when user says yes to setup."""
+        checker = PreRunChecker()
+        mock_ch = MagicMock()
+        mock_ch.create_from_example.return_value = True
+        mock_wizard_cls = MagicMock()
+
+        with (
+            patch(
+                "src.utils.config_handler.config_handler", mock_ch
+            ),
+            patch("src.setup.SetupWizard", mock_wizard_cls),
+        ):
+            result = checker.check_config_exists()
+
+        assert result is True
+        mock_ch.create_from_example.assert_called_once()
+        mock_wizard_cls.return_value.run.assert_called_once()
+
+    @patch("os.path.exists", return_value=False)
+    @patch("builtins.input", return_value="y")
+    def test_create_from_example_fails(self, mock_input, mock_exists):
+        """Returns False when create_from_example fails."""
+        checker = PreRunChecker()
+        mock_ch = MagicMock()
+        mock_ch.create_from_example.return_value = False
+
+        with patch(
+            "src.utils.config_handler.config_handler", mock_ch
+        ):
+            result = checker.check_config_exists()
+
+        assert result is False
+
+    @patch("os.path.exists", return_value=False)
+    @patch("builtins.input", return_value="n")
+    def test_decline_setup_returns_false(self, mock_input, mock_exists, capsys):
+        """Returns False when user declines setup."""
+        checker = PreRunChecker()
+        with patch(
+            "src.utils.config_handler.config_handler"
+        ):
+            result = checker.check_config_exists()
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Cannot continue without configuration" in captured.out
+
+    @patch("os.path.exists", return_value=False)
+    @patch("builtins.input", side_effect=["maybe", "n"])
+    def test_invalid_input_loop(self, mock_input, mock_exists, capsys):
+        """Loops on invalid input, then accepts valid response."""
+        checker = PreRunChecker()
+        with patch(
+            "src.utils.config_handler.config_handler"
+        ):
+            result = checker.check_config_exists()
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Please answer with 'y' or 'n'" in captured.out
+
+
+# ---- run_checks ----
+
+
+class TestRunChecks:
+    """Tests for run_checks."""
+
+    def test_both_pass(self):
+        """Returns True when both dependencies and config checks pass."""
+        checker = PreRunChecker()
+        checker.check_dependencies = MagicMock(return_value=True)
+        checker.check_config_exists = MagicMock(return_value=True)
+        assert checker.run_checks() is True
+        checker.check_dependencies.assert_called_once()
+        checker.check_config_exists.assert_called_once()
+
+    def test_deps_fail_skips_config(self):
+        """Returns False and skips config check when deps fail."""
+        checker = PreRunChecker()
+        checker.check_dependencies = MagicMock(return_value=False)
+        checker.check_config_exists = MagicMock()
+        assert checker.run_checks() is False
+        checker.check_config_exists.assert_not_called()
+
+    def test_config_fail(self):
+        """Returns False when config check fails."""
+        checker = PreRunChecker()
+        checker.check_dependencies = MagicMock(return_value=True)
+        checker.check_config_exists = MagicMock(return_value=False)
+        assert checker.run_checks() is False
+
+
+# ---- global prerun_checker instance ----
+
+
+class TestGlobalInstance:
+    """Tests for the module-level prerun_checker."""
+
+    def test_is_prerun_checker_instance(self):
+        """Global instance is a PreRunChecker."""
+        assert isinstance(prerun_checker, PreRunChecker)
+
+    def test_has_colors(self):
+        """Global instance has a ColorHandler."""
+        assert isinstance(prerun_checker.colors, ColorHandler)

--- a/tests/test_utils/test_splash.py
+++ b/tests/test_utils/test_splash.py
@@ -1,0 +1,271 @@
+"""Tests for src/utils/splash.py"""
+
+from unittest.mock import patch
+
+from src.utils.splash import (
+    get_splash_screen,
+    show_splash_screen,
+    show_version,
+    show_welcome_screen,
+    show_token_help,
+)
+
+
+# ---- get_splash_screen ----
+
+
+class TestGetSplashScreen:
+    """Tests for get_splash_screen -- returns formatted ASCII art string."""
+
+    def test_returns_non_empty_string(self):
+        """Splash screen returns a non-empty string."""
+        result = get_splash_screen()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_contains_refresh_edition(self):
+        """Splash screen contains the REFRESH EDITION branding."""
+        result = get_splash_screen()
+        assert "REFRESH EDITION" in result
+
+    def test_contains_addarr_ascii_art(self):
+        """Splash screen contains the ADDARR ASCII art block letters."""
+        result = get_splash_screen()
+        # The ASCII art spells out ADDARR with block characters
+        assert "█▀▀█" in result
+
+    def test_contains_feature_tagline(self):
+        """Splash screen includes the feature tagline icons."""
+        result = get_splash_screen()
+        assert "Organize" in result
+        assert "Search" in result
+        assert "Download" in result
+        assert "Notify" in result
+
+
+# ---- show_splash_screen ----
+
+
+class TestShowSplashScreen:
+    """Tests for show_splash_screen -- prints splash to stdout."""
+
+    def test_prints_splash_to_stdout(self, capsys):
+        """show_splash_screen writes the splash to stdout."""
+        show_splash_screen()
+        captured = capsys.readouterr()
+        assert "REFRESH EDITION" in captured.out
+
+    def test_output_is_non_empty(self, capsys):
+        """show_splash_screen produces non-empty output."""
+        show_splash_screen()
+        captured = capsys.readouterr()
+        assert len(captured.out) > 0
+
+
+# ---- show_version ----
+
+
+class TestShowVersion:
+    """Tests for show_version -- prints version info to stdout."""
+
+    def test_shows_version_number(self, capsys):
+        """Output includes the version string."""
+        show_version()
+        captured = capsys.readouterr()
+        assert "1.0.0" in captured.out
+
+    def test_shows_addarr_label(self, capsys):
+        """Output includes the Addarr Version label."""
+        show_version()
+        captured = capsys.readouterr()
+        assert "Addarr Version" in captured.out
+
+    def test_shows_repository_url(self, capsys):
+        """Output includes the GitHub repository URL."""
+        show_version()
+        captured = capsys.readouterr()
+        assert "https://github.com/cyneric/addarr" in captured.out
+
+    def test_shows_documentation_url(self, capsys):
+        """Output includes the wiki documentation URL."""
+        show_version()
+        captured = capsys.readouterr()
+        assert "https://github.com/cyneric/addarr/wiki" in captured.out
+
+    def test_shows_media_description(self, capsys):
+        """Output includes the media management tagline."""
+        show_version()
+        captured = capsys.readouterr()
+        assert "Telegram bot for media management" in captured.out
+
+
+# ---- show_welcome_screen ----
+
+
+class TestShowWelcomeScreen:
+    """Tests for show_welcome_screen -- prints system info, config, and commands."""
+
+    def test_shows_bot_header(self, capsys):
+        """Output includes the Addarr Bot header."""
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "Addarr Bot" in captured.out
+
+    @patch("src.utils.splash.platform.python_version", return_value="3.11.5")
+    def test_shows_python_version(self, mock_ver, capsys):
+        """Output includes the Python version."""
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "3.11.5" in captured.out
+
+    @patch("src.utils.splash.platform.platform", return_value="Linux-6.1-x86_64")
+    def test_shows_os_info(self, mock_plat, capsys):
+        """Output includes the OS platform string."""
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "Linux-6.1-x86_64" in captured.out
+
+    def test_debug_mode_disabled_by_default(self, capsys):
+        """Default mock config has debug disabled -- shows disabled indicator."""
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "Debug Mode" in captured.out
+        assert "Disabled" in captured.out
+
+    @patch("src.utils.splash.config")
+    def test_debug_mode_enabled(self, mock_cfg, capsys):
+        """When debug is True, output shows enabled indicator."""
+        mock_cfg.get.side_effect = lambda key, default=None: {
+            "logging": {"debug": True},
+            "security": {"enableAdmin": False},
+            "language": "en-us",
+        }.get(key, default)
+
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "Debug Mode" in captured.out
+        # Enabled indicator
+        assert "Enabled" in captured.out
+
+    def test_admin_mode_disabled_by_default(self, capsys):
+        """Default mock config has admin disabled -- shows disabled indicator."""
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "Admin Mode" in captured.out
+        assert "Disabled" in captured.out
+
+    @patch("src.utils.splash.config")
+    def test_admin_mode_enabled(self, mock_cfg, capsys):
+        """When enableAdmin is True, output shows enabled indicator."""
+        mock_cfg.get.side_effect = lambda key, default=None: {
+            "logging": {"debug": False},
+            "security": {"enableAdmin": True},
+            "language": "en-us",
+        }.get(key, default)
+
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "Admin Mode" in captured.out
+        # Both enabled and disabled will appear, check the admin line specifically
+        lines = captured.out.split("\n")
+        admin_line = [line for line in lines if "Admin Mode" in line][0]
+        assert "Enabled" in admin_line
+
+    def test_shows_default_language(self, capsys):
+        """Default config shows en-us language."""
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "en-us" in captured.out
+
+    @patch("src.utils.splash.config")
+    def test_shows_custom_language(self, mock_cfg, capsys):
+        """Custom language config is displayed."""
+        mock_cfg.get.side_effect = lambda key, default=None: {
+            "logging": {"debug": False},
+            "security": {"enableAdmin": False},
+            "language": "de-de",
+        }.get(key, default)
+
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "de-de" in captured.out
+
+    def test_shows_cli_commands(self, capsys):
+        """Output includes all CLI commands."""
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "python run.py" in captured.out
+        assert "--setup" in captured.out
+        assert "--configure" in captured.out
+        assert "--check" in captured.out
+        assert "--version" in captured.out
+        assert "--backup" in captured.out
+        assert "--reset" in captured.out
+        assert "--validate-i18n" in captured.out
+        assert "--help" in captured.out
+
+    def test_shows_telegram_commands(self, capsys):
+        """Output includes all Telegram chat commands."""
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "/movie" in captured.out
+        assert "/series" in captured.out
+        assert "/music" in captured.out
+        assert "/delete" in captured.out
+        assert "/status" in captured.out
+        assert "/settings" in captured.out
+        assert "/help" in captured.out
+
+    def test_shows_resource_urls(self, capsys):
+        """Output includes all resource URLs."""
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "https://github.com/cyneric/addarr" in captured.out
+        assert "https://github.com/cyneric/addarr/wiki" in captured.out
+        assert "https://github.com/cyneric/addarr/issues" in captured.out
+
+    def test_shows_starting_message(self, capsys):
+        """Output includes the starting bot message."""
+        show_welcome_screen()
+        captured = capsys.readouterr()
+        assert "Starting bot" in captured.out
+
+
+# ---- show_token_help ----
+
+
+class TestShowTokenHelp:
+    """Tests for show_token_help -- prints token configuration guidance."""
+
+    def test_shows_invalid_token_header(self, capsys):
+        """Output includes the invalid token error header."""
+        show_token_help()
+        captured = capsys.readouterr()
+        assert "Invalid Telegram Bot Token" in captured.out
+
+    def test_shows_botfather_instructions(self, capsys):
+        """Output includes BotFather instructions."""
+        show_token_help()
+        captured = capsys.readouterr()
+        assert "@BotFather" in captured.out
+        assert "/newbot" in captured.out
+
+    def test_shows_config_example(self, capsys):
+        """Output includes config.yaml example."""
+        show_token_help()
+        captured = capsys.readouterr()
+        assert "config.yaml" in captured.out
+        assert "telegram" in captured.out
+        assert "token" in captured.out
+
+    def test_shows_setup_wizard_hint(self, capsys):
+        """Output includes setup wizard command."""
+        show_token_help()
+        captured = capsys.readouterr()
+        assert "python run.py --setup" in captured.out
+
+    def test_shows_wiki_url(self, capsys):
+        """Output includes the help wiki URL."""
+        show_token_help()
+        captured = capsys.readouterr()
+        assert "https://github.com/cyneric/addarr/wiki" in captured.out


### PR DESCRIPTION
## Summary

- Added **141 new tests** across 4 new test files and 2 gap-filled existing files, closing the coverage gap for 5 source files previously excluded from `.coveragerc`
- Removed exclusions from `.coveragerc` so `fail_under=100` now enforces coverage on `main.py`, `wizard.py`, `config_handler.py`, `prerun.py`, and `splash.py`
- **1380 total tests, 4723 statements, 100% coverage** — no production code changed

### New test files
| File | Tests | Covers |
|------|-------|--------|
| `tests/test_utils/test_splash.py` | 29 | `src/utils/splash.py` — splash screen, version, welcome, token help |
| `tests/test_utils/test_config_handler.py` | 25 | `src/utils/config_handler.py` — YAML config CRUD, backup, global instance |
| `tests/test_utils/test_prerun.py` | 41 | `src/utils/prerun.py` — dependency checking, config existence, colorama handling |
| `tests/test_main.py` | 31 | `src/main.py` — AddarrBot init/start/stop, handler registration, signal handling |

### Gap-filled existing tests
| File | Added | Result |
|------|-------|--------|
| `tests/test_setup/test_wizard.py` | +12 tests | wizard.py: 69% → 100% |
| `tests/test_setup/test_service_config.py` | +3 tests | service_config.py: 96% → 100% branch |

## Test plan
- [x] `pytest --cov=src --cov-report=term-missing --tb=short -q` — 1380 passed, 100% coverage
- [x] `flake8 .` — 0 lint errors
- [x] Review pass: find-bugs, code-simplifier, DRY review — 4 issues found and fixed

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)