### PR TITLE
Add architecture tests (PyTestArch + AST structural checks)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,11 @@ Addarr Refresh is a Telegram bot for managing media collections through Radarr (
 
 These patterns avoid triggering permission prompts in Claude Code:
 
-- **Avoid combining `cd` with `git`** — prefer `git -C <path>` instead
+- **Avoid `cd && command` compound patterns entirely** — this applies to ALL commands, not just git. Use `git -C <path>` for git, and absolute paths or tool `path` parameters for everything else
 - **Avoid `$()` and backtick command substitution** — prefer writing content to a temp file first, then referencing it (e.g., `gh issue create --body-file /tmp/body.md` instead of inline `--body`)
 - **Avoid shell glob expansion in paths** (e.g., `translations/addarr.*.yml`) — prefer listing files explicitly
 - **Avoid backslash escapes in commands** — prefer quotes over escaping spaces/special characters
+- **Never use `find`, `grep`, or `rg` via Bash** — use the dedicated Glob and Grep tools instead (this includes subagents/Explore agents)
 - **Use `PYTHONIOENCODING=utf-8`** when running `python run.py --validate-i18n` (Windows emoji encoding)
 
 ## Commands

--- a/docs/issues/issue-127/TASKS.md
+++ b/docs/issues/issue-127/TASKS.md
@@ -1,0 +1,91 @@
+# Issue #127: Architecture Tests (PyTestArch + AST-Based Structural Checks)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enforce layer boundaries and structural conventions with automated tests that run in CI.
+
+**Ref:** [plan.md](plan.md) for full analysis, design decisions, and API reference.
+
+---
+
+### Phase 1: Layer Boundary Tests — PyTestArch (1 task)
+
+**Goal:** Install pytestarch and enforce the 6 layer dependency rules via import analysis.
+
+- [x] **1.1** Set up PyTestArch infrastructure and write layer boundary tests
+    - **Context:**
+        - **Why:** Layer boundaries (handlers -> services -> api) are documented but not enforced. Violations like the circular import fixed in #110 should be caught automatically.
+        - **Architecture:** PyTestArch scans real source files on disk and builds an import graph. Tests use `Rule` fluent API to assert import direction constraints. Runs as normal pytest tests — no special CI step needed.
+        - **Key refs:**
+            - `src/bot/handlers/` (11 handler files), `src/services/` (8 service files), `src/api/` (6 client files)
+            - `src/config/settings.py` (config layer), `src/utils/` (utility layer)
+            - `tests/conftest.py` (existing test infrastructure — architecture tests don't need config mocking)
+            - Plan section "PyTestArch API Reference" for exact API patterns
+        - **Watch out:**
+            - PyTestArch needs the **real** `src/` directory path, not mocked modules
+            - `get_evaluable_architecture(project_root, source_root)` — first arg is project root (for distinguishing internal/external), second is the source dir to scan
+            - Handler-to-handler imports (e.g., `@require_auth` from `auth.py`) are allowed — the rule is handlers must not import `src.api.*` directly
+            - Module paths in rules use dotted notation: `"src.bot.handlers"` not `"src/bot/handlers"`
+    - **Scope:** New dependency, test directory, conftest fixtures, 7 layer boundary tests
+    - **Touches:**
+        - Modify: `requirements-test.txt`
+        - Create: `tests/test_architecture/__init__.py`
+        - Create: `tests/test_architecture/conftest.py`
+        - Create: `tests/test_architecture/test_layer_boundaries.py`
+    - **Success:** `pytest tests/test_architecture/test_layer_boundaries.py -v` — all 7 tests pass
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - PyTestArch module names depend on the first arg to `get_evaluable_architecture` — pass `SRC_ROOT` as both args to get `src.*` dotted paths matching Python import convention
+        - PyTestArch's parser doesn't specify `encoding='utf-8'` when reading files, causing UnicodeDecodeError on Windows (cp1252) with emoji-containing source files. Monkey-patched `Parser._parse_file` in conftest for Windows compatibility.
+        - Split utils into two separate tests (handlers + services) instead of one combined rule — cleaner failure messages
+    - **Key Changes:**
+        - Added `pytestarch>=2.0.0` to `requirements-test.txt`
+        - Created `tests/test_architecture/` with conftest.py (fixtures + Windows monkey-patch) and test_layer_boundaries.py (7 tests)
+    - **Notes:** Watch for pytestarch upstream fix for UTF-8 encoding — can remove monkey-patch when fixed
+
+---
+
+### Phase 2: Structural Convention Tests — AST-Based (1 task)
+
+**Goal:** Enforce handler/service/client structural patterns and config access conventions using stdlib `ast`.
+
+- [x] **2.1** Write AST-based structural convention tests
+    - **Context:**
+        - **Why:** Structural conventions (singleton pattern, required methods, config access) are documented in CLAUDE.md but a new contributor could easily miss them. AST tests make conventions executable.
+        - **Architecture:** Parse source files with `ast.parse()`, walk the tree to find class definitions and method names. No imports of `src.*` needed — pure static analysis on file contents. Helper functions shared across tests in the same file.
+        - **Key refs:**
+            - `src/bot/handlers/*.py` — 11 handler classes, all have `get_handler()` method
+            - `src/services/*.py` — 8 singleton classes
+            - `src/api/radarr.py:20` — `RadarrClient(BaseApiClient)` pattern
+            - `src/api/transmission.py:16` — `TransmissionClient` (no BaseApiClient inheritance — excluded)
+    - **Scope:** 4 convention tests in a single test file with shared AST helpers
+    - **Touches:**
+        - Create: `tests/test_architecture/test_conventions.py`
+        - Modify: `src/utils/validation.py` (fixed 2 bracket access violations)
+    - **Success:** `pytest tests/test_architecture/test_conventions.py -v` — all 4 tests pass
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - Config bracket access check surfaced 2 real violations in `validation.py` (lines 163, 172) — `config['admins']` and `config['allow_list']` were guarded by `.get()` above but used brackets in the f-string. Fixed to `.get()` with defaults.
+        - Using `ast.iter_child_nodes(tree)` instead of `ast.walk(tree)` for class discovery ensures only top-level classes are found (not nested ones)
+    - **Key Changes:**
+        - Created `tests/test_architecture/test_conventions.py` with 4 tests + 5 AST helper functions
+        - Fixed `src/utils/validation.py:163,172` — bracket access -> `.get()` with defaults
+    - **Notes:** SINGLETON_CLASSES set must be updated when new services are added
+
+---
+
+### Phase 3: Integration Verification (1 task)
+
+**Goal:** Confirm architecture tests integrate cleanly with the full test suite.
+
+- [x] **3.1** Run full suite and coverage check
+    - **Context:**
+        - **Why:** New tests must not break existing tests or interfere with the config mock injection in `tests/conftest.py`.
+        - **Architecture:** Architecture tests are pure static analysis — they don't import `src.*` modules at runtime, so they shouldn't conflict with the mock config injection.
+    - **Scope:** Full test suite run, lint check
+    - **Touches:** No file changes
+    - **Success:** Full suite green (1408 passed), all 11 architecture tests pass, flake8 clean
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - Architecture tests run cleanly alongside existing tests — no conflicts with mock config injection since they only do static file analysis
+    - **Key Changes:** None (verification only)

--- a/docs/issues/issue-127/plan.md
+++ b/docs/issues/issue-127/plan.md
@@ -1,0 +1,459 @@
+# Architecture Tests (PyTestArch + AST-Based Structural Checks) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add automated architecture tests that enforce layer boundaries and structural conventions, catching violations in CI before they reach code review.
+
+**Architecture:** Two complementary approaches in a single test directory: PyTestArch for import-level layer dependency rules (using its fluent `Rule` and `LayerRule` APIs), and stdlib `ast`-based pytest tests for structural pattern verification (method existence, singleton pattern, config access). All tests run as part of the normal `pytest` suite.
+
+**Tech Stack:** `pytestarch` (new dependency in `requirements-test.txt`), stdlib `ast` module, `pytest`
+
+---
+
+## Context
+
+### Codebase Layers
+
+| Layer | Module Root | Contents |
+|-------|------------|----------|
+| **Handlers** | `src.bot.handlers` | 11 handler classes (auth, start, media, delete, library, preferences, settings, system, help, transmission, sabnzbd) |
+| **Services** | `src.services` | 8 service/scheduler classes (media, health, translation, transmission, sabnzbd, preferences, notification, scheduler) |
+| **API Clients** | `src.api` | 6 clients: 3 media (radarr, sonarr, lidarr) inherit `BaseApiClient`; 2 download (transmission, sabnzbd) standalone; 1 abstract base |
+| **Config** | `src.config` | `Config` singleton in `settings.py` |
+| **Utils** | `src.utils` | Logger, backup, chat, config_handler, error_handler, helpers, prerun, splash, validation, validate_translations |
+| **Models** | `src.models` | Data models (media, notification) |
+| **Bot core** | `src.bot` (excl. handlers) | `commands.py`, `keyboards.py`, `states.py` |
+
+### Pragmatic Design Decisions
+
+These decisions were confirmed during analysis:
+
+1. **`search()` check scoped to `BaseApiClient` subclasses only.** TransmissionClient and SabnzbdClient are download clients that don't inherit `BaseApiClient` and don't implement search — this is intentional, not a gap.
+
+2. **Config bracket access check excludes `src/setup/` and `src/api/base.py`.** Setup code legitimately manipulates config during interactive setup. `base.py` accesses `self.config` (a pre-extracted service dict) with brackets, which is the established pattern for API clients. The check targets module-level `config["..."]` access in business logic code.
+
+3. **Handler cross-imports allowed for `auth.py` decorator and shared state.** The `@require_auth` decorator from `auth.py` and state constants (e.g., `SEARCHING`, `SELECTING`) are shared infrastructure. The layer rule "handlers must not import API clients directly" is the meaningful boundary — handler-to-handler imports within `src.bot.handlers` are acceptable.
+
+### Current Compliance (Verified)
+
+All proposed rules **currently pass** against the codebase:
+- No services import handlers
+- No API clients import handlers or services
+- No utils or config import handlers or services
+- No handlers import API clients directly (all go through services)
+- All 11 handler classes have `get_handler()`
+- All 8 service classes implement `__new__()` (singleton)
+- All 3 `BaseApiClient` subclasses implement `search()`
+
+### File Structure
+
+```
+tests/
+  test_architecture/
+    __init__.py
+    conftest.py              # evaluable + layered_architecture fixtures
+    test_layer_boundaries.py # PyTestArch layer rules
+    test_conventions.py      # ast-based structural checks
+```
+
+### PyTestArch API Reference
+
+```python
+# Evaluable architecture (session-scoped fixture)
+from pytestarch import get_evaluable_architecture
+evaluable = get_evaluable_architecture(project_root, source_root)
+
+# Module-level rules (for import direction checks)
+from pytestarch import Rule
+rule = (
+    Rule()
+    .modules_that()
+    .are_sub_modules_of("src.services")
+    .should_not()
+    .import_modules_that()
+    .are_sub_modules_of("src.bot.handlers")
+)
+rule.assert_applies(evaluable)
+
+# Layer-level rules (for layer boundary checks)
+from pytestarch import LayeredArchitecture, LayerRule
+arch = (
+    LayeredArchitecture()
+    .layer("handlers").containing_modules(["src.bot.handlers"])
+    .layer("services").containing_modules(["src.services"])
+    .layer("api").containing_modules(["src.api"])
+)
+rule = (
+    LayerRule()
+    .based_on(arch)
+    .layers_that()
+    .are_named("api")
+    .should_not()
+    .access_layers_that()
+    .are_named("handlers")
+)
+rule.assert_applies(evaluable)
+```
+
+### Existing Test Infrastructure
+
+- Root `tests/conftest.py` injects `MockConfig` into `sys.modules` before any `src` imports
+- `tests/conftest.py` already resets all singletons between tests
+- Architecture tests don't need config mocking — they inspect code structure, not runtime behavior
+- PyTestArch needs the real source files on disk (not mocked modules), so we point it at the `src/` directory directly
+
+---
+
+## Phase 1: Setup & Layer Boundary Tests (PyTestArch)
+
+### Task 1.1: Add pytestarch dependency
+
+**Files:**
+- Modify: `requirements-test.txt`
+
+**What:** Add `pytestarch>=2.0.0` to `requirements-test.txt` and install it.
+
+### Task 1.2: Create test directory and conftest with PyTestArch fixtures
+
+**Files:**
+- Create: `tests/test_architecture/__init__.py`
+- Create: `tests/test_architecture/conftest.py`
+
+**What:** Set up the test directory and conftest with two session-scoped fixtures:
+1. `evaluable` — calls `get_evaluable_architecture()` pointing at the project root and `src/` directory
+2. `layered_architecture` — defines the five layers (handlers, services, api, config, utils)
+
+**conftest.py pattern:**
+```python
+import os
+import pytest
+from pytestarch import get_evaluable_architecture, LayeredArchitecture
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+SRC_ROOT = os.path.join(PROJECT_ROOT, "src")
+
+
+@pytest.fixture(scope="session")
+def evaluable():
+    return get_evaluable_architecture(PROJECT_ROOT, SRC_ROOT)
+
+
+@pytest.fixture(scope="session")
+def layered_architecture():
+    return (
+        LayeredArchitecture()
+        .layer("handlers").containing_modules(["src.bot.handlers"])
+        .layer("services").containing_modules(["src.services"])
+        .layer("api").containing_modules(["src.api"])
+        .layer("config").containing_modules(["src.config"])
+        .layer("utils").containing_modules(["src.utils"])
+    )
+```
+
+### Task 1.3: Write layer boundary tests
+
+**Files:**
+- Create: `tests/test_architecture/test_layer_boundaries.py`
+
+**What:** Write one test per layer boundary rule using PyTestArch's `Rule` API. Each test should have a descriptive docstring explaining what it enforces and why.
+
+**Rules to implement (5 tests):**
+
+1. `test_services_do_not_import_handlers` — Services must not depend on the handler layer
+2. `test_api_clients_do_not_import_handlers` — API clients must not depend on handlers
+3. `test_api_clients_do_not_import_services` — API clients must not depend on services
+4. `test_utils_do_not_import_handlers_or_services` — Utils must not depend on handlers or services
+5. `test_config_does_not_import_handlers_or_services` — Config must not depend on handlers or services
+
+**Note:** The issue also mentions "handlers must not import API clients directly." This rule uses the `Rule` API (not `LayerRule`) since it's about a specific import direction between two modules, and the handler layer is allowed to import services (which sit between handlers and API).
+
+6. `test_handlers_do_not_import_api_clients_directly` — Handlers should go through services, never import `src.api.*` directly
+
+**Test pattern:**
+```python
+from pytestarch import Rule
+
+def test_services_do_not_import_handlers(evaluable):
+    """Services must not depend on the handler layer.
+
+    The service layer provides business logic consumed by handlers.
+    Reverse dependencies would create circular imports and violate
+    the handlers -> services -> api layering.
+    """
+    rule = (
+        Rule()
+        .modules_that()
+        .are_sub_modules_of("src.services")
+        .should_not()
+        .import_modules_that()
+        .are_sub_modules_of("src.bot.handlers")
+    )
+    rule.assert_applies(evaluable)
+```
+
+### Task 1.4: Verify all layer boundary tests pass
+
+**What:** Run `pytest tests/test_architecture/test_layer_boundaries.py -v` and confirm all 6 tests pass against the current codebase. If any fail, investigate whether it's a real violation or a PyTestArch configuration issue (e.g., module path resolution).
+
+---
+
+## Phase 2: Structural Convention Tests (AST-Based)
+
+### Task 2.1: Write handler `get_handler()` convention test
+
+**Files:**
+- Create: `tests/test_architecture/test_conventions.py`
+
+**What:** Use `ast` module to parse each Python file in `src/bot/handlers/` (excluding `__init__.py`), find all classes ending in `Handler`, and verify each has a `get_handler` method defined.
+
+**Pattern:**
+```python
+import ast
+import os
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+HANDLERS_DIR = os.path.join(PROJECT_ROOT, "src", "bot", "handlers")
+SERVICES_DIR = os.path.join(PROJECT_ROOT, "src", "services")
+API_DIR = os.path.join(PROJECT_ROOT, "src", "api")
+
+
+def _get_python_files(directory):
+    """Get all .py files in directory, excluding __init__.py."""
+    return [
+        os.path.join(directory, f)
+        for f in sorted(os.listdir(directory))
+        if f.endswith(".py") and f != "__init__.py"
+    ]
+
+
+def _get_classes_in_file(filepath):
+    """Parse a file and return all class definitions."""
+    with open(filepath, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=filepath)
+    return [node for node in ast.walk(tree) if isinstance(node, ast.ClassDef)]
+
+
+def _class_has_method(class_node, method_name):
+    """Check if a class AST node defines a method with the given name."""
+    return any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == method_name
+        for node in class_node.body
+    )
+
+
+def test_all_handlers_have_get_handler():
+    """Every *Handler class in src/bot/handlers/ must expose get_handler().
+
+    Handlers register themselves with the bot by returning ConversationHandler
+    or CommandHandler instances from get_handler(). Missing this method means
+    the handler can't be registered.
+    """
+    missing = []
+    for filepath in _get_python_files(HANDLERS_DIR):
+        for cls in _get_classes_in_file(filepath):
+            if cls.name.endswith("Handler"):
+                if not _class_has_method(cls, "get_handler"):
+                    filename = os.path.basename(filepath)
+                    missing.append(f"{filename}:{cls.name}")
+
+    assert not missing, (
+        f"Handler classes missing get_handler(): {', '.join(missing)}"
+    )
+```
+
+### Task 2.2: Write service singleton convention test
+
+**Files:**
+- Modify: `tests/test_architecture/test_conventions.py`
+
+**What:** Parse each file in `src/services/`, find classes ending in `Service` OR named `JobScheduler`, verify each implements `__new__()`.
+
+**Service classes to check (from codebase):**
+- MediaService, HealthService, TranslationService, TransmissionService, SABnzbdService, PreferencesService, NotificationService, JobScheduler
+
+**The test uses a set of known singleton class names** rather than a suffix match, because `JobScheduler` doesn't follow the `*Service` naming convention but is architecturally a singleton service.
+
+```python
+SINGLETON_CLASSES = {
+    "MediaService", "HealthService", "TranslationService",
+    "TransmissionService", "SABnzbdService", "PreferencesService",
+    "NotificationService", "JobScheduler",
+}
+
+
+def test_all_services_implement_singleton():
+    """Every service class must implement __new__() for singleton pattern.
+
+    Services are singletons to maintain shared state (e.g., API client
+    instances, cached translations). Missing __new__() means multiple
+    instances could be created, causing state inconsistency.
+    """
+    missing = []
+    for filepath in _get_python_files(SERVICES_DIR):
+        for cls in _get_classes_in_file(filepath):
+            if cls.name in SINGLETON_CLASSES:
+                if not _class_has_method(cls, "__new__"):
+                    filename = os.path.basename(filepath)
+                    missing.append(f"{filename}:{cls.name}")
+
+    assert not missing, (
+        f"Service classes missing __new__() singleton: {', '.join(missing)}"
+    )
+```
+
+### Task 2.3: Write API client `search()` convention test
+
+**Files:**
+- Modify: `tests/test_architecture/test_conventions.py`
+
+**What:** Parse files in `src/api/`, find classes that inherit from `BaseApiClient` (check `ast.ClassDef.bases` for the name `BaseApiClient`), and verify each implements `search()`.
+
+**Scoped to `BaseApiClient` subclasses only** — TransmissionClient and SabnzbdClient don't inherit from it and are intentionally excluded.
+
+```python
+def _class_inherits_from(class_node, base_name):
+    """Check if a class inherits from a given base class name."""
+    for base in class_node.bases:
+        if isinstance(base, ast.Name) and base.id == base_name:
+            return True
+        if isinstance(base, ast.Attribute) and base.attr == base_name:
+            return True
+    return False
+
+
+def test_all_api_clients_implement_search():
+    """Every BaseApiClient subclass must implement search().
+
+    Media API clients (Radarr, Sonarr, Lidarr) inherit from BaseApiClient
+    which declares search() as abstract. This test catches any new client
+    that forgets to implement it.
+
+    Download clients (Transmission, SABnzbd) don't inherit BaseApiClient
+    and are intentionally excluded.
+    """
+    missing = []
+    for filepath in _get_python_files(API_DIR):
+        for cls in _get_classes_in_file(filepath):
+            if _class_inherits_from(cls, "BaseApiClient"):
+                if not _class_has_method(cls, "search"):
+                    filename = os.path.basename(filepath)
+                    missing.append(f"{filename}:{cls.name}")
+
+    assert not missing, (
+        f"BaseApiClient subclasses missing search(): {', '.join(missing)}"
+    )
+```
+
+### Task 2.4: Write config bracket access convention test
+
+**Files:**
+- Modify: `tests/test_architecture/test_conventions.py`
+
+**What:** Use `ast` to walk all `.py` files under `src/` and find `Subscript` nodes where the value is a `Name` node with id `config` — i.e., `config["anything"]` or `config['anything']`.
+
+**Exclusions:**
+- `src/setup/` — interactive setup legitimately uses bracket access to build config
+- `src/api/base.py` — accesses `self.config` (pre-extracted service dict), not the global config
+- `src/config/settings.py` — the Config class itself defines `__getitem__`
+
+**What to flag:** Any `config["..."]` or `config['...']` in business logic code (`src/bot/`, `src/services/`, `src/api/` excluding base.py, `src/utils/`, `src/models/`).
+
+```python
+SRC_DIR = os.path.join(PROJECT_ROOT, "src")
+
+# Directories/files excluded from bracket access check
+BRACKET_ACCESS_EXCLUDED = {
+    os.path.join(SRC_DIR, "setup"),
+    os.path.join(SRC_DIR, "api", "base.py"),
+    os.path.join(SRC_DIR, "config", "settings.py"),
+}
+
+
+def _is_excluded_from_bracket_check(filepath):
+    """Check if a filepath is excluded from the bracket access rule."""
+    for excluded in BRACKET_ACCESS_EXCLUDED:
+        if filepath.startswith(excluded):
+            return True
+    return False
+
+
+def _find_config_bracket_access(filepath):
+    """Find config['key'] or config['key'] patterns via AST."""
+    with open(filepath, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=filepath)
+
+    violations = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "config"
+        ):
+            violations.append(node.lineno)
+    return violations
+
+
+def test_no_config_bracket_access_in_business_logic():
+    """Business logic must use config.get() instead of config['key'].
+
+    Bracket access raises KeyError on missing keys with no fallback.
+    Using config.get(key, default) provides graceful degradation.
+
+    Excluded: src/setup/ (builds config interactively),
+    src/api/base.py (accesses self.config service dict),
+    src/config/settings.py (defines __getitem__).
+    """
+    violations = []
+    for root, dirs, files in os.walk(SRC_DIR):
+        # Skip __pycache__
+        dirs[:] = [d for d in dirs if d != "__pycache__"]
+        for filename in sorted(files):
+            if not filename.endswith(".py"):
+                continue
+            filepath = os.path.join(root, filename)
+            if _is_excluded_from_bracket_check(filepath):
+                continue
+            lines = _find_config_bracket_access(filepath)
+            if lines:
+                rel = os.path.relpath(filepath, PROJECT_ROOT)
+                for line in lines:
+                    violations.append(f"{rel}:{line}")
+
+    assert not violations, (
+        f"Found config['key'] bracket access (use config.get() instead):\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+```
+
+**Important:** This test may surface existing violations. If it does, we need to evaluate whether they're real issues or acceptable patterns, and either fix them or add targeted exclusions before the test can pass.
+
+### Task 2.5: Verify all convention tests pass
+
+**What:** Run `pytest tests/test_architecture/test_conventions.py -v` and confirm all 4 convention tests pass. Handle any failures:
+- If the config bracket test reveals violations, either fix the violations or add narrowly-scoped exclusions with comments explaining why.
+- All other convention tests should pass based on analysis.
+
+---
+
+## Phase 3: Integration & Verification
+
+### Task 3.1: Run full test suite
+
+**What:** Run `pytest --tb=short -q` to verify the new architecture tests integrate cleanly with the existing suite and don't break anything.
+
+### Task 3.2: Run coverage on the new test files
+
+**What:** Run `pytest tests/test_architecture/ --cov=tests.test_architecture --cov-report=term-missing -v` to verify the test files themselves are well-covered. (Note: architecture tests test source structure, not runtime code, so we measure coverage of the test module itself, not `src/`.)
+
+---
+
+## Summary
+
+| Phase | Tasks | Tests Added |
+|-------|-------|-------------|
+| 1. Layer Boundaries | 1.1–1.4 | 6 PyTestArch rule tests |
+| 2. Structural Conventions | 2.1–2.5 | 4 AST-based convention tests |
+| 3. Integration | 3.1–3.2 | Full suite verification |
+
+**Total: 10 new tests, 1 new dependency, 4 new files.**

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ pytest-cov>=4.1.0
 pytest-mock>=3.12.0
 aioresponses>=0.7.6
 freezegun>=1.3.0
+pytestarch>=2.0.0

--- a/src/utils/validation.py
+++ b/src/utils/validation.py
@@ -14,7 +14,10 @@ import subprocess
 from typing import Any, Dict, List, Optional, Set
 from colorama import Fore, Style
 from .error_handler import ValidationError
+from .logger import get_logger
 from ..config.settings import config
+
+logger = get_logger("addarr.validation")
 
 
 def check_dependencies() -> bool:
@@ -160,20 +163,20 @@ def _check_security_settings():
     # Check admin mode
     if security.get("enableAdmin"):
         if config.get("admins"):
-            print(f"{Fore.GREEN}✅ Admin mode enabled with {len(config.get('admins', []))} admin(s)")
+            logger.info("✅ Admin mode enabled with %d admin(s)", len(config.get("admins", [])))
         else:
-            print(f"{Fore.YELLOW}⚠️ Admin mode enabled but no admins configured")
+            logger.warning("⚠️ Admin mode enabled but no admins configured")
     else:
-        print(f"{Fore.BLUE}ℹ️ Admin mode disabled")
+        logger.info("ℹ️ Admin mode disabled")
 
     # Check allowlist
     if security.get("enableAllowlist"):
         if config.get("allow_list"):
-            print(f"{Fore.GREEN}✅ Allowlist enabled with {len(config.get('allow_list', []))} user(s)")
+            logger.info("✅ Allowlist enabled with %d user(s)", len(config.get("allow_list", [])))
         else:
-            print(f"{Fore.YELLOW}⚠️ Allowlist enabled but no users configured")
+            logger.warning("⚠️ Allowlist enabled but no users configured")
     else:
-        print(f"{Fore.BLUE}ℹ️ Allowlist disabled")
+        logger.info("ℹ️ Allowlist disabled")
 
 
 def parse_requirements(filename: str = "requirements.txt") -> List[str]:

--- a/src/utils/validation.py
+++ b/src/utils/validation.py
@@ -160,7 +160,7 @@ def _check_security_settings():
     # Check admin mode
     if security.get("enableAdmin"):
         if config.get("admins"):
-            print(f"{Fore.GREEN}✅ Admin mode enabled with {len(config['admins'])} admin(s)")
+            print(f"{Fore.GREEN}✅ Admin mode enabled with {len(config.get('admins', []))} admin(s)")
         else:
             print(f"{Fore.YELLOW}⚠️ Admin mode enabled but no admins configured")
     else:
@@ -169,7 +169,7 @@ def _check_security_settings():
     # Check allowlist
     if security.get("enableAllowlist"):
         if config.get("allow_list"):
-            print(f"{Fore.GREEN}✅ Allowlist enabled with {len(config['allow_list'])} user(s)")
+            print(f"{Fore.GREEN}✅ Allowlist enabled with {len(config.get('allow_list', []))} user(s)")
         else:
             print(f"{Fore.YELLOW}⚠️ Allowlist enabled but no users configured")
     else:

--- a/tests/test_architecture/conftest.py
+++ b/tests/test_architecture/conftest.py
@@ -23,8 +23,6 @@ SRC_ROOT = os.path.join(PROJECT_ROOT, "src")
 # The upstream _parse_file opens files without specifying encoding, which
 # defaults to cp1252 on Windows and chokes on emoji characters in source.
 if sys.platform == "win32":
-    _original_parse_file = Parser._parse_file
-
     def _parse_file_utf8(self, path):
         absolute_path = path.resolve()
         if self._file_should_be_parsed(absolute_path):

--- a/tests/test_architecture/conftest.py
+++ b/tests/test_architecture/conftest.py
@@ -1,0 +1,66 @@
+"""
+Architecture test fixtures.
+
+Provides PyTestArch evaluable architecture and layer definitions
+for import dependency rule tests.
+"""
+
+import ast
+import os
+import sys
+
+import pytest
+from pytestarch import LayeredArchitecture, get_evaluable_architecture
+from pytestarch.eval_structure_generation.file_import.parser import (
+    NamedModule,
+    Parser,
+)
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+SRC_ROOT = os.path.join(PROJECT_ROOT, "src")
+
+# Monkey-patch PyTestArch's file parser to use UTF-8 encoding on Windows.
+# The upstream _parse_file opens files without specifying encoding, which
+# defaults to cp1252 on Windows and chokes on emoji characters in source.
+if sys.platform == "win32":
+    _original_parse_file = Parser._parse_file
+
+    def _parse_file_utf8(self, path):
+        absolute_path = path.resolve()
+        if self._file_should_be_parsed(absolute_path):
+            with open(absolute_path, encoding="utf-8") as file:
+                code = file.read()
+            module_name = self._get_module_name(path)
+            self._all_modules.append(module_name)
+            return NamedModule(ast.parse(code), module_name)
+        return None
+
+    Parser._parse_file = _parse_file_utf8
+
+
+@pytest.fixture(scope="session")
+def evaluable():
+    """Scan src/ and build an evaluable import graph for PyTestArch rules.
+
+    Using SRC_ROOT as both root and source path so module names match
+    the import-style dotted paths (e.g., src.bot.handlers, src.services).
+    """
+    return get_evaluable_architecture(SRC_ROOT, SRC_ROOT)
+
+
+@pytest.fixture(scope="session")
+def layered_architecture():
+    """Define the five architectural layers and their module roots."""
+    return (
+        LayeredArchitecture()
+        .layer("handlers")
+        .containing_modules(["src.bot.handlers"])
+        .layer("services")
+        .containing_modules(["src.services"])
+        .layer("api")
+        .containing_modules(["src.api"])
+        .layer("config")
+        .containing_modules(["src.config"])
+        .layer("utils")
+        .containing_modules(["src.utils"])
+    )

--- a/tests/test_architecture/test_conventions.py
+++ b/tests/test_architecture/test_conventions.py
@@ -1,0 +1,207 @@
+"""
+Structural convention tests using stdlib ast.
+
+Verifies that handler, service, and API client classes follow
+the project's established patterns: required methods, singleton
+pattern, and config access conventions.
+"""
+
+import ast
+import os
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+SRC_DIR = os.path.join(PROJECT_ROOT, "src")
+HANDLERS_DIR = os.path.join(SRC_DIR, "bot", "handlers")
+SERVICES_DIR = os.path.join(SRC_DIR, "services")
+API_DIR = os.path.join(SRC_DIR, "api")
+
+# Service classes that must implement the singleton pattern.
+# Explicit set because JobScheduler doesn't follow *Service naming.
+SINGLETON_CLASSES = {
+    "MediaService",
+    "HealthService",
+    "TranslationService",
+    "TransmissionService",
+    "SABnzbdService",
+    "PreferencesService",
+    "NotificationService",
+    "JobScheduler",
+}
+
+# Paths excluded from the config bracket access check.
+# Setup code legitimately builds config interactively.
+# base.py accesses self.config (pre-extracted service dict).
+# settings.py defines __getitem__ on the Config class.
+BRACKET_ACCESS_EXCLUDED = {
+    os.path.join(SRC_DIR, "setup"),
+    os.path.join(SRC_DIR, "api", "base.py"),
+    os.path.join(SRC_DIR, "config", "settings.py"),
+}
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_python_files(directory):
+    """Get all .py files in a directory, excluding __init__.py."""
+    return [
+        os.path.join(directory, f)
+        for f in sorted(os.listdir(directory))
+        if f.endswith(".py") and f != "__init__.py"
+    ]
+
+
+def _get_classes_in_file(filepath):
+    """Parse a file and return all top-level class definitions."""
+    with open(filepath, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=filepath)
+    return [node for node in ast.iter_child_nodes(tree)
+            if isinstance(node, ast.ClassDef)]
+
+
+def _class_has_method(class_node, method_name):
+    """Check if a class AST node defines a method with the given name."""
+    return any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == method_name
+        for node in class_node.body
+    )
+
+
+def _class_inherits_from(class_node, base_name):
+    """Check if a class inherits from a given base class name."""
+    for base in class_node.bases:
+        if isinstance(base, ast.Name) and base.id == base_name:
+            return True
+        if isinstance(base, ast.Attribute) and base.attr == base_name:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_all_handlers_have_get_handler():
+    """Every *Handler class in src/bot/handlers/ must expose get_handler().
+
+    Handlers register themselves with the bot by returning ConversationHandler
+    or CommandHandler instances from get_handler(). Missing this method means
+    the handler can't be registered in AddarrBot._add_handlers().
+    """
+    missing = []
+    for filepath in _get_python_files(HANDLERS_DIR):
+        for cls in _get_classes_in_file(filepath):
+            if cls.name.endswith("Handler"):
+                if not _class_has_method(cls, "get_handler"):
+                    filename = os.path.basename(filepath)
+                    missing.append(f"{filename}:{cls.name}")
+
+    assert not missing, (
+        f"Handler classes missing get_handler(): {', '.join(missing)}"
+    )
+
+
+def test_all_services_implement_singleton():
+    """Every service class must implement __new__() for singleton pattern.
+
+    Services are singletons to maintain shared state (e.g., API client
+    instances, cached translations). Missing __new__() means multiple
+    instances could be created, causing state inconsistency.
+    """
+    missing = []
+    for filepath in _get_python_files(SERVICES_DIR):
+        for cls in _get_classes_in_file(filepath):
+            if cls.name in SINGLETON_CLASSES:
+                if not _class_has_method(cls, "__new__"):
+                    filename = os.path.basename(filepath)
+                    missing.append(f"{filename}:{cls.name}")
+
+    assert not missing, (
+        f"Service classes missing __new__() singleton: {', '.join(missing)}"
+    )
+
+
+def test_all_api_clients_implement_search():
+    """Every BaseApiClient subclass must implement search().
+
+    Media API clients (Radarr, Sonarr, Lidarr) inherit from BaseApiClient
+    which declares search() as abstract. This test catches any new client
+    that forgets to implement it.
+
+    Download clients (Transmission, SABnzbd) don't inherit BaseApiClient
+    and are intentionally excluded.
+    """
+    missing = []
+    for filepath in _get_python_files(API_DIR):
+        for cls in _get_classes_in_file(filepath):
+            if _class_inherits_from(cls, "BaseApiClient"):
+                if not _class_has_method(cls, "search"):
+                    filename = os.path.basename(filepath)
+                    missing.append(f"{filename}:{cls.name}")
+
+    assert not missing, (
+        f"BaseApiClient subclasses missing search(): {', '.join(missing)}"
+    )
+
+
+def _is_excluded_from_bracket_check(filepath):
+    """Check if a filepath is excluded from the bracket access rule."""
+    for excluded in BRACKET_ACCESS_EXCLUDED:
+        if filepath.startswith(excluded):
+            return True
+    return False
+
+
+def _find_config_bracket_access(filepath):
+    """Find config["key"] or config['key'] patterns via AST.
+
+    Detects ast.Subscript nodes where the value is a Name node
+    with id "config" — i.e., module-level config["..."] access.
+    """
+    with open(filepath, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=filepath)
+
+    violations = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "config"
+        ):
+            violations.append(node.lineno)
+    return violations
+
+
+def test_no_config_bracket_access_in_business_logic():
+    """Business logic must use config.get() instead of config["key"].
+
+    Bracket access raises KeyError on missing keys with no fallback.
+    Using config.get(key, default) provides graceful degradation.
+
+    Excluded: src/setup/ (builds config interactively),
+    src/api/base.py (accesses self.config service dict),
+    src/config/settings.py (defines __getitem__).
+    """
+    violations = []
+    for root, dirs, files in os.walk(SRC_DIR):
+        dirs[:] = [d for d in dirs if d != "__pycache__"]
+        for filename in sorted(files):
+            if not filename.endswith(".py"):
+                continue
+            filepath = os.path.join(root, filename)
+            if _is_excluded_from_bracket_check(filepath):
+                continue
+            lines = _find_config_bracket_access(filepath)
+            if lines:
+                rel = os.path.relpath(filepath, PROJECT_ROOT)
+                for line in lines:
+                    violations.append(f"{rel}:{line}")
+
+    assert not violations, (
+        "Found config['key'] bracket access (use config.get() instead):\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )

--- a/tests/test_architecture/test_conventions.py
+++ b/tests/test_architecture/test_conventions.py
@@ -151,7 +151,7 @@ def test_all_api_clients_implement_search():
 def _is_excluded_from_bracket_check(filepath):
     """Check if a filepath is excluded from the bracket access rule."""
     for excluded in BRACKET_ACCESS_EXCLUDED:
-        if filepath.startswith(excluded):
+        if filepath == excluded or filepath.startswith(excluded + os.sep):
             return True
     return False
 

--- a/tests/test_architecture/test_layer_boundaries.py
+++ b/tests/test_architecture/test_layer_boundaries.py
@@ -1,0 +1,138 @@
+"""
+Layer boundary tests using PyTestArch.
+
+Enforces the three-layer architecture: handlers -> services -> api.
+Lower layers must not depend on higher layers. Utilities and config
+must not depend on handlers or services.
+"""
+
+from pytestarch import Rule
+
+
+def test_services_do_not_import_handlers(evaluable):
+    """Services must not depend on the handler layer.
+
+    The service layer provides business logic consumed by handlers.
+    Reverse dependencies would create circular imports and violate
+    the handlers -> services -> api layering.
+    """
+    rule = (
+        Rule()
+        .modules_that()
+        .are_sub_modules_of("src.services")
+        .should_not()
+        .import_modules_that()
+        .are_sub_modules_of("src.bot.handlers")
+    )
+    rule.assert_applies(evaluable)
+
+
+def test_api_clients_do_not_import_handlers(evaluable):
+    """API clients must not depend on the handler layer.
+
+    API clients are the lowest layer — they talk to external services.
+    They should have no knowledge of how handlers orchestrate them.
+    """
+    rule = (
+        Rule()
+        .modules_that()
+        .are_sub_modules_of("src.api")
+        .should_not()
+        .import_modules_that()
+        .are_sub_modules_of("src.bot.handlers")
+    )
+    rule.assert_applies(evaluable)
+
+
+def test_api_clients_do_not_import_services(evaluable):
+    """API clients must not depend on the service layer.
+
+    Services aggregate API clients, not the other way around.
+    An API client importing a service would invert the dependency.
+    """
+    rule = (
+        Rule()
+        .modules_that()
+        .are_sub_modules_of("src.api")
+        .should_not()
+        .import_modules_that()
+        .are_sub_modules_of("src.services")
+    )
+    rule.assert_applies(evaluable)
+
+
+def test_utils_do_not_import_handlers(evaluable):
+    """Utilities must not depend on the handler layer.
+
+    Utils are shared infrastructure used across all layers.
+    Depending on handlers would create circular dependencies.
+    """
+    rule = (
+        Rule()
+        .modules_that()
+        .are_sub_modules_of("src.utils")
+        .should_not()
+        .import_modules_that()
+        .are_sub_modules_of("src.bot.handlers")
+    )
+    rule.assert_applies(evaluable)
+
+
+def test_utils_do_not_import_services(evaluable):
+    """Utilities must not depend on the service layer.
+
+    Utils are lower-level than services. Services may use utils,
+    but not vice versa.
+    """
+    rule = (
+        Rule()
+        .modules_that()
+        .are_sub_modules_of("src.utils")
+        .should_not()
+        .import_modules_that()
+        .are_sub_modules_of("src.services")
+    )
+    rule.assert_applies(evaluable)
+
+
+def test_config_does_not_import_handlers_or_services(evaluable):
+    """Config must not depend on handlers or services.
+
+    Config is foundational — nearly everything depends on it.
+    It must not create upward dependencies into business logic.
+    """
+    no_handlers = (
+        Rule()
+        .modules_that()
+        .are_sub_modules_of("src.config")
+        .should_not()
+        .import_modules_that()
+        .are_sub_modules_of("src.bot.handlers")
+    )
+    no_services = (
+        Rule()
+        .modules_that()
+        .are_sub_modules_of("src.config")
+        .should_not()
+        .import_modules_that()
+        .are_sub_modules_of("src.services")
+    )
+    no_handlers.assert_applies(evaluable)
+    no_services.assert_applies(evaluable)
+
+
+def test_handlers_do_not_import_api_clients_directly(evaluable):
+    """Handlers must not import API clients directly.
+
+    Handlers should access API clients through the service layer.
+    Direct imports bypass business logic and create tight coupling.
+    """
+    rule = (
+        Rule()
+        .modules_that()
+        .are_sub_modules_of("src.bot.handlers")
+        .should_not()
+        .import_modules_that()
+        .are_sub_modules_of("src.api")
+    )
+    rule.assert_applies(evaluable)


### PR DESCRIPTION
## Summary

Closes #127

Adds automated architecture tests to enforce layer boundaries and structural conventions. Catches violations in CI before they reach code review.

- **7 PyTestArch layer boundary tests** enforcing the handlers -> services -> api import direction (services don't import handlers, API clients don't import handlers or services, utils/config don't import handlers or services, handlers don't import API clients directly)
- **4 AST-based structural convention tests** verifying handler classes have `get_handler()`, services implement `__new__()` singleton, `BaseApiClient` subclasses implement `search()`, and no `config["key"]` bracket access in business logic
- **1 new dependency**: `pytestarch>=2.0.0` in `requirements-test.txt`
- **1 bug fix**: replaced 2 unsafe `config['key']` bracket accesses in `src/utils/validation.py` with safe `config.get('key', [])` calls (discovered by the new architecture test)
- **Windows compatibility**: monkey-patches PyTestArch's file parser to use UTF-8 encoding (upstream defaults to cp1252 on Windows, fails on emoji in source)

## Test plan

- [x] All 11 architecture tests pass locally (`pytest tests/test_architecture/ -v`)
- [x] Full test suite green (1408 passed)
- [x] flake8 clean on all new files
- [ ] CI passes (pytest, flake8, validate-i18n, Docker build)

Generated with [Claude Code](https://claude.com/claude-code)
