### PR TITLE
feat: add per-user rate limiting on commands and API calls

### DIFF
--- a/.claude/hooks/validate-bash.sh
+++ b/.claude/hooks/validate-bash.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Pre-tool hook: Validates Bash commands against Addarr shell conventions.
+# Blocks commands that use banned patterns to avoid permission prompts.
+# See CLAUDE.md "Shell Conventions" section.
+
+# Read JSON from stdin
+input=$(cat)
+
+# Extract the command field using python (jq not available on this system)
+command=$(echo "$input" | python -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('command',''))" 2>/dev/null)
+
+# If no command found, allow (non-Bash tool or empty)
+if [ -z "$command" ]; then
+  exit 0
+fi
+
+# 1. Block $() command substitution
+if echo "$command" | grep -qP '\$\('; then
+  echo "BLOCKED: \$() command substitution is banned. Write output to a temp file first, then reference it. Example: write commit msg to /tmp/msg.txt, then use 'git commit -F /tmp/msg.txt'" >&2
+  exit 2
+fi
+
+# 2. Block backtick command substitution
+if echo "$command" | grep -qP '`[^`]+`'; then
+  echo "BLOCKED: Backtick command substitution is banned. Write output to a temp file first, then reference it." >&2
+  exit 2
+fi
+
+# 3. Block cd && pattern (cd followed by && anywhere)
+if echo "$command" | grep -qP '^\s*cd\s.*&&'; then
+  echo "BLOCKED: 'cd && command' pattern is banned. Use absolute paths or 'git -C <path>' instead." >&2
+  exit 2
+fi
+
+# 4. Block bare find command (should use Glob tool)
+if echo "$command" | grep -qP '(^|\|)\s*find\s'; then
+  echo "BLOCKED: 'find' via Bash is banned. Use the Glob tool instead." >&2
+  exit 2
+fi
+
+# 5. Block bare grep/rg commands (should use Grep tool)
+if echo "$command" | grep -qP '(^|\|)\s*(grep|rg)\s'; then
+  echo "BLOCKED: 'grep'/'rg' via Bash is banned. Use the Grep tool instead." >&2
+  exit 2
+fi
+
+# 6. Block backslash escapes (prefer quotes over escaping spaces/special chars)
+if echo "$command" | grep -qP '\\[ !@#&()|;]'; then
+  echo "BLOCKED: Backslash escapes are banned. Use quotes instead of escaping spaces/special characters." >&2
+  exit 2
+fi
+
+# All checks passed
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,21 @@ Tests live in `tests/` mirroring `src/` structure. Key patterns:
 - **Translation mock**: `autouse=True` fixture patches `TranslationService._load_translations` so tests don't need YAML files.
 - **Config patching gotcha**: Module-level `from src.config.settings import config` binds at import time. To override in tests, patch at the import site: `patch("src.the_module.config", mock_config)` — replacing `sys.modules` won't affect modules that already imported `config`.
 
+### Architecture Tests
+
+Automated architecture tests in `tests/test_architecture/` enforce conventions at CI time:
+
+- **Layer boundaries** (`test_layer_boundaries.py`): PyTestArch import-direction rules. Services must not import handlers, API clients must not import handlers or services, utils/config must not import handlers or services, handlers must not import API clients directly.
+- **Structural conventions** (`test_conventions.py`): AST-based checks. All `*Handler` classes must have `get_handler()`, all service singletons must have `__new__()`, all `BaseApiClient` subclasses must have `search()`, no `config["key"]` bracket access in business logic (use `config.get()` instead).
+
+**When adding new services:** Update `SINGLETON_CLASSES` set in `tests/test_architecture/test_conventions.py`.
+
+**When adding new API clients inheriting `BaseApiClient`:** They must implement `search()` or the convention test will fail.
+
+**Config access rule:** `config["key"]` bracket access is banned in `src/` business logic (enforced by test). Use `config.get("key", default)` instead. Excluded from this rule: `src/setup/` (interactive config building), `src/api/base.py` (`self.config` service dict), `src/config/settings.py` (`__getitem__` definition).
+
+**PyTestArch on Windows:** The conftest monkey-patches PyTestArch's file parser to use UTF-8 encoding (upstream defaults to cp1252 on Windows, fails on emoji in source files).
+
 ## Lint Configuration
 
 Flake8 with max line length 88. Ignored rules: E203, E501, W503 (configured in `.flake8`).
@@ -160,7 +175,7 @@ All issue work follows a two-file workflow stored in `docs/issues/issue-<N>/`:
 2. Convert plan → `docs/issues/issue-<N>/TASKS.md` (via `/task-writer`)
 3. Implement tasks in order, checking off as completed
 
-**Existing examples:** issues 12, 17, 20, 21, 22, 67, 76, 77, 78, 79.
+**Existing examples:** issues 12, 17, 20, 21, 22, 67, 76, 77, 78, 79, 127.
 
 ## Docker
 

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -137,6 +137,20 @@ security:
   enableAdmin: false  # Enable admin features
   enableAllowlist: false  # Enable allowlist restriction
 
+# Rate Limiting Configuration
+rateLimit:
+  enable: false  # Set to true to enable rate limiting
+  limits:
+    search:
+      maxRequests: 10  # Max search requests per window
+      windowSeconds: 60  # Window duration in seconds
+    modify:
+      maxRequests: 5  # Max add/delete requests per window
+      windowSeconds: 60
+    auth:
+      maxRequests: 3  # Max auth attempts per window
+      windowSeconds: 300  # 5 minutes
+
 # Localization
 language: en-us  # Available: de-de, en-us, es-es, fr-fr, it-it, nl-be, pl-pl, pt-pt, ru-ru
 

--- a/docs/issues/issue-116/TASKS.md
+++ b/docs/issues/issue-116/TASKS.md
@@ -55,7 +55,7 @@
         - [GREEN] Add `"RateLimitService"` to `SINGLETON_CLASSES` in `tests/test_architecture/test_conventions.py`
     - **Success:** `pytest tests/test_services/test_rate_limit_service.py -v` all green, architecture tests pass, `python -m flake8 src/services/rate_limit.py` clean
 
-- [~] **1.2** Implement `@rate_limit` decorator with DummyHandler tests
+- [x] **1.2** Implement `@rate_limit` decorator with DummyHandler tests
     - **Context:**
         - **Why:** The decorator is the integration point between the service and handlers — it wraps handler methods to check limits before the handler body runs, returning a cooldown message when the limit is exceeded.
         - **Architecture:** Decorator factory `rate_limit(category: str)` returns a decorator that wraps `async def method(self, update, context)`. Follows `@require_auth` pattern exactly (see `src/bot/handlers/auth.py:36-50`). Lives in `src/services/rate_limit.py` alongside the service (not in handlers — the decorator is tightly coupled to the service, and handler→service imports are the correct layer direction).
@@ -89,7 +89,7 @@
 
 **Goal:** Wire the decorator into real handler methods, add translation keys, and verify everything works end-to-end.
 
-- [ ] **2.1** Add translation keys and apply `@rate_limit` to handler methods
+- [~] **2.1** Add translation keys and apply `@rate_limit` to handler methods
     - **Context:**
         - **Why:** The service and decorator are built — now wire them into the actual bot handlers and add the user-facing cooldown message in all supported languages.
         - **Architecture:** Import `rate_limit` from `src.services.rate_limit` in each handler. Stack BELOW `@require_auth` (auth runs first as outermost). For `auth.py`, `start_auth` has no `@require_auth` (it IS the auth flow) — apply `@rate_limit("auth")` directly. Translation key `RateLimitExceeded` uses `%(seconds)s` %-formatting (matches `TranslationService.get_text()` line 98).

--- a/docs/issues/issue-116/TASKS.md
+++ b/docs/issues/issue-116/TASKS.md
@@ -10,7 +10,7 @@
 
 **Goal:** Build the complete `RateLimitService` singleton with sliding window logic, config integration, and all supporting test infrastructure.
 
-- [~] **1.1** Implement RateLimitService core with sliding window and singleton pattern
+- [x] **1.1** Implement RateLimitService core with sliding window and singleton pattern
     - **Context:**
         - **Why:** No rate limiting exists — users can spam commands and overwhelm *arr APIs. This service tracks per-user request timestamps to enforce limits.
         - **Architecture:** Singleton service in `src/services/` following `TranslationService` pattern (`__new__` override, class-level state). In-memory sliding window: `{user_id: {category: [timestamps]}}`. `check(user_id, category)` prunes expired timestamps, checks count, records new timestamp if allowed. Returns `(allowed: bool, retry_after: int)`.
@@ -55,7 +55,7 @@
         - [GREEN] Add `"RateLimitService"` to `SINGLETON_CLASSES` in `tests/test_architecture/test_conventions.py`
     - **Success:** `pytest tests/test_services/test_rate_limit_service.py -v` all green, architecture tests pass, `python -m flake8 src/services/rate_limit.py` clean
 
-- [ ] **1.2** Implement `@rate_limit` decorator with DummyHandler tests
+- [~] **1.2** Implement `@rate_limit` decorator with DummyHandler tests
     - **Context:**
         - **Why:** The decorator is the integration point between the service and handlers — it wraps handler methods to check limits before the handler body runs, returning a cooldown message when the limit is exceeded.
         - **Architecture:** Decorator factory `rate_limit(category: str)` returns a decorator that wraps `async def method(self, update, context)`. Follows `@require_auth` pattern exactly (see `src/bot/handlers/auth.py:36-50`). Lives in `src/services/rate_limit.py` alongside the service (not in handlers — the decorator is tightly coupled to the service, and handler→service imports are the correct layer direction).

--- a/docs/issues/issue-116/TASKS.md
+++ b/docs/issues/issue-116/TASKS.md
@@ -1,0 +1,142 @@
+# Issue #116: Rate Limiting on Commands and API Calls
+
+**Plan:** [plan.md](plan.md)
+**Branch:** `feature/116-rate-limiting`
+**Issue:** https://github.com/Krypt0nBull3t/Addarr/issues/116
+
+---
+
+### Phase 1: RateLimitService + Config + Test Infrastructure (2 tasks)
+
+**Goal:** Build the complete `RateLimitService` singleton with sliding window logic, config integration, and all supporting test infrastructure.
+
+- [~] **1.1** Implement RateLimitService core with sliding window and singleton pattern
+    - **Context:**
+        - **Why:** No rate limiting exists — users can spam commands and overwhelm *arr APIs. This service tracks per-user request timestamps to enforce limits.
+        - **Architecture:** Singleton service in `src/services/` following `TranslationService` pattern (`__new__` override, class-level state). In-memory sliding window: `{user_id: {category: [timestamps]}}`. `check(user_id, category)` prunes expired timestamps, checks count, records new timestamp if allowed. Returns `(allowed: bool, retry_after: int)`.
+        - **Key refs:**
+            - `src/services/translation.py:20-33` — singleton pattern to follow
+            - `tests/conftest.py:190-229` — singleton reset fixture to update
+            - `tests/test_architecture/test_conventions.py:20-29` — `SINGLETON_CLASSES` set to update
+            - `src/config/settings.py:89` — `config.get()` API (not bracket access)
+        - **Watch out:**
+            - Config access: use `config.get("rateLimit", {})` not `config["rateLimit"]` (bracket access banned in business logic)
+            - `check()` must record the timestamp ONLY if the request is allowed (don't count blocked requests against the user)
+            - `time.time()` returns float — store as-is, compare with `>` not `>=` for window boundary
+            - Singleton reset in conftest must clear both `_instance` and `_records`
+    - **Scope:** `RateLimitService` class with `check()`, `_get_limit()`, `reset()`, `is_enabled` property. Config integration reads from `rateLimit` config section with hardcoded defaults as fallback. Also includes `RateLimitExceededError` in error_handler, conftest singleton reset, SINGLETON_CLASSES update, and mock config data.
+    - **Touches:**
+        - Create: `src/services/rate_limit.py`
+        - Create: `tests/test_services/test_rate_limit_service.py`
+        - Modify: `src/utils/error_handler.py` (add `RateLimitExceededError`)
+        - Modify: `config_example.yaml` (add `rateLimit` section after `security:`)
+        - Modify: `tests/conftest.py` (singleton reset + mock config data)
+        - Modify: `tests/test_architecture/test_conventions.py` (SINGLETON_CLASSES)
+    - **Action items:**
+        - [RED] Write tests for singleton pattern (`test_singleton_pattern`, `test_reset_clears_all`)
+        - [RED] Write tests for `check()` core logic: `test_check_allows_first_request`, `test_check_allows_under_limit`, `test_check_blocks_over_limit`, `test_check_allows_after_window_expires` (mock `time.time`), `test_check_prunes_expired_timestamps`
+        - [RED] Write tests for isolation: `test_different_categories_independent`, `test_different_users_independent`
+        - [RED] Write tests for `_get_limit()`: `test_get_limit_defaults`, `test_get_limit_from_config`, `test_get_limit_missing_category_uses_default`
+        - [RED] Write tests for `is_enabled`: `test_is_enabled_true`, `test_is_enabled_false`, `test_is_enabled_missing_config`
+        - [RED] Write test for `RateLimitExceededError`: `test_rate_limit_exceeded_error_attributes`
+        - [GREEN] Implement `RateLimitService` in `src/services/rate_limit.py` with defaults:
+            ```python
+            DEFAULT_LIMITS = {
+                "search": (10, 60),
+                "modify": (5, 60),
+                "auth": (3, 300),
+            }
+            DEFAULT_FALLBACK = (10, 60)
+            ```
+        - [GREEN] Add `RateLimitExceededError` to `src/utils/error_handler.py` after `ServiceNotEnabledError`
+        - [GREEN] Add `rateLimit` section to `config_example.yaml` after `security:` (~line 139)
+        - [GREEN] Add `rateLimit` to `MOCK_CONFIG_DATA` in `tests/conftest.py` (**`enable: False` by default** — rate limit tests override to `True` in their fixtures)
+        - [GREEN] Add `RateLimitService` singleton reset to `tests/conftest.py` autouse fixture
+        - [GREEN] Add `"RateLimitService"` to `SINGLETON_CLASSES` in `tests/test_architecture/test_conventions.py`
+    - **Success:** `pytest tests/test_services/test_rate_limit_service.py -v` all green, architecture tests pass, `python -m flake8 src/services/rate_limit.py` clean
+
+- [ ] **1.2** Implement `@rate_limit` decorator with DummyHandler tests
+    - **Context:**
+        - **Why:** The decorator is the integration point between the service and handlers — it wraps handler methods to check limits before the handler body runs, returning a cooldown message when the limit is exceeded.
+        - **Architecture:** Decorator factory `rate_limit(category: str)` returns a decorator that wraps `async def method(self, update, context)`. Follows `@require_auth` pattern exactly (see `src/bot/handlers/auth.py:36-50`). Lives in `src/services/rate_limit.py` alongside the service (not in handlers — the decorator is tightly coupled to the service, and handler→service imports are the correct layer direction).
+        - **Key refs:**
+            - `src/bot/handlers/auth.py:36-50` — `require_auth` decorator pattern to mirror
+            - `tests/test_handlers/test_auth_handler.py:39-111` — DummyHandler testing pattern
+            - `src/services/translation.py:73-98` — `get_text(key, **kwargs)` uses %-formatting, pass `seconds=retry_after`
+        - **Watch out:**
+            - Decorator is a **no-op when `service.is_enabled` is False** — must pass through to handler immediately
+            - When `update.effective_user` is None, return None (same guard as `require_auth`)
+            - Use `update.effective_message.reply_text()` not `update.message.reply_text()` — `effective_message` works for both messages and callback queries
+            - Stacking order: `@require_auth` THEN `@rate_limit("category")` — auth check runs first (outermost decorator), rate limit runs second. Test this explicitly.
+            - Must import `TranslationService` inside decorator body (not at module level) to avoid circular imports if translation service ever imports from services
+    - **Scope:** `rate_limit()` decorator factory function + comprehensive tests using DummyHandler pattern
+    - **Touches:**
+        - Modify: `src/services/rate_limit.py` (add decorator)
+        - Create: `tests/test_handlers/test_rate_limit_decorator.py`
+    - **Action items:**
+        - [RED] Write `test_rate_limit_allows_when_under_limit` — DummyHandler with `@rate_limit("search")`, service enabled, under limit → handler body runs, returns value
+        - [RED] Write `test_rate_limit_blocks_when_over_limit` — Over limit → handler body NOT called, `reply_text` called with cooldown message
+        - [RED] Write `test_rate_limit_noop_when_disabled` — `is_enabled` False → handler always runs regardless of limits
+        - [RED] Write `test_rate_limit_returns_none_no_user` — `update.effective_user = None` → returns None
+        - [RED] Write `test_rate_limit_shows_retry_seconds` — Blocked response includes `retry_after` value in message
+        - [RED] Write `test_rate_limit_with_require_auth_stacking` — `@require_auth @rate_limit("search")`: authenticated+under→runs, authenticated+over→rate limit msg, not authenticated→auth msg
+        - [GREEN] Implement `rate_limit(category)` decorator in `src/services/rate_limit.py`
+    - **Success:** `pytest tests/test_handlers/test_rate_limit_decorator.py -v` all green, `python -m flake8 src/services/rate_limit.py` clean
+
+---
+
+### Phase 2: Handler Integration + i18n + Verification (2 tasks)
+
+**Goal:** Wire the decorator into real handler methods, add translation keys, and verify everything works end-to-end.
+
+- [ ] **2.1** Add translation keys and apply `@rate_limit` to handler methods
+    - **Context:**
+        - **Why:** The service and decorator are built — now wire them into the actual bot handlers and add the user-facing cooldown message in all supported languages.
+        - **Architecture:** Import `rate_limit` from `src.services.rate_limit` in each handler. Stack BELOW `@require_auth` (auth runs first as outermost). For `auth.py`, `start_auth` has no `@require_auth` (it IS the auth flow) — apply `@rate_limit("auth")` directly. Translation key `RateLimitExceeded` uses `%(seconds)s` %-formatting (matches `TranslationService.get_text()` line 98).
+        - **Key refs:**
+            - `src/bot/handlers/media.py:187,218,249` — `handle_movie`, `handle_series`, `handle_music` with `@require_auth`
+            - `src/bot/handlers/auth.py:101` — `start_auth` (no `@require_auth`)
+            - `src/bot/handlers/delete.py:34-35` — `handle_delete` with `@require_auth`
+            - `src/bot/handlers/library.py:48-59` — `handle_all_movies/series/music` with `@require_auth`
+            - `translations/addarr.en-us.yml` — flat key format, %-formatting with `%(key)s`
+        - **Watch out:**
+            - **Mock config has `rateLimit.enable: False` by default** (set in task 1.1) — existing handler tests won't be affected because the decorator is a no-op when disabled
+            - All 9 language files + template must get the new key — use English text for non-English files (translators update later)
+            - Run `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` to confirm no missing keys
+            - `delete.py` has `handle_delete` (entry point) and `handle_delete_selection` (callback) — only rate-limit the entry point
+    - **Scope:** Add `RateLimitExceeded` translation key to all 10 translation files. Add `@rate_limit` decorator to 7 handler methods across 4 files. Verify existing tests still pass.
+    - **Touches:**
+        - Modify: `src/bot/handlers/media.py` (add import + 3 decorators)
+        - Modify: `src/bot/handlers/auth.py` (add import + 1 decorator)
+        - Modify: `src/bot/handlers/delete.py` (add import + 1 decorator)
+        - Modify: `src/bot/handlers/library.py` (add import + 3 decorators)
+        - Modify: `translations/addarr.en-us.yml` + 8 other locale files + `translations/addarr.template.yml`
+    - **Action items:**
+        - [GREEN] Add `RateLimitExceeded` key to all translation files (en-us, de-de, es-es, fr-fr, it-it, nl-be, pl-pl, pt-pt, ru-ru, template)
+        - [GREEN] Add `from src.services.rate_limit import rate_limit` and `@rate_limit("search")` to `media.py` on `handle_movie`, `handle_series`, `handle_music`
+        - [GREEN] Add `from src.services.rate_limit import rate_limit` and `@rate_limit("auth")` to `auth.py` on `start_auth`
+        - [GREEN] Add `from src.services.rate_limit import rate_limit` and `@rate_limit("modify")` to `delete.py` on `handle_delete`
+        - [GREEN] Add `from src.services.rate_limit import rate_limit` and `@rate_limit("search")` to `library.py` on `handle_all_movies`, `handle_all_series`, `handle_all_music`
+        - [GREEN] Run existing handler test suite: `pytest tests/test_handlers/ -v` — all must pass unchanged
+        - [GREEN] Validate translations: `PYTHONIOENCODING=utf-8 python run.py --validate-i18n`
+    - **Success:** All existing handler tests pass, translation validation passes, `python -m flake8 .` clean
+
+- [ ] **2.2** Full verification and coverage check
+    - **Context:**
+        - **Why:** Final gate before PR — ensure 100% coverage on new code, all checks pass, no regressions.
+        - **Architecture:** Run full test suite, coverage analysis on `src.services.rate_limit`, flake8, translation validation, architecture tests.
+        - **Key refs:**
+            - `tests/test_architecture/test_conventions.py` — should already pass from task 1.1 SINGLETON_CLASSES update
+        - **Watch out:**
+            - Coverage must use dotted module paths (`--cov=src.services.rate_limit`), not file paths
+            - Any uncovered lines need new tests added
+    - **Scope:** Verification-only task. Fix any gaps found.
+    - **Touches:** Potentially any test file if coverage gaps found
+    - **Action items:**
+        - [GREEN] Run full test suite: `pytest --tb=short -q`
+        - [GREEN] Run coverage: `pytest --cov=src.services.rate_limit --cov-report=term-missing tests/test_services/test_rate_limit_service.py tests/test_handlers/test_rate_limit_decorator.py`
+        - [GREEN] Fix any uncovered lines by adding targeted tests
+        - [GREEN] Run flake8: `python -m flake8 .`
+        - [GREEN] Run translation validation: `PYTHONIOENCODING=utf-8 python run.py --validate-i18n`
+        - [GREEN] Run architecture tests: `pytest tests/test_architecture/ -v`
+    - **Success:** 100% coverage on `src/services/rate_limit.py`, all checks green, ready for PR

--- a/docs/issues/issue-116/TASKS.md
+++ b/docs/issues/issue-116/TASKS.md
@@ -54,6 +54,19 @@
         - [GREEN] Add `RateLimitService` singleton reset to `tests/conftest.py` autouse fixture
         - [GREEN] Add `"RateLimitService"` to `SINGLETON_CLASSES` in `tests/test_architecture/test_conventions.py`
     - **Success:** `pytest tests/test_services/test_rate_limit_service.py -v` all green, architecture tests pass, `python -m flake8 src/services/rate_limit.py` clean
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - Singleton reset must clear both `_instance` and `_records` class variables — missing either causes cross-test pollution
+        - `time.time()` mock patches must target `src.services.rate_limit.time` (the module-level import), not `time.time` globally
+        - 17 tests needed (vs ~11 obvious ones) — edge cases for window expiry, pruning, and config fallback chains added ~50%
+    - **Key Changes:**
+        - Created `src/services/rate_limit.py` with `RateLimitService` singleton (sliding window algorithm)
+        - Created `tests/test_services/test_rate_limit_service.py` (17 tests)
+        - Added `RateLimitExceededError` to `src/utils/error_handler.py`
+        - Added `rateLimit` section to `config_example.yaml`
+        - Updated `tests/conftest.py` (mock config data + singleton reset)
+        - Updated `tests/test_architecture/test_conventions.py` (SINGLETON_CLASSES)
+    - **Notes:** Mock config defaults to `rateLimit.enable: False` so existing tests are unaffected
 
 - [x] **1.2** Implement `@rate_limit` decorator with DummyHandler tests
     - **Context:**
@@ -82,6 +95,15 @@
         - [RED] Write `test_rate_limit_with_require_auth_stacking` — `@require_auth @rate_limit("search")`: authenticated+under→runs, authenticated+over→rate limit msg, not authenticated→auth msg
         - [GREEN] Implement `rate_limit(category)` decorator in `src/services/rate_limit.py`
     - **Success:** `pytest tests/test_handlers/test_rate_limit_decorator.py -v` all green, `python -m flake8 src/services/rate_limit.py` clean
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - DummyHandler pattern works well for decorator testing — define handler class inside each test with the decorator applied
+        - `TranslationService` must be patched at `src.services.rate_limit.TranslationService` (class-level) not as an instance, since the decorator instantiates it inside the wrapper
+        - Stacking test for `@require_auth @rate_limit("search")` requires 3 sub-assertions: auth-pass+under-limit, auth-pass+over-limit, auth-fail
+    - **Key Changes:**
+        - Added `rate_limit(category)` decorator factory to `src/services/rate_limit.py`
+        - Created `tests/test_handlers/test_rate_limit_decorator.py` (8 tests)
+    - **Notes:** Decorator is a no-op when `is_enabled` is False — safe to apply to handlers before users enable rate limiting in config
 
 ---
 
@@ -89,7 +111,7 @@
 
 **Goal:** Wire the decorator into real handler methods, add translation keys, and verify everything works end-to-end.
 
-- [~] **2.1** Add translation keys and apply `@rate_limit` to handler methods
+- [x] **2.1** Add translation keys and apply `@rate_limit` to handler methods
     - **Context:**
         - **Why:** The service and decorator are built — now wire them into the actual bot handlers and add the user-facing cooldown message in all supported languages.
         - **Architecture:** Import `rate_limit` from `src.services.rate_limit` in each handler. Stack BELOW `@require_auth` (auth runs first as outermost). For `auth.py`, `start_auth` has no `@require_auth` (it IS the auth flow) — apply `@rate_limit("auth")` directly. Translation key `RateLimitExceeded` uses `%(seconds)s` %-formatting (matches `TranslationService.get_text()` line 98).
@@ -120,8 +142,19 @@
         - [GREEN] Run existing handler test suite: `pytest tests/test_handlers/ -v` — all must pass unchanged
         - [GREEN] Validate translations: `PYTHONIOENCODING=utf-8 python run.py --validate-i18n`
     - **Success:** All existing handler tests pass, translation validation passes, `python -m flake8 .` clean
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - Translation files need to be read before editing (Edit tool requires prior Read call)
+        - `addarr.template.yml` has duplicate command blocks — need extra context in edits to disambiguate
+        - Existing handler tests pass unchanged because mock config defaults `rateLimit.enable: False`, making the decorator a no-op
+    - **Key Changes:**
+        - Added `RateLimitExceeded` translation key to all 10 translation files (9 locales + template)
+        - Added `@rate_limit("search")` to `media.py` (3 methods) and `library.py` (3 methods)
+        - Added `@rate_limit("auth")` to `auth.py` (`start_auth`)
+        - Added `@rate_limit("modify")` to `delete.py` (`handle_delete`)
+    - **Notes:** Non-English locales use English text for now — translators update later
 
-- [ ] **2.2** Full verification and coverage check
+- [x] **2.2** Full verification and coverage check
     - **Context:**
         - **Why:** Final gate before PR — ensure 100% coverage on new code, all checks pass, no regressions.
         - **Architecture:** Run full test suite, coverage analysis on `src.services.rate_limit`, flake8, translation validation, architecture tests.
@@ -140,3 +173,11 @@
         - [GREEN] Run translation validation: `PYTHONIOENCODING=utf-8 python run.py --validate-i18n`
         - [GREEN] Run architecture tests: `pytest tests/test_architecture/ -v`
     - **Success:** 100% coverage on `src/services/rate_limit.py`, all checks green, ready for PR
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - Coverage CLI requires dotted module paths (`--cov=src.services.rate_limit`), not file paths — file paths silently collect nothing
+        - All 25 rate-limit tests (17 service + 8 decorator) plus all 1434 total tests pass
+        - Architecture tests (11 total) all pass including the new SINGLETON_CLASSES entry
+    - **Key Changes:**
+        - Verification-only task — no code changes, confirmed 100% coverage on `src/services/rate_limit.py`
+    - **Notes:** Full suite: 1434 passed, flake8 clean, i18n valid, architecture tests green

--- a/docs/issues/issue-116/plan.md
+++ b/docs/issues/issue-116/plan.md
@@ -1,0 +1,498 @@
+# Rate Limiting on Commands and API Calls — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add per-user, per-category rate limiting to Telegram bot handlers to prevent API abuse and brute-force auth attempts.
+
+**Architecture:** A `RateLimitService` singleton tracks per-user request timestamps in memory using a sliding window algorithm. A `@rate_limit("category")` decorator (mirroring `@require_auth`) wraps handler methods to check/enforce limits before the handler body runs. Config section `rateLimit` controls enable/disable and per-category limits. The decorator becomes a no-op when rate limiting is disabled.
+
+**Tech Stack:** Python stdlib only (`time`, `collections`). No new dependencies.
+
+---
+
+## Context
+
+### How `@require_auth` Works (the pattern to follow)
+
+**File:** `src/bot/handlers/auth.py:36-50`
+
+```python
+def require_auth(func):
+    @wraps(func)
+    async def wrapped(self, update: Update, context: ContextTypes.DEFAULT_TYPE, *args, **kwargs):
+        if not update.effective_user:
+            return
+        if not AuthHandler.is_authenticated(update.effective_user.id):
+            translation = TranslationService()
+            await update.message.reply_text(
+                translation.get_text("NotAuthorized", default="...")
+            )
+            return
+        return await func(self, update, context, *args, **kwargs)
+    return wrapped
+```
+
+Key characteristics:
+- Takes `self, update, context` — it decorates *instance methods* on handler classes
+- Extracts `update.effective_user.id` for the user check
+- Returns early with a translated message on failure
+- Returns the wrapped function's result on success
+- Uses `functools.wraps` to preserve metadata
+
+### Handler Method Signatures
+
+All handler methods: `async def method(self, update: Update, context: ContextTypes.DEFAULT_TYPE)`
+
+Decorator stacking order (auth first, then rate limit):
+```python
+@require_auth
+@rate_limit("search")
+async def handle_movie(self, update, context):
+    ...
+```
+
+Auth runs first — no point rate-limiting unauthenticated users.
+
+### Config Access Pattern
+
+Per CLAUDE.md: **bracket access `config["key"]` is banned in business logic**. Always use `config.get("key", default)`.
+
+Current config structure has `security:` section at line 135-138 of `config_example.yaml`. The `rateLimit` section goes right after it (grouping security-adjacent features).
+
+### Singleton Service Pattern
+
+From `src/services/translation.py`:
+```python
+class TranslationService:
+    _instance = None
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(TranslationService, cls).__new__(cls)
+            cls._initialize()
+        return cls._instance
+```
+
+Reset in `tests/conftest.py` autouse fixture: `TranslationService._instance = None`
+
+### Test Patterns
+
+- Import inside test functions (after `sys.modules` injection)
+- Patch at the import site: `@patch("src.bot.handlers.auth.TranslationService")`
+- Use `DummyHandler` class for decorator tests (see `test_auth_handler.py`)
+- Factory fixtures: `make_update`, `make_context`, `make_user`
+
+### Architecture Test Updates
+
+`tests/test_architecture/test_conventions.py:20-29` has `SINGLETON_CLASSES` set — must add `RateLimitService`.
+
+---
+
+## Design Decisions
+
+1. **In-memory sliding window** — No external store (Redis, SQLite). Timestamps are pruned on each check. State resets on bot restart (acceptable for this use case).
+
+2. **Three categories with sensible defaults:**
+   - `search`: 10 requests per 60 seconds (movie/series/music search commands)
+   - `modify`: 5 requests per 60 seconds (add/delete operations)
+   - `auth`: 3 requests per 300 seconds (password attempts)
+
+3. **Decorator takes category string** — `@rate_limit("search")`. Category maps to config limits. Unknown categories fall back to a default (10/60s).
+
+4. **No-op when disabled** — `rateLimit.enable: false` makes the decorator pass through immediately. Zero overhead for users who don't want it.
+
+5. **Cooldown message shows remaining wait time** — e.g., "Please wait 23 seconds before trying again." Uses `TranslationService` for i18n.
+
+6. **Service placed in `src/services/`** — Follows existing singleton pattern. Not a handler, not a utility — it's business logic that tracks state.
+
+7. **Decorator placed in `src/bot/handlers/auth.py`** — Wait, no. The rate limit decorator is separate from auth. It should live alongside the service in a dedicated module or in a shared decorators module. Since `require_auth` already lives in `auth.py` and is imported by other handlers, a new `src/bot/handlers/rate_limit.py` module for just the decorator would be clean. But handlers shouldn't contain service logic. Better approach: **decorator in the service file** (`src/services/rate_limit.py`) — the service and its decorator are a cohesive unit. Handlers import `rate_limit` from `src.services.rate_limit`, same as they import `require_auth` from `src.bot.handlers.auth`.
+
+   Actually, to match the existing pattern: `require_auth` is in `src/bot/handlers/auth.py` because it's tightly coupled to `AuthHandler`. The rate limit decorator is tightly coupled to `RateLimitService`. So: **decorator and service together in `src/services/rate_limit.py`**.
+
+8. **Layer boundary compliance** — Handlers import from services (allowed). The decorator lives in services, so handler → service import is fine. The service doesn't import handlers (correct direction).
+
+---
+
+## File Structure
+
+```
+src/services/rate_limit.py          # NEW: RateLimitService + @rate_limit decorator
+src/utils/error_handler.py          # MODIFY: add RateLimitExceededError
+config_example.yaml                 # MODIFY: add rateLimit section
+tests/conftest.py                   # MODIFY: add singleton reset + mock config
+tests/test_services/test_rate_limit_service.py  # NEW: service unit tests
+tests/test_handlers/test_rate_limit_decorator.py # NEW: decorator integration tests
+tests/test_architecture/test_conventions.py     # MODIFY: add to SINGLETON_CLASSES
+translations/addarr.en-us.yml       # MODIFY: add RateLimitExceeded key
+translations/addarr.template.yml    # MODIFY: add RateLimitExceeded key
+```
+
+Handler files modified to apply decorator:
+```
+src/bot/handlers/media.py           # @rate_limit("search") on handle_movie, handle_series, handle_music
+src/bot/handlers/auth.py            # @rate_limit("auth") on start_auth
+src/bot/handlers/delete.py          # @rate_limit("modify") on delete methods
+src/bot/handlers/library.py         # @rate_limit("search") on library commands
+```
+
+---
+
+## Phased Approach
+
+### Phase 1: Core Service (Tasks 1.1–1.3)
+Build `RateLimitService` with full test coverage. Pure logic, no Telegram integration yet.
+
+### Phase 2: Decorator + Error (Tasks 2.1–2.2)
+Build `@rate_limit` decorator and `RateLimitExceededError`. Test with dummy handlers.
+
+### Phase 3: Config + i18n (Tasks 3.1–3.2)
+Add config section and translation keys. Wire service to read from config.
+
+### Phase 4: Handler Integration (Tasks 4.1–4.2)
+Apply decorator to handler methods. Update architecture tests. End-to-end verification.
+
+---
+
+## Task Breakdown
+
+### Task 1.1: RateLimitService — Core Sliding Window Logic
+
+**Size:** Medium (~30 min)
+
+**Files:**
+- Create: `src/services/rate_limit.py`
+- Create: `tests/test_services/test_rate_limit_service.py`
+- Modify: `tests/conftest.py` (singleton reset)
+- Modify: `tests/test_architecture/test_conventions.py` (SINGLETON_CLASSES)
+
+**What to build:**
+
+`RateLimitService` singleton with:
+- `_instance = None` class var (singleton pattern via `__new__`)
+- `_records: dict` class var — `{user_id: {category: [timestamps]}}`
+- `check(user_id: int, category: str) -> tuple[bool, int]` — Returns `(allowed, retry_after_seconds)`. Prunes expired timestamps, checks count against limit, records new timestamp if allowed.
+- `_get_limit(category: str) -> tuple[int, int]` — Returns `(max_requests, window_seconds)` for a category. Reads from config with hardcoded defaults.
+- `reset()` classmethod — Clears all records (for testing).
+
+**Default limits (when config missing or disabled):**
+```python
+DEFAULT_LIMITS = {
+    "search": (10, 60),
+    "modify": (5, 60),
+    "auth": (3, 300),
+}
+DEFAULT_FALLBACK = (10, 60)
+```
+
+**Singleton reset in conftest.py:**
+```python
+from src.services.rate_limit import RateLimitService
+RateLimitService._instance = None
+RateLimitService._records = {}
+```
+
+**SINGLETON_CLASSES update:**
+Add `"RateLimitService"` to the set in `test_conventions.py:20-29`.
+
+**Tests to write:**
+1. `test_check_allows_first_request` — First request for a user/category returns `(True, 0)`
+2. `test_check_allows_under_limit` — Multiple requests under limit all return `(True, 0)`
+3. `test_check_blocks_over_limit` — Requests exceeding limit return `(False, retry_seconds > 0)`
+4. `test_check_allows_after_window_expires` — After window passes, requests are allowed again (mock `time.time`)
+5. `test_check_prunes_expired_timestamps` — Old timestamps are removed on check
+6. `test_different_categories_independent` — Hitting search limit doesn't affect modify limit
+7. `test_different_users_independent` — User A's limits don't affect User B
+8. `test_get_limit_defaults` — Unknown category returns default fallback
+9. `test_reset_clears_all` — `reset()` empties all records
+10. `test_singleton_pattern` — Two instantiations return same object
+
+---
+
+### Task 1.2: RateLimitService — Config Integration
+
+**Size:** Small (~15 min)
+
+**Files:**
+- Modify: `src/services/rate_limit.py`
+- Modify: `config_example.yaml`
+- Modify: `tests/test_services/test_rate_limit_service.py`
+
+**What to build:**
+
+Add `rateLimit` section to `config_example.yaml` after `security:` (line ~139):
+```yaml
+# Rate Limiting Configuration
+rateLimit:
+  enable: false
+  limits:
+    search:
+      maxRequests: 10
+      windowSeconds: 60
+    modify:
+      maxRequests: 5
+      windowSeconds: 60
+    auth:
+      maxRequests: 3
+      windowSeconds: 300
+```
+
+Update `_get_limit()` to read from config:
+```python
+def _get_limit(self, category):
+    rate_config = config.get("rateLimit", {})
+    limits = rate_config.get("limits", {})
+    cat_config = limits.get(category, {})
+    max_req = cat_config.get("maxRequests", DEFAULT_LIMITS.get(category, DEFAULT_FALLBACK)[0])
+    window = cat_config.get("windowSeconds", DEFAULT_LIMITS.get(category, DEFAULT_FALLBACK)[1])
+    return (max_req, window)
+```
+
+Add `is_enabled()` property:
+```python
+@property
+def is_enabled(self):
+    return config.get("rateLimit", {}).get("enable", False)
+```
+
+**Mock config update in `tests/conftest.py`:**
+Add to `MOCK_CONFIG_DATA`:
+```python
+"rateLimit": {
+    "enable": True,
+    "limits": {
+        "search": {"maxRequests": 10, "windowSeconds": 60},
+        "modify": {"maxRequests": 5, "windowSeconds": 60},
+        "auth": {"maxRequests": 3, "windowSeconds": 300},
+    },
+},
+```
+
+**Tests to write:**
+1. `test_get_limit_from_config` — Config values override defaults
+2. `test_get_limit_missing_category_uses_default` — Category not in config falls back
+3. `test_is_enabled_true` — Returns True when config says true
+4. `test_is_enabled_false` — Returns False when config says false
+5. `test_is_enabled_missing_config` — Returns False when rateLimit section missing
+
+---
+
+### Task 2.1: Rate Limit Decorator
+
+**Size:** Medium (~25 min)
+
+**Files:**
+- Modify: `src/services/rate_limit.py` (add `rate_limit` function)
+- Create: `tests/test_handlers/test_rate_limit_decorator.py`
+
+**What to build:**
+
+The `rate_limit(category)` decorator factory:
+```python
+def rate_limit(category: str):
+    """Decorator to enforce rate limiting on handler methods."""
+    def decorator(func):
+        @wraps(func)
+        async def wrapped(self, update: Update, context: ContextTypes.DEFAULT_TYPE, *args, **kwargs):
+            service = RateLimitService()
+
+            # No-op when disabled
+            if not service.is_enabled:
+                return await func(self, update, context, *args, **kwargs)
+
+            if not update.effective_user:
+                return
+
+            user_id = update.effective_user.id
+            allowed, retry_after = service.check(user_id, category)
+
+            if not allowed:
+                translation = TranslationService()
+                await update.effective_message.reply_text(
+                    translation.get_text(
+                        "RateLimitExceeded",
+                        default=f"Slow down! Please wait {retry_after} seconds before trying again.",
+                        seconds=retry_after,
+                    )
+                )
+                return
+
+            return await func(self, update, context, *args, **kwargs)
+        return wrapped
+    return decorator
+```
+
+**Tests to write (using DummyHandler pattern from test_auth_handler.py):**
+1. `test_rate_limit_allows_when_under_limit` — Handler body runs, returns its value
+2. `test_rate_limit_blocks_when_over_limit` — Handler body does NOT run, reply_text called with rate limit message
+3. `test_rate_limit_noop_when_disabled` — When `is_enabled` is False, handler always runs
+4. `test_rate_limit_returns_none_no_user` — When `update.effective_user` is None, returns None
+5. `test_rate_limit_with_require_auth_stacking` — Both decorators applied: `@require_auth @rate_limit("search")`. Authenticated + under limit → handler runs. Authenticated + over limit → rate limit message. Not authenticated → auth message.
+6. `test_rate_limit_shows_retry_seconds` — Reply message includes the retry_after value
+
+---
+
+### Task 2.2: RateLimitExceededError Exception
+
+**Size:** Small (~5 min)
+
+**Files:**
+- Modify: `src/utils/error_handler.py`
+
+**What to build:**
+
+Add after `ServiceNotEnabledError` (line ~39):
+```python
+class RateLimitExceededError(AddarrError):
+    """Raised when a user exceeds the rate limit for an action."""
+    def __init__(self, category: str, retry_after: int):
+        message = f"Rate limit exceeded for {category}. Retry after {retry_after}s."
+        super().__init__(message)
+        self.category = category
+        self.retry_after = retry_after
+```
+
+This exception isn't used by the decorator directly (it handles things inline) but provides a programmatic way for other code to signal rate limit violations if needed.
+
+**Tests:**
+1. `test_rate_limit_exceeded_error_attributes` — Verify `category`, `retry_after`, and message are set correctly
+
+---
+
+### Task 3.1: Translation Keys
+
+**Size:** Small (~10 min)
+
+**Files:**
+- Modify: `translations/addarr.en-us.yml`
+- Modify: `translations/addarr.template.yml`
+- Modify all other translation files (8 languages)
+
+**What to add:**
+
+In each translation file, add under the appropriate section:
+```yaml
+  # Rate limiting
+  RateLimitExceeded: "Slow down! Please wait %(seconds)s seconds before trying again."
+```
+
+The `%(seconds)s` uses Python %-formatting which is what `TranslationService.get_text()` uses (line 98 of `translation.py`).
+
+For `addarr.template.yml`, add the key with a placeholder comment for translators.
+
+**Verification:** Run `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` to confirm no missing keys.
+
+---
+
+### Task 4.1: Apply Decorator to Handlers
+
+**Size:** Medium (~20 min)
+
+**Files:**
+- Modify: `src/bot/handlers/media.py`
+- Modify: `src/bot/handlers/auth.py`
+- Modify: `src/bot/handlers/delete.py`
+- Modify: `src/bot/handlers/library.py`
+
+**What to change:**
+
+**media.py** — Add import and decorators:
+```python
+from src.services.rate_limit import rate_limit
+
+# On entry-point methods:
+@require_auth
+@rate_limit("search")
+async def handle_movie(self, update, context):
+
+@require_auth
+@rate_limit("search")
+async def handle_series(self, update, context):
+
+@require_auth
+@rate_limit("search")
+async def handle_music(self, update, context):
+```
+
+**auth.py** — Add import and decorator:
+```python
+from src.services.rate_limit import rate_limit
+
+@rate_limit("auth")
+async def start_auth(self, update, context):
+```
+
+Note: `start_auth` is NOT guarded by `@require_auth` (it IS the auth flow). Rate limiting is still applied to prevent brute-force password attempts.
+
+**delete.py** — Add import and decorators:
+```python
+from src.services.rate_limit import rate_limit
+
+@require_auth
+@rate_limit("modify")
+async def handle_delete_movie(self, update, context):
+
+@require_auth
+@rate_limit("modify")
+async def handle_delete_series(self, update, context):
+```
+
+**library.py** — Add import and decorators:
+```python
+from src.services.rate_limit import rate_limit
+
+@require_auth
+@rate_limit("search")
+async def handle_all_movies(self, update, context):
+
+@require_auth
+@rate_limit("search")
+async def handle_all_series(self, update, context):
+
+@require_auth
+@rate_limit("search")
+async def handle_all_music(self, update, context):
+```
+
+**Existing test impact:** Existing handler tests mock services at import sites. The `RateLimitService` will be instantiated inside the decorator. Tests need to either:
+- Patch `src.services.rate_limit.RateLimitService` in handler tests, OR
+- Patch `config.get("rateLimit", {}).get("enable", False)` to return `False` so the decorator is a no-op
+
+The simplest approach: Add `"rateLimit": {"enable": False, ...}` to `MOCK_CONFIG_DATA` in conftest.py (already done in Task 1.2). Since the mock config has `enable: True` for rate limit tests but existing handler tests need it to not interfere — we should set the default mock config to `enable: False`, and only enable it in rate-limit-specific tests.
+
+**Decision:** Set `MOCK_CONFIG_DATA["rateLimit"]["enable"]` to `False` by default. Rate limit tests override it to `True` in their fixtures.
+
+**Tests:**
+- Verify existing handler tests still pass with the decorator applied (no behavior change when disabled)
+- Add one integration test per handler showing the decorator is wired up correctly
+
+---
+
+### Task 4.2: Final Verification + Architecture Test Update
+
+**Size:** Small (~10 min)
+
+**Files:**
+- Modify: `tests/test_architecture/test_conventions.py` (already done in 1.1)
+
+**What to verify:**
+1. `pytest --tb=short -q` — All tests pass
+2. `python -m flake8 .` — No lint errors
+3. `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` — Translations valid
+4. Architecture tests pass (SINGLETON_CLASSES includes RateLimitService)
+5. Coverage on new files: `pytest --cov=src.services.rate_limit --cov-report=term-missing`
+
+---
+
+## Verification Checklist
+
+- [ ] `RateLimitService` is a proper singleton (has `__new__`)
+- [ ] `@rate_limit("category")` decorator follows `@require_auth` pattern
+- [ ] Decorator is a no-op when `rateLimit.enable` is `false`
+- [ ] Config section with sensible defaults in `config_example.yaml`
+- [ ] Translation key `RateLimitExceeded` in all 9 languages + template
+- [ ] SINGLETON_CLASSES updated in architecture tests
+- [ ] Singleton reset added in conftest.py
+- [ ] Mock config data includes rateLimit section (disabled by default)
+- [ ] All existing tests still pass after decorator application
+- [ ] 100% coverage on `src/services/rate_limit.py`
+- [ ] No flake8 violations
+- [ ] No bracket config access (`config["..."]`) in new code

--- a/src/bot/handlers/auth.py
+++ b/src/bot/handlers/auth.py
@@ -25,6 +25,7 @@ from src.config.settings import config
 from src.definitions import CONFIG_PATH
 from src.bot.commands import register_commands_for_chat
 from src.services.translation import TranslationService
+from src.services.rate_limit import rate_limit
 
 # Get logger instance
 logger = get_logger("addarr.auth")
@@ -98,6 +99,7 @@ class AuthHandler:
             )
         ]
 
+    @rate_limit("auth")
     async def start_auth(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Start the authentication process"""
         if not update.effective_message or not update.effective_user:

--- a/src/bot/handlers/delete.py
+++ b/src/bot/handlers/delete.py
@@ -12,6 +12,7 @@ from telegram.ext import CommandHandler, ContextTypes, CallbackQueryHandler
 from src.utils.logger import get_logger, log_user_interaction
 from src.services.media import MediaService
 from src.bot.handlers.auth import require_auth
+from src.services.rate_limit import rate_limit
 from src.services.translation import TranslationService
 
 logger = get_logger("addarr.delete")
@@ -32,6 +33,7 @@ class DeleteHandler:
         ]
 
     @require_auth
+    @rate_limit("modify")
     async def handle_delete(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Handle delete command"""
         if not update.effective_message or not update.effective_user:

--- a/src/bot/handlers/library.py
+++ b/src/bot/handlers/library.py
@@ -14,6 +14,7 @@ from src.utils.logger import get_logger, log_user_interaction
 from src.services.media import MediaService
 from src.services.translation import TranslationService
 from src.bot.handlers.auth import require_auth
+from src.services.rate_limit import rate_limit
 
 logger = get_logger("addarr.library")
 
@@ -46,16 +47,19 @@ class LibraryHandler:
         ]
 
     @require_auth
+    @rate_limit("search")
     async def handle_all_movies(self, update, context):
         """Handle /allMovies command."""
         await self._fetch_and_show(update, context, "m")
 
     @require_auth
+    @rate_limit("search")
     async def handle_all_series(self, update, context):
         """Handle /allSeries command."""
         await self._fetch_and_show(update, context, "s")
 
     @require_auth
+    @rate_limit("search")
     async def handle_all_music(self, update, context):
         """Handle /allMusic command."""
         await self._fetch_and_show(update, context, "a")

--- a/src/bot/handlers/media.py
+++ b/src/bot/handlers/media.py
@@ -20,6 +20,7 @@ from telegram.ext import (
 from src.config.settings import config
 from src.utils.logger import get_logger, log_user_interaction
 from src.bot.handlers.auth import require_auth
+from src.services.rate_limit import rate_limit
 from src.bot.keyboards import (
     get_search_results_list_keyboard,
     get_list_detail_keyboard,
@@ -185,6 +186,7 @@ class MediaHandler:
         return SEARCHING
 
     @require_auth
+    @rate_limit("search")
     async def handle_movie(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Start movie search conversation"""
         if not update.effective_message or not update.effective_user:
@@ -216,6 +218,7 @@ class MediaHandler:
         return SEARCHING
 
     @require_auth
+    @rate_limit("search")
     async def handle_series(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Start series search conversation"""
         if not update.effective_message or not update.effective_user:
@@ -247,6 +250,7 @@ class MediaHandler:
         return SEARCHING
 
     @require_auth
+    @rate_limit("search")
     async def handle_music(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Start music search conversation"""
         if not update.effective_message or not update.effective_user:

--- a/src/services/rate_limit.py
+++ b/src/services/rate_limit.py
@@ -1,0 +1,104 @@
+"""
+Filename: rate_limit.py
+Author: Addarr Contributors
+Created Date: 2026-03-03
+Description: Rate limiting service and decorator.
+
+This module provides per-user, per-category rate limiting for bot handlers.
+Uses an in-memory sliding window algorithm to track request timestamps.
+"""
+
+import time
+
+from src.config.settings import config
+from src.utils.logger import get_logger
+
+logger = get_logger("addarr.ratelimit")
+
+# Default limits per category: (max_requests, window_seconds)
+DEFAULT_LIMITS = {
+    "search": (10, 60),
+    "modify": (5, 60),
+    "auth": (3, 300),
+}
+DEFAULT_FALLBACK = (10, 60)
+
+
+class RateLimitService:
+    """Per-user rate limiting using in-memory sliding window."""
+
+    _instance = None
+    _records = {}
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(RateLimitService, cls).__new__(cls)
+        return cls._instance
+
+    @property
+    def is_enabled(self):
+        """Check if rate limiting is enabled in config."""
+        return config.get("rateLimit", {}).get("enable", False)
+
+    def check(self, user_id, category):
+        """Check if a request is allowed under the rate limit.
+
+        Args:
+            user_id: Telegram user ID.
+            category: Rate limit category (search, modify, auth).
+
+        Returns:
+            Tuple of (allowed: bool, retry_after: int).
+            retry_after is 0 when allowed, otherwise seconds to wait.
+        """
+        max_requests, window_seconds = self._get_limit(category)
+        now = time.time()
+        cutoff = now - window_seconds
+
+        # Initialize nested dicts
+        if user_id not in self._records:
+            self._records[user_id] = {}
+        if category not in self._records[user_id]:
+            self._records[user_id][category] = []
+
+        # Prune expired timestamps
+        self._records[user_id][category] = [
+            ts for ts in self._records[user_id][category] if ts > cutoff
+        ]
+
+        timestamps = self._records[user_id][category]
+
+        if len(timestamps) >= max_requests:
+            # Blocked — calculate retry_after from oldest timestamp in window
+            oldest = min(timestamps)
+            retry_after = int(oldest + window_seconds - now) + 1
+            return (False, max(retry_after, 1))
+
+        # Allowed — record this request
+        timestamps.append(now)
+        return (True, 0)
+
+    def _get_limit(self, category):
+        """Get the rate limit for a category.
+
+        Reads from config, falls back to hardcoded defaults.
+
+        Returns:
+            Tuple of (max_requests, window_seconds).
+        """
+        rate_config = config.get("rateLimit", {})
+        limits = rate_config.get("limits", {})
+        cat_config = limits.get(category, {})
+
+        default_max, default_window = DEFAULT_LIMITS.get(
+            category, DEFAULT_FALLBACK
+        )
+
+        max_req = cat_config.get("maxRequests", default_max)
+        window = cat_config.get("windowSeconds", default_window)
+        return (max_req, window)
+
+    @classmethod
+    def reset(cls):
+        """Clear all rate limit records."""
+        cls._records = {}

--- a/src/services/rate_limit.py
+++ b/src/services/rate_limit.py
@@ -9,8 +9,13 @@ Uses an in-memory sliding window algorithm to track request timestamps.
 """
 
 import time
+from functools import wraps
+
+from telegram import Update
+from telegram.ext import ContextTypes
 
 from src.config.settings import config
+from src.services.translation import TranslationService
 from src.utils.logger import get_logger
 
 logger = get_logger("addarr.ratelimit")
@@ -102,3 +107,46 @@ class RateLimitService:
     def reset(cls):
         """Clear all rate limit records."""
         cls._records = {}
+
+
+def rate_limit(category):
+    """Decorator to enforce rate limiting on handler methods.
+
+    Args:
+        category: Rate limit category (search, modify, auth).
+    """
+    def decorator(func):
+        @wraps(func)
+        async def wrapped(
+            self, update: Update,
+            context: ContextTypes.DEFAULT_TYPE,
+            *args, **kwargs
+        ):
+            service = RateLimitService()
+
+            if not service.is_enabled:
+                return await func(self, update, context, *args, **kwargs)
+
+            if not update.effective_user:
+                return
+
+            user_id = update.effective_user.id
+            allowed, retry_after = service.check(user_id, category)
+
+            if not allowed:
+                translation = TranslationService()
+                await update.effective_message.reply_text(
+                    translation.get_text(
+                        "RateLimitExceeded",
+                        default=(
+                            f"Slow down! Please wait {retry_after} "
+                            "seconds before trying again."
+                        ),
+                        seconds=retry_after,
+                    )
+                )
+                return
+
+            return await func(self, update, context, *args, **kwargs)
+        return wrapped
+    return decorator

--- a/src/utils/error_handler.py
+++ b/src/utils/error_handler.py
@@ -38,6 +38,15 @@ class ServiceNotEnabledError(AddarrError):
     """Raised when trying to use a service that is not enabled"""
     pass
 
+
+class RateLimitExceededError(AddarrError):
+    """Raised when a user exceeds the rate limit for an action."""
+    def __init__(self, category, retry_after):
+        message = f"Rate limit exceeded for {category}. Retry after {retry_after}s."
+        super().__init__(message)
+        self.category = category
+        self.retry_after = retry_after
+
 # Error Handlers
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,14 @@ MOCK_CONFIG_DATA = {
     "logging": {"toConsole": False, "debug": False, "adminNotifyId": None},
     "admins": [], "allow_list": [], "chat_id": [],
     "authenticated_users": [12345],
+    "rateLimit": {
+        "enable": False,
+        "limits": {
+            "search": {"maxRequests": 10, "windowSeconds": 60},
+            "modify": {"maxRequests": 5, "windowSeconds": 60},
+            "auth": {"maxRequests": 3, "windowSeconds": 300},
+        },
+    },
     "enableAllowlist": False, "logToConsole": False, "debugLogging": False,
 }
 
@@ -201,6 +209,7 @@ def reset_singletons():
     from src.services.transmission import TransmissionService
     from src.services.sabnzbd import SABnzbdService
     from src.services.preferences import PreferencesService
+    from src.services.rate_limit import RateLimitService
     from src.bot.handlers.auth import AuthHandler
 
     # Reset singletons
@@ -225,6 +234,9 @@ def reset_singletons():
 
     PreferencesService._instance = None
     PreferencesService._preferences = {}
+
+    RateLimitService._instance = None
+    RateLimitService._records = {}
 
     AuthHandler._authenticated_users = set()
 

--- a/tests/test_architecture/test_conventions.py
+++ b/tests/test_architecture/test_conventions.py
@@ -25,6 +25,7 @@ SINGLETON_CLASSES = {
     "SABnzbdService",
     "PreferencesService",
     "NotificationService",
+    "RateLimitService",
     "JobScheduler",
 }
 

--- a/tests/test_handlers/test_rate_limit_decorator.py
+++ b/tests/test_handlers/test_rate_limit_decorator.py
@@ -24,7 +24,7 @@ async def test_rate_limit_allows_when_under_limit(
     mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
     mock_ts_class.return_value = mock_ts
 
-    from src.services.rate_limit import rate_limit, RateLimitService
+    from src.services.rate_limit import rate_limit
 
     # Enable rate limiting
     with patch("src.services.rate_limit.config") as mock_cfg:
@@ -53,7 +53,7 @@ async def test_rate_limit_blocks_when_over_limit(
     mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
     mock_ts_class.return_value = mock_ts
 
-    from src.services.rate_limit import rate_limit, RateLimitService
+    from src.services.rate_limit import rate_limit
 
     with patch("src.services.rate_limit.config") as mock_cfg:
         mock_cfg.get.return_value = {
@@ -145,7 +145,7 @@ async def test_rate_limit_shows_retry_seconds(
     mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
     mock_ts_class.return_value = mock_ts
 
-    from src.services.rate_limit import rate_limit, RateLimitService
+    from src.services.rate_limit import rate_limit
 
     with patch("src.services.rate_limit.config") as mock_cfg:
         mock_cfg.get.return_value = {

--- a/tests/test_handlers/test_rate_limit_decorator.py
+++ b/tests/test_handlers/test_rate_limit_decorator.py
@@ -1,0 +1,300 @@
+"""
+Tests for the @rate_limit decorator from src/services/rate_limit.py.
+
+Uses the DummyHandler pattern (same as test_auth_handler.py) to test
+the decorator in isolation from real handlers.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Basic behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("src.services.rate_limit.TranslationService")
+async def test_rate_limit_allows_when_under_limit(
+    mock_ts_class, make_update, make_context
+):
+    """Handler body runs and returns its value when under limit."""
+    mock_ts = MagicMock()
+    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_ts_class.return_value = mock_ts
+
+    from src.services.rate_limit import rate_limit, RateLimitService
+
+    # Enable rate limiting
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = {"enable": True, "limits": {}}
+
+        class DummyHandler:
+            @rate_limit("search")
+            async def guarded(self, update, context):
+                return "allowed"
+
+        handler = DummyHandler()
+        update = make_update(text="/movie")
+        context = make_context()
+
+        result = await handler.guarded(update, context)
+        assert result == "allowed"
+
+
+@pytest.mark.asyncio
+@patch("src.services.rate_limit.TranslationService")
+async def test_rate_limit_blocks_when_over_limit(
+    mock_ts_class, make_update, make_context
+):
+    """Handler body does NOT run; reply_text called with rate limit message."""
+    mock_ts = MagicMock()
+    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_ts_class.return_value = mock_ts
+
+    from src.services.rate_limit import rate_limit, RateLimitService
+
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = {
+            "enable": True,
+            "limits": {"search": {"maxRequests": 2, "windowSeconds": 60}},
+        }
+
+        class DummyHandler:
+            @rate_limit("search")
+            async def guarded(self, update, context):
+                return "allowed"
+
+        handler = DummyHandler()
+        update = make_update(text="/movie")
+        context = make_context()
+
+        # Exhaust limit (2 requests)
+        await handler.guarded(update, context)
+        await handler.guarded(update, context)
+
+        # Third should be blocked
+        result = await handler.guarded(update, context)
+        assert result is None
+        update.effective_message.reply_text.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_noop_when_disabled(make_update, make_context):
+    """When is_enabled is False, handler always runs regardless of limits."""
+    from src.services.rate_limit import rate_limit
+
+    # Default mock config has rateLimit.enable = False
+    class DummyHandler:
+        @rate_limit("search")
+        async def guarded(self, update, context):
+            return "allowed"
+
+    handler = DummyHandler()
+    update = make_update(text="/movie")
+    context = make_context()
+
+    # Should always pass even with many calls
+    for _ in range(20):
+        result = await handler.guarded(update, context)
+        assert result == "allowed"
+
+
+@pytest.mark.asyncio
+@patch("src.services.rate_limit.TranslationService")
+async def test_rate_limit_returns_none_no_user(
+    mock_ts_class, make_update, make_context
+):
+    """When update.effective_user is None, returns None."""
+    mock_ts = MagicMock()
+    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_ts_class.return_value = mock_ts
+
+    from src.services.rate_limit import rate_limit
+
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = {"enable": True, "limits": {}}
+
+        class DummyHandler:
+            @rate_limit("search")
+            async def guarded(self, update, context):
+                return "allowed"
+
+        handler = DummyHandler()
+        update = make_update(text="/movie")
+        update.effective_user = None
+        context = make_context()
+
+        result = await handler.guarded(update, context)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Retry seconds in blocked response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("src.services.rate_limit.TranslationService")
+async def test_rate_limit_shows_retry_seconds(
+    mock_ts_class, make_update, make_context
+):
+    """Blocked response passes retry_after seconds to translation."""
+    mock_ts = MagicMock()
+    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_ts_class.return_value = mock_ts
+
+    from src.services.rate_limit import rate_limit, RateLimitService
+
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = {
+            "enable": True,
+            "limits": {"search": {"maxRequests": 1, "windowSeconds": 60}},
+        }
+
+        class DummyHandler:
+            @rate_limit("search")
+            async def guarded(self, update, context):
+                return "allowed"
+
+        handler = DummyHandler()
+        update = make_update(text="/movie")
+        context = make_context()
+
+        # First allowed, second blocked
+        await handler.guarded(update, context)
+        await handler.guarded(update, context)
+
+        # TranslationService.get_text should have been called with seconds kwarg
+        mock_ts.get_text.assert_called()
+        call_kwargs = mock_ts.get_text.call_args
+        assert "seconds" in call_kwargs.kwargs
+        assert call_kwargs.kwargs["seconds"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Stacking with @require_auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("src.services.rate_limit.TranslationService")
+@patch("src.bot.handlers.auth.TranslationService")
+async def test_stacking_authenticated_and_under_limit(
+    mock_auth_ts_class, mock_rl_ts_class, make_update, make_context
+):
+    """@require_auth + @rate_limit: authenticated + under limit -> runs."""
+    mock_auth_ts = MagicMock()
+    mock_auth_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_auth_ts_class.return_value = mock_auth_ts
+
+    mock_rl_ts = MagicMock()
+    mock_rl_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_rl_ts_class.return_value = mock_rl_ts
+
+    from src.bot.handlers.auth import AuthHandler, require_auth
+    from src.services.rate_limit import rate_limit
+
+    AuthHandler._authenticated_users = {12345}
+
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = {"enable": True, "limits": {}}
+
+        class DummyHandler:
+            @require_auth
+            @rate_limit("search")
+            async def guarded(self, update, context):
+                return "allowed"
+
+        handler = DummyHandler()
+        update = make_update(text="/movie")
+        context = make_context()
+
+        result = await handler.guarded(update, context)
+        assert result == "allowed"
+
+
+@pytest.mark.asyncio
+@patch("src.services.rate_limit.TranslationService")
+@patch("src.bot.handlers.auth.TranslationService")
+async def test_stacking_authenticated_but_over_limit(
+    mock_auth_ts_class, mock_rl_ts_class, make_update, make_context
+):
+    """@require_auth + @rate_limit: authenticated + over limit -> rate limit msg."""
+    mock_auth_ts = MagicMock()
+    mock_auth_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_auth_ts_class.return_value = mock_auth_ts
+
+    mock_rl_ts = MagicMock()
+    mock_rl_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_rl_ts_class.return_value = mock_rl_ts
+
+    from src.bot.handlers.auth import AuthHandler, require_auth
+    from src.services.rate_limit import rate_limit
+
+    AuthHandler._authenticated_users = {12345}
+
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = {
+            "enable": True,
+            "limits": {"search": {"maxRequests": 1, "windowSeconds": 60}},
+        }
+
+        class DummyHandler:
+            @require_auth
+            @rate_limit("search")
+            async def guarded(self, update, context):
+                return "allowed"
+
+        handler = DummyHandler()
+        update = make_update(text="/movie")
+        context = make_context()
+
+        # First allowed
+        result = await handler.guarded(update, context)
+        assert result == "allowed"
+
+        # Second blocked by rate limit (not auth)
+        result = await handler.guarded(update, context)
+        assert result is None
+        update.effective_message.reply_text.assert_called()
+
+
+@pytest.mark.asyncio
+@patch("src.services.rate_limit.TranslationService")
+@patch("src.bot.handlers.auth.TranslationService")
+async def test_stacking_not_authenticated(
+    mock_auth_ts_class, mock_rl_ts_class, make_update, make_context
+):
+    """@require_auth + @rate_limit: not authenticated -> auth message."""
+    mock_auth_ts = MagicMock()
+    mock_auth_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_auth_ts_class.return_value = mock_auth_ts
+
+    mock_rl_ts = MagicMock()
+    mock_rl_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_rl_ts_class.return_value = mock_rl_ts
+
+    from src.bot.handlers.auth import AuthHandler, require_auth
+    from src.services.rate_limit import rate_limit
+
+    AuthHandler._authenticated_users = set()  # Not authenticated
+
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = {"enable": True, "limits": {}}
+
+        class DummyHandler:
+            @require_auth
+            @rate_limit("search")
+            async def guarded(self, update, context):
+                return "allowed"
+
+        handler = DummyHandler()
+        update = make_update(text="/movie")
+        context = make_context()
+
+        result = await handler.guarded(update, context)
+        assert result is None
+        # Auth message should be sent (via update.message.reply_text)
+        update.message.reply_text.assert_called_once()

--- a/tests/test_services/test_rate_limit_service.py
+++ b/tests/test_services/test_rate_limit_service.py
@@ -6,8 +6,6 @@ using an in-memory sliding window. It enforces configurable rate limits
 per command category (search, modify, auth).
 """
 
-import time
-import pytest
 from unittest.mock import patch
 
 

--- a/tests/test_services/test_rate_limit_service.py
+++ b/tests/test_services/test_rate_limit_service.py
@@ -1,0 +1,301 @@
+"""
+Tests for src/services/rate_limit.py - RateLimitService.
+
+RateLimitService is a singleton that tracks per-user request timestamps
+using an in-memory sliding window. It enforces configurable rate limits
+per command category (search, modify, auth).
+"""
+
+import time
+import pytest
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Singleton pattern
+# ---------------------------------------------------------------------------
+
+
+def test_singleton_pattern():
+    """Two instantiations return the same object."""
+    from src.services.rate_limit import RateLimitService
+
+    a = RateLimitService()
+    b = RateLimitService()
+    assert a is b
+
+
+def test_reset_clears_all():
+    """reset() empties all records."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+    service.check(12345, "search")
+    service.reset()
+    assert service._records == {}
+
+
+# ---------------------------------------------------------------------------
+# check() — core sliding window logic
+# ---------------------------------------------------------------------------
+
+
+def test_check_allows_first_request():
+    """First request for a user/category returns (True, 0)."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+    allowed, retry_after = service.check(12345, "search")
+    assert allowed is True
+    assert retry_after == 0
+
+
+def test_check_allows_under_limit():
+    """Multiple requests under limit all return (True, 0)."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+    # Default search limit is 10/60s
+    for _ in range(9):
+        allowed, retry_after = service.check(12345, "search")
+        assert allowed is True
+        assert retry_after == 0
+
+
+def test_check_blocks_over_limit():
+    """Requests exceeding limit return (False, retry_seconds > 0)."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+    # Default search limit is 10/60s — make 10 allowed, 11th blocked
+    for _ in range(10):
+        allowed, _ = service.check(12345, "search")
+        assert allowed is True
+
+    allowed, retry_after = service.check(12345, "search")
+    assert allowed is False
+    assert retry_after > 0
+
+
+@patch("src.services.rate_limit.time")
+def test_check_allows_after_window_expires(mock_time):
+    """After window passes, requests are allowed again."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+
+    # Fill up limit at t=1000
+    mock_time.time.return_value = 1000.0
+    for _ in range(10):
+        service.check(12345, "search")
+
+    # Blocked at t=1000
+    allowed, _ = service.check(12345, "search")
+    assert allowed is False
+
+    # Window expires at t=1061 (60s window + 1)
+    mock_time.time.return_value = 1061.0
+    allowed, retry_after = service.check(12345, "search")
+    assert allowed is True
+    assert retry_after == 0
+
+
+@patch("src.services.rate_limit.time")
+def test_check_prunes_expired_timestamps(mock_time):
+    """Old timestamps are removed when check() runs."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+
+    # Add timestamps at t=100
+    mock_time.time.return_value = 100.0
+    service.check(12345, "search")
+
+    # Move far into the future
+    mock_time.time.return_value = 200.0
+    service.check(12345, "search")
+
+    # Only the recent timestamp should remain
+    timestamps = service._records[12345]["search"]
+    assert len(timestamps) == 1
+    assert timestamps[0] == 200.0
+
+
+# ---------------------------------------------------------------------------
+# Isolation between categories and users
+# ---------------------------------------------------------------------------
+
+
+def test_different_categories_independent():
+    """Hitting search limit doesn't affect modify limit."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+
+    # Exhaust search limit (10 requests)
+    for _ in range(10):
+        service.check(12345, "search")
+
+    # search should be blocked
+    allowed, _ = service.check(12345, "search")
+    assert allowed is False
+
+    # modify should still work
+    allowed, retry_after = service.check(12345, "modify")
+    assert allowed is True
+    assert retry_after == 0
+
+
+def test_different_users_independent():
+    """User A's limits don't affect User B."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+
+    # Exhaust search limit for user 111
+    for _ in range(10):
+        service.check(111, "search")
+
+    allowed, _ = service.check(111, "search")
+    assert allowed is False
+
+    # User 222 should be unaffected
+    allowed, retry_after = service.check(222, "search")
+    assert allowed is True
+    assert retry_after == 0
+
+
+# ---------------------------------------------------------------------------
+# _get_limit() — defaults and config reading
+# ---------------------------------------------------------------------------
+
+
+def test_get_limit_defaults():
+    """Unknown category returns the default fallback (10, 60)."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+    max_req, window = service._get_limit("unknown_category")
+    assert max_req == 10
+    assert window == 60
+
+
+def test_get_limit_known_category_defaults():
+    """Known categories return their specific defaults."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+
+    max_req, window = service._get_limit("search")
+    assert max_req == 10
+    assert window == 60
+
+    max_req, window = service._get_limit("modify")
+    assert max_req == 5
+    assert window == 60
+
+    max_req, window = service._get_limit("auth")
+    assert max_req == 3
+    assert window == 300
+
+
+def test_get_limit_from_config():
+    """Config values override defaults."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+
+    # Patch config to return custom limits
+    custom_config = {
+        "enable": True,
+        "limits": {
+            "search": {"maxRequests": 20, "windowSeconds": 120},
+        },
+    }
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = custom_config
+        max_req, window = service._get_limit("search")
+
+    assert max_req == 20
+    assert window == 120
+
+
+def test_get_limit_missing_category_uses_default():
+    """Category not in config falls back to hardcoded defaults."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+
+    custom_config = {
+        "enable": True,
+        "limits": {},  # no categories configured
+    }
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = custom_config
+        max_req, window = service._get_limit("search")
+
+    assert max_req == 10
+    assert window == 60
+
+
+# ---------------------------------------------------------------------------
+# is_enabled property
+# ---------------------------------------------------------------------------
+
+
+def test_is_enabled_true():
+    """Returns True when config rateLimit.enable is true."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = {"enable": True}
+        assert service.is_enabled is True
+
+
+def test_is_enabled_false():
+    """Returns False when config rateLimit.enable is false."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = {"enable": False}
+        assert service.is_enabled is False
+
+
+def test_is_enabled_missing_config():
+    """Returns False when rateLimit section is missing from config."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+    with patch("src.services.rate_limit.config") as mock_cfg:
+        mock_cfg.get.return_value = {}
+        assert service.is_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# check() does not count blocked requests
+# ---------------------------------------------------------------------------
+
+
+@patch("src.services.rate_limit.time")
+def test_check_does_not_count_blocked_requests(mock_time):
+    """Blocked requests should not add timestamps (don't penalize further)."""
+    from src.services.rate_limit import RateLimitService
+
+    service = RateLimitService()
+    mock_time.time.return_value = 1000.0
+
+    # Fill up limit (10 allowed)
+    for _ in range(10):
+        service.check(12345, "search")
+
+    timestamps_before = len(service._records[12345]["search"])
+
+    # These should be blocked and NOT add timestamps
+    for _ in range(5):
+        allowed, _ = service.check(12345, "search")
+        assert allowed is False
+
+    timestamps_after = len(service._records[12345]["search"])
+    assert timestamps_after == timestamps_before

--- a/tests/test_utils/test_error_handler.py
+++ b/tests/test_utils/test_error_handler.py
@@ -10,6 +10,7 @@ from src.utils.error_handler import (
     ConfigError,
     ValidationError,
     ServiceNotEnabledError,
+    RateLimitExceededError,
     handle_token_error,
     handle_missing_token_error,
     handle_network_error,
@@ -55,6 +56,15 @@ class TestExceptionSubclasses:
         """ServiceNotEnabledError is a subclass of AddarrError."""
         err = ServiceNotEnabledError("radarr disabled")
         assert isinstance(err, AddarrError)
+
+    def test_rate_limit_exceeded_error_attributes(self):
+        """RateLimitExceededError stores category and retry_after."""
+        err = RateLimitExceededError("search", 23)
+        assert isinstance(err, AddarrError)
+        assert err.category == "search"
+        assert err.retry_after == 23
+        assert "search" in str(err)
+        assert "23" in str(err)
 
 
 # ---- handle_token_error ----

--- a/translations/addarr.de-de.yml
+++ b/translations/addarr.de-de.yml
@@ -216,3 +216,6 @@ de-de:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+
+  # Rate limiting
+  RateLimitExceeded: "Langsam! Bitte warte %(seconds)s Sekunden, bevor du es erneut versuchst."

--- a/translations/addarr.en-us.yml
+++ b/translations/addarr.en-us.yml
@@ -219,3 +219,6 @@ en-us:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+
+  # Rate limiting
+  RateLimitExceeded: "Slow down! Please wait %(seconds)s seconds before trying again."

--- a/translations/addarr.es-es.yml
+++ b/translations/addarr.es-es.yml
@@ -216,3 +216,6 @@ es-es:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+
+  # Rate limiting
+  RateLimitExceeded: "Demasiado rapido! Por favor espera %(seconds)s segundos antes de intentarlo de nuevo."

--- a/translations/addarr.fr-fr.yml
+++ b/translations/addarr.fr-fr.yml
@@ -216,3 +216,6 @@ fr-fr:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+
+  # Rate limiting
+  RateLimitExceeded: "Doucement ! Veuillez patienter %(seconds)s secondes avant de reessayer."

--- a/translations/addarr.it-it.yml
+++ b/translations/addarr.it-it.yml
@@ -216,3 +216,6 @@ it-it:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+
+  # Rate limiting
+  RateLimitExceeded: "Rallenta! Attendi %(seconds)s secondi prima di riprovare."

--- a/translations/addarr.nl-be.yml
+++ b/translations/addarr.nl-be.yml
@@ -216,3 +216,6 @@ nl-be:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+
+  # Rate limiting
+  RateLimitExceeded: "Rustig aan! Wacht %(seconds)s seconden voor je het opnieuw probeert."

--- a/translations/addarr.pl-pl.yml
+++ b/translations/addarr.pl-pl.yml
@@ -216,3 +216,6 @@ pl-pl:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+
+  # Rate limiting
+  RateLimitExceeded: "Zwolnij! Poczekaj %(seconds)s sekund przed ponowna proba."

--- a/translations/addarr.pt-pt.yml
+++ b/translations/addarr.pt-pt.yml
@@ -216,3 +216,6 @@ pt-pt:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+
+  # Rate limiting
+  RateLimitExceeded: "Devagar! Por favor aguarde %(seconds)s segundos antes de tentar novamente."

--- a/translations/addarr.ru-ru.yml
+++ b/translations/addarr.ru-ru.yml
@@ -216,3 +216,6 @@ ru-ru:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+
+  # Rate limiting
+  RateLimitExceeded: "Podozhdite %(seconds)s sekund pered povtornoj popytkoj."

--- a/translations/addarr.template.yml
+++ b/translations/addarr.template.yml
@@ -240,3 +240,6 @@ template:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+
+  # Rate limiting
+  RateLimitExceeded: "Slow down! Please wait %(seconds)s seconds before trying again."


### PR DESCRIPTION
## Summary

Adds per-user, per-category rate limiting to all Telegram bot command handlers. Closes #116.

- **RateLimitService** singleton with in-memory sliding window algorithm tracking `{user_id: {category: [timestamps]}}`. Three default categories: `search` (10/60s), `modify` (5/60s), `auth` (3/300s).
- **`@rate_limit("category")` decorator** mirrors `@require_auth` pattern. No-op when disabled in config. Stacks below `@require_auth` so auth runs first.
- **Handler integration**: Applied to 7 handler methods across `media.py`, `auth.py`, `delete.py`, `library.py`
- **i18n**: `RateLimitExceeded` translation key added to all 10 translation files
- **Config**: `rateLimit` section added to `config_example.yaml` (disabled by default)
- **25 new tests** (17 service + 8 decorator) with 100% coverage on `src/services/rate_limit.py`

## Test plan

- [ ] `pytest --tb=short -q` — all 1434 tests pass
- [ ] `python -m flake8 .` — clean
- [ ] `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` — all 9 locales valid
- [ ] `pytest tests/test_architecture/ -v` — all 11 architecture tests pass
- [ ] `pytest --cov=src.services.rate_limit --cov-report=term-missing` — 100% coverage
- [ ] Existing handler tests unaffected (rate limiting disabled in mock config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
