### PR TITLE
feat: add /upcoming calendar command (#104)

### DIFF
--- a/docs/issues/issue-104/TASKS.md
+++ b/docs/issues/issue-104/TASKS.md
@@ -41,7 +41,7 @@
 
 **Goal:** `MediaService.get_upcoming()` aggregates calendar data from both services into a normalized, sorted list.
 
-- [ ] **2.1** Add `get_upcoming()` to MediaService
+- [x] **2.1** Add `get_upcoming()` to MediaService
     - **Context:**
         - **Why:** The handler needs a single call to get all upcoming releases across services. MediaService already aggregates Radarr/Sonarr for search — calendar follows the same pattern.
         - **Architecture:** MediaService is a singleton (`src/services/media.py`). New method calls `self.radarr.get_calendar()` and `self.sonarr.get_calendar()` concurrently via `asyncio.gather`, then normalizes into a unified schema. Skips disabled services (checks `self.radarr is None`).
@@ -73,6 +73,18 @@
         - [RED] Write test: API error on one service — still returns results from the other (use `asyncio.gather(return_exceptions=True)` or try/except)
         - [GREEN] Implement `get_upcoming()` with date computation, concurrent fetch, normalization, sorting
     - **Success:** `pytest tests/test_services/test_media_service.py --tb=short -q` passes, all normalization and edge cases covered
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - `asyncio.gather(return_exceptions=True)` returns exceptions as values — check `isinstance(result, Exception)` to handle gracefully
+        - Radarr calendar movies have three date fields (inCinemas, digitalRelease, physicalRelease) — pick earliest non-null, sort by string since ISO format sorts correctly
+        - Sonarr calendar returns episode-level objects with nested `series` dict containing `tvdbId` and series `id`
+        - `"id" in movie` is the reliable way to detect in-library items
+    - **Key Changes:**
+        - Added `get_upcoming(days)` to `MediaService` (`src/services/media.py`)
+        - Added `_normalize_radarr_calendar()` and `_normalize_sonarr_calendar()` static methods
+        - Added `get_calendar` to mock fixtures in `tests/test_services/conftest.py`
+        - Added `TestGetUpcoming` class with 11 tests covering all edge cases
+    - **Notes:** 100% coverage on media.py (373 statements)
 
 ---
 

--- a/docs/issues/issue-104/TASKS.md
+++ b/docs/issues/issue-104/TASKS.md
@@ -141,7 +141,7 @@
 
 **Goal:** Working `/upcoming` command with inline navigation, pagination, and Add to Library.
 
-- [ ] **4.1** Implement CalendarHandler
+- [x] **4.1** Implement CalendarHandler
     - **Context:**
         - **Why:** This is the core feature — the Telegram handler that ties everything together.
         - **Architecture:** Follows `SystemHandler` pattern (`src/bot/handlers/system.py`): `CommandHandler` for `/upcoming` + `CallbackQueryHandler` for `cal_*` callbacks. No conversation states needed. Uses `context.user_data` to cache calendar items (avoids re-fetching on pagination) and store current period.
@@ -164,6 +164,17 @@
         - [RED] Write test: unauthenticated user — blocked by @require_auth
         - [GREEN] Implement CalendarHandler class with all methods
     - **Success:** `pytest tests/test_handlers/test_calendar_handler.py --tb=short -q` passes, all handler paths covered
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - CalendarHandler follows SystemHandler pattern (CommandHandler + CallbackQueryHandler, no ConversationHandler states)
+        - `_build_response()` helper eliminates duplicated text/keyboard building across show, period, refresh
+        - Quick-add uses first root folder + first quality profile from the respective API client
+        - Sonarr episode "add" actually calls `add_series_with_profile` with the tvdbId
+    - **Key Changes:**
+        - Created `src/bot/handlers/calendar.py` with CalendarHandler class (97 statements)
+        - Created `tests/test_handlers/test_calendar_handler.py` with 17 tests
+        - Updated `tests/test_handlers/conftest.py` — added keyboard patches to calendar_handler fixture
+    - **Notes:** 100% coverage on calendar.py. Handler not yet wired into bot (task 4.2)
 
 - [ ] **4.2** Register CalendarHandler and wire into bot
     - **Context:**

--- a/docs/issues/issue-104/TASKS.md
+++ b/docs/issues/issue-104/TASKS.md
@@ -1,0 +1,164 @@
+# Issue #104: Calendar / Upcoming Releases (`/upcoming`)
+
+> **Plan:** [docs/issues/issue-104/plan.md](plan.md)
+> **Branch:** `feature/104-upcoming-calendar`
+> **Issue:** https://github.com/Krypt0nBull3t/Addarr/issues/104
+
+---
+
+### Phase 1: Backend — API Client Calendar Methods (1 task)
+
+**Goal:** Both RadarrClient and SonarrClient can fetch calendar data from their respective APIs.
+
+- [x] **1.1** Add `get_calendar()` to RadarrClient and SonarrClient
+    - **Context:**
+        - **Why:** Radarr and Sonarr both expose `GET /api/v3/calendar?start=&end=` but we have no client methods for them. This is the data source for everything else.
+        - **Architecture:** Each client inherits `BaseApiClient`. New methods use `self._request()` convenience wrapper (returns parsed JSON or None). Follow the pattern of `get_movies()` (radarr.py:196) and `get_all_series()` (sonarr.py:202) — simple `_request()` call, log, return list.
+        - **Key refs:** `src/api/base.py:226` (`_request` wrapper), `src/api/radarr.py:196` (`get_movies` pattern), `src/api/sonarr.py:202` (`get_all_series` pattern), `tests/test_api/conftest.py` (API test fixtures with `aioresponses`), `tests/test_api/test_radarr.py` (existing Radarr test patterns)
+        - **Watch out:** Endpoint is `calendar?start={start}&end={end}` (query params in path string, same as `movie/lookup?term={term}` pattern at radarr.py:47). Both APIs return arrays directly. Use `_request()` not `_make_request()` — the convenience wrapper handles error → None. Don't forget `from typing import List, Dict` is already imported in both files.
+    - **Scope:** Add `get_calendar(start: str, end: str) -> List[Dict]` to both RadarrClient and SonarrClient + full test coverage
+    - **Touches:** `src/api/radarr.py`, `src/api/sonarr.py`, `tests/test_api/test_radarr.py`, `tests/test_api/test_sonarr.py`
+    - **Action items:**
+        - [RED] Write tests for `RadarrClient.get_calendar()` — happy path (returns list of movies), empty result, API error/exception
+        - [RED] Write tests for `SonarrClient.get_calendar()` — happy path (returns list of episodes), empty result, API error/exception
+        - [GREEN] Implement `RadarrClient.get_calendar()` — `_request(f"calendar?start={start}&end={end}")`, log, return list or `[]`
+        - [GREEN] Implement `SonarrClient.get_calendar()` — identical pattern
+    - **Success:** `pytest tests/test_api/test_radarr.py tests/test_api/test_sonarr.py --tb=short -q` passes, new methods return calendar data
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - Calendar endpoint uses query params in path string (`calendar?start={start}&end={end}`), same pattern as `movie/lookup?term={term}`
+        - Both Radarr and Sonarr return arrays directly from the calendar endpoint
+        - `_request()` convenience wrapper handles errors → None cleanly; `not results` catches both None and empty list
+    - **Key Changes:**
+        - Added `get_calendar(start, end)` to `RadarrClient` (`src/api/radarr.py`)
+        - Added `get_calendar(start, end)` to `SonarrClient` (`src/api/sonarr.py`)
+        - Added `TestRadarrGetCalendar` and `TestSonarrGetCalendar` test classes (6 tests total)
+    - **Notes:** 100% coverage on both radarr.py and sonarr.py
+
+---
+
+### Phase 2: Backend — Service Layer (1 task)
+
+**Goal:** `MediaService.get_upcoming()` aggregates calendar data from both services into a normalized, sorted list.
+
+- [ ] **2.1** Add `get_upcoming()` to MediaService
+    - **Context:**
+        - **Why:** The handler needs a single call to get all upcoming releases across services. MediaService already aggregates Radarr/Sonarr for search — calendar follows the same pattern.
+        - **Architecture:** MediaService is a singleton (`src/services/media.py`). New method calls `self.radarr.get_calendar()` and `self.sonarr.get_calendar()` concurrently via `asyncio.gather`, then normalizes into a unified schema. Skips disabled services (checks `self.radarr is None`).
+        - **Key refs:** `src/services/media.py:100` (`search_movies` for Radarr delegation pattern), `src/services/media.py:180` (`search_music` for `asyncio.gather` pattern), `tests/test_services/test_media_service.py` (service test patterns), `tests/test_services/conftest.py`
+        - **Watch out:** Radarr calendar returns movie-level objects (has `inCinemas`, `digitalRelease`, `physicalRelease` — pick earliest non-null as the "date", label accordingly). Sonarr calendar returns episode-level objects (has `airDateUtc` for date, `series` nested object for series-level info like `tvdbId`). Items with `id` field are already in the library (monitored). Use `datetime.date.today()` for start date computation — import `datetime` at top of file (already imported: `asyncio`).
+    - **Scope:** `get_upcoming(days=7)` returning normalized list of dicts sorted by date, with `in_library` flag
+    - **Touches:** `src/services/media.py`, `tests/test_services/test_media_service.py`
+    - **Normalized item schema:**
+        ```
+        type: "movie" | "episode"
+        title: str              # Movie title or episode title
+        series_title: str|None  # None for movies, series name for episodes
+        date: str               # YYYY-MM-DD
+        date_label: str         # "Cinema" / "Digital" / "Physical" / "Airing"
+        year: int|None          # Movie year
+        season: int|None        # Episode season number
+        episode: int|None       # Episode number
+        in_library: bool        # True if item has an internal ID (already monitored)
+        media_id: str           # tmdbId (movies) or series tvdbId (episodes)
+        internal_id: int|None   # Radarr movie ID or Sonarr series ID
+        ```
+    - **Action items:**
+        - [RED] Write test: both services enabled — returns combined, date-sorted list with correct normalization
+        - [RED] Write test: only Radarr enabled (sonarr is None) — returns only movies
+        - [RED] Write test: only Sonarr enabled (radarr is None) — returns only episodes
+        - [RED] Write test: neither enabled — returns `[]`
+        - [RED] Write test: Radarr movie date selection — picks earliest of inCinemas/digitalRelease/physicalRelease, labels correctly
+        - [RED] Write test: items with `id` field have `in_library=True`, items without have `in_library=False`
+        - [RED] Write test: API error on one service — still returns results from the other (use `asyncio.gather(return_exceptions=True)` or try/except)
+        - [GREEN] Implement `get_upcoming()` with date computation, concurrent fetch, normalization, sorting
+    - **Success:** `pytest tests/test_services/test_media_service.py --tb=short -q` passes, all normalization and edge cases covered
+
+---
+
+### Phase 3: UI Infrastructure — Keyboards & i18n (1 task)
+
+**Goal:** Calendar keyboard functions and translation keys are ready for the handler to use.
+
+- [ ] **3.1** Add calendar keyboards and translation keys
+    - **Context:**
+        - **Why:** CalendarHandler (next task) needs keyboard layouts and translated strings. Building these first means the handler can focus on logic.
+        - **Architecture:** Keyboards in `src/bot/keyboards.py` follow the pattern of `get_system_keyboard()` (simple buttons) and `get_search_results_list_keyboard()` (paginated). Translations use flat top-level keys in YAML files (NOT nested — `get_text()` does single-level lookup).
+        - **Key refs:** `src/bot/keyboards.py:64` (`get_system_keyboard` — simple layout), `src/bot/keyboards.py:295` (`get_search_results_list_keyboard` — pagination pattern), `tests/test_bot/test_keyboards.py` (keyboard tests), `translations/addarr.en-us.yml` (English translation file)
+        - **Watch out:** Callback data prefix is `cal_` for all calendar buttons. All callback_data strings must be under 64 bytes (Telegram limit). Translation keys must be flat top-level (e.g., `CalendarTitle` not `Calendar.Title`). Template file is `translations/addarr.template.yml`. There are 9 locale files plus the template — all need the same keys added.
+    - **Scope:** Two keyboard functions + translation keys across all locale files
+    - **Touches:** `src/bot/keyboards.py`, `tests/test_bot/test_keyboards.py`, `translations/addarr.*.yml` (9 locales + template)
+    - **Keyboard functions:**
+        1. `get_calendar_keyboard(days: int)` — Period row (7d/14d/30d, current highlighted with checkmark), Refresh button, Back button
+        2. `get_calendar_items_keyboard(items, page, days, page_size=5)` — Item buttons (emoji + title, `cal_add_{type}_{media_id}` for non-library items), pagination row, period/refresh/back row
+    - **Callback data conventions:**
+        - `cal_period_7`, `cal_period_14`, `cal_period_30`
+        - `cal_page_0`, `cal_page_1`, ...
+        - `cal_refresh`
+        - `cal_back`
+        - `cal_add_movie_{tmdbId}`, `cal_add_episode_{tvdbId}`
+    - **Translation keys to add:**
+        ```
+        Upcoming, CommandUpcoming, CalendarTitle, CalendarEmpty,
+        CalendarMovie, CalendarEpisode, CalendarCinema, CalendarDigital,
+        CalendarPhysical, CalendarAiring, CalendarDays7, CalendarDays14,
+        CalendarDays30, CalendarAddSuccess, CalendarAddFailed,
+        CalendarAlreadyInLibrary
+        ```
+    - **Action items:**
+        - [RED] Write tests for `get_calendar_keyboard()` — verify period buttons with correct callback_data, current period highlighted, refresh + back buttons present
+        - [RED] Write tests for `get_calendar_items_keyboard()` — verify item buttons, add buttons only for non-library items, pagination when items > page_size, no pagination for single page
+        - [GREEN] Implement `get_calendar_keyboard()`
+        - [GREEN] Implement `get_calendar_items_keyboard()`
+        - [GREEN] Add translation keys to all 10 YAML files (9 locales + template)
+    - **Success:** `pytest tests/test_bot/test_keyboards.py --tb=short -q` passes, `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` passes
+
+---
+
+### Phase 4: Handler — CalendarHandler + Registration (2 tasks)
+
+**Goal:** Working `/upcoming` command with inline navigation, pagination, and Add to Library.
+
+- [ ] **4.1** Implement CalendarHandler
+    - **Context:**
+        - **Why:** This is the core feature — the Telegram handler that ties everything together.
+        - **Architecture:** Follows `SystemHandler` pattern (`src/bot/handlers/system.py`): `CommandHandler` for `/upcoming` + `CallbackQueryHandler` for `cal_*` callbacks. No conversation states needed. Uses `context.user_data` to cache calendar items (avoids re-fetching on pagination) and store current period.
+        - **Key refs:** `src/bot/handlers/system.py` (simple handler pattern — CommandHandler + CallbackQueryHandler), `src/bot/handlers/auth.py:37` (`@require_auth` decorator), `src/services/rate_limit.py` (`@rate_limit("search")` decorator), `tests/test_handlers/conftest.py` (handler fixture pattern with patched services), `tests/test_handlers/test_system_handler.py` (simple handler tests)
+        - **Watch out:** `@require_auth` expects `self` as first arg (it's a method decorator, checks `update.effective_user`). For callback queries, `update.message` is None — use `update.callback_query.message` for editing. Quick-add needs first root folder + first quality profile — call `radarr.get_root_folders()` and `radarr.get_quality_profiles()` (accessed via `self.media_service.radarr`). Sonarr episodes "Add" actually adds the series (by tvdbId). `query.answer(text)` shows a toast, `query.message.edit_text()` updates the message.
+    - **Scope:** Full CalendarHandler class with show_upcoming, handle_calendar_action, period/page/refresh/back/add handlers
+    - **Touches:** `src/bot/handlers/calendar.py` (create), `tests/test_handlers/test_calendar_handler.py` (create), `tests/test_handlers/conftest.py` (add calendar_handler fixture)
+    - **Action items:**
+        - [RED] Write `calendar_handler` fixture in `tests/test_handlers/conftest.py` — patch MediaService, TranslationService, set auth
+        - [RED] Write test: `show_upcoming` with results — sends message with calendar text and keyboard
+        - [RED] Write test: `show_upcoming` with empty results — sends "no upcoming releases" message
+        - [RED] Write test: `show_upcoming` via callback query (menu_upcoming) — edits message instead of sending new
+        - [RED] Write test: period change (`cal_period_14`) — updates user_data, re-fetches, edits message
+        - [RED] Write test: pagination (`cal_page_1`) — shows second page from cached items
+        - [RED] Write test: refresh (`cal_refresh`) — clears cache, re-fetches
+        - [RED] Write test: back (`cal_back`) — returns to main menu
+        - [RED] Write test: add movie (`cal_add_movie_12345`) — calls add_movie_with_profile, shows toast
+        - [RED] Write test: add movie failure — shows error toast
+        - [RED] Write test: add episode (`cal_add_episode_67890`) — calls add_series_with_profile, shows toast
+        - [RED] Write test: unauthenticated user — blocked by @require_auth
+        - [GREEN] Implement CalendarHandler class with all methods
+    - **Success:** `pytest tests/test_handlers/test_calendar_handler.py --tb=short -q` passes, all handler paths covered
+
+- [ ] **4.2** Register CalendarHandler and wire into bot
+    - **Context:**
+        - **Why:** Handler exists but isn't wired into the bot yet. Need to register it, add the command to Telegram's menu, add it to the main menu keyboard, and route the main menu callback.
+        - **Architecture:** Handler registration in `src/main.py:_add_handlers()`. Command registration in `src/bot/commands.py:build_authenticated_commands()`. Main menu keyboard in `src/bot/keyboards.py:get_main_menu_keyboard()`. StartHandler routes `menu_*` callbacks to handlers.
+        - **Key refs:** `src/main.py:102` (`_add_handlers` — registration order), `src/bot/commands.py:31` (`build_authenticated_commands`), `src/bot/keyboards.py:14` (`get_main_menu_keyboard`), `src/bot/handlers/start.py` (menu callback routing), `src/bot/handlers/__init__.py` (handler exports), `tests/test_main.py`, `tests/test_bot/test_commands.py`
+        - **Watch out:** Handler registration ORDER matters — put CalendarHandler after Media handler, before Transmission. The `/upcoming` command should only appear when Radarr OR Sonarr is enabled. StartHandler needs to handle `menu_upcoming` callback. Architecture tests (`tests/test_architecture/`) will auto-verify the handler has `get_handler()` and doesn't violate layer boundaries — run them to confirm.
+    - **Scope:** Import + register handler, export, command registration, main menu button, start handler routing
+    - **Touches:** `src/main.py`, `src/bot/handlers/__init__.py`, `src/bot/commands.py`, `src/bot/keyboards.py`, `src/bot/handlers/start.py`, `tests/test_main.py`, `tests/test_bot/test_commands.py`, `tests/test_bot/test_keyboards.py`
+    - **Action items:**
+        - [RED] Write test: `/upcoming` appears in authenticated commands when Radarr or Sonarr enabled
+        - [RED] Write test: `/upcoming` does NOT appear when neither Radarr nor Sonarr enabled
+        - [RED] Write test: main menu keyboard includes "Upcoming" button
+        - [GREEN] Add CalendarHandler import and registration to `src/main.py:_add_handlers()`
+        - [GREEN] Export CalendarHandler from `src/bot/handlers/__init__.py`
+        - [GREEN] Add `/upcoming` to `build_authenticated_commands()` (conditional on Radarr/Sonarr)
+        - [GREEN] Add "📅 Upcoming" button to `get_main_menu_keyboard()`
+        - [GREEN] Handle `menu_upcoming` callback in StartHandler
+        - [GREEN] Run architecture tests to verify no violations: `pytest tests/test_architecture/ --tb=short -q`
+    - **Success:** `pytest --tb=short -q` all pass, `python -m flake8 .` clean, `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` passes, architecture tests pass

--- a/docs/issues/issue-104/TASKS.md
+++ b/docs/issues/issue-104/TASKS.md
@@ -92,7 +92,7 @@
 
 **Goal:** Calendar keyboard functions and translation keys are ready for the handler to use.
 
-- [ ] **3.1** Add calendar keyboards and translation keys
+- [x] **3.1** Add calendar keyboards and translation keys
     - **Context:**
         - **Why:** CalendarHandler (next task) needs keyboard layouts and translated strings. Building these first means the handler can focus on logic.
         - **Architecture:** Keyboards in `src/bot/keyboards.py` follow the pattern of `get_system_keyboard()` (simple buttons) and `get_search_results_list_keyboard()` (paginated). Translations use flat top-level keys in YAML files (NOT nested — `get_text()` does single-level lookup).
@@ -124,6 +124,16 @@
         - [GREEN] Implement `get_calendar_items_keyboard()`
         - [GREEN] Add translation keys to all 10 YAML files (9 locales + template)
     - **Success:** `pytest tests/test_bot/test_keyboards.py --tb=short -q` passes, `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` passes
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - Translation keys must be flat top-level (e.g., `CalendarTitle` not `Calendar.Title`) — `get_text()` does single-level lookup
+        - Calendar items keyboard needs both display buttons and add buttons as separate rows — display shows the item, add button triggers the action
+        - Pagination in calendar follows same ceil-division pattern as search results list
+    - **Key Changes:**
+        - Added `get_calendar_keyboard(days)` and `get_calendar_items_keyboard(items, page, days)` to `src/bot/keyboards.py`
+        - Added 16 calendar translation keys to all 10 YAML files
+        - Added `TestCalendarKeyboard` (5 tests) and `TestCalendarItemsKeyboard` (7 tests) to `tests/test_bot/test_keyboards.py`
+    - **Notes:** 100% coverage on keyboards.py, all i18n validation passes
 
 ---
 

--- a/docs/issues/issue-104/TASKS.md
+++ b/docs/issues/issue-104/TASKS.md
@@ -176,7 +176,7 @@
         - Updated `tests/test_handlers/conftest.py` — added keyboard patches to calendar_handler fixture
     - **Notes:** 100% coverage on calendar.py. Handler not yet wired into bot (task 4.2)
 
-- [ ] **4.2** Register CalendarHandler and wire into bot
+- [x] **4.2** Register CalendarHandler and wire into bot
     - **Context:**
         - **Why:** Handler exists but isn't wired into the bot yet. Need to register it, add the command to Telegram's menu, add it to the main menu keyboard, and route the main menu callback.
         - **Architecture:** Handler registration in `src/main.py:_add_handlers()`. Command registration in `src/bot/commands.py:build_authenticated_commands()`. Main menu keyboard in `src/bot/keyboards.py:get_main_menu_keyboard()`. StartHandler routes `menu_*` callbacks to handlers.
@@ -195,3 +195,17 @@
         - [GREEN] Handle `menu_upcoming` callback in StartHandler
         - [GREEN] Run architecture tests to verify no violations: `pytest tests/test_architecture/ --tb=short -q`
     - **Success:** `pytest --tb=short -q` all pass, `python -m flake8 .` clean, `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` passes, architecture tests pass
+    - **Completed:** 2026-03-03
+    - **Learnings:**
+        - CalendarHandler is always-on (not conditional) — registered like other handlers in `_add_handlers()`
+        - The `/upcoming` command is conditional on Radarr OR Sonarr in `build_authenticated_commands()`
+        - StartHandler routes `menu_upcoming` to `calendar_handler.show_upcoming()` and returns `ConversationHandler.END` so the standalone `cal_*` CallbackQueryHandler can pick up further interactions
+        - Existing command count tests needed updating since Radarr/Sonarr now also trigger the `upcoming` command
+    - **Key Changes:**
+        - Registered CalendarHandler in `src/main.py:_add_handlers()` (after Library, before Transmission)
+        - Exported from `src/bot/handlers/__init__.py`
+        - Added `/upcoming` to `build_authenticated_commands()` (conditional on Radarr/Sonarr)
+        - Added "📅 Upcoming" button to `get_main_menu_keyboard()`
+        - Added `menu_upcoming` routing in `StartHandler.handle_menu_selection()`
+        - Updated test counts and added new tests in test_commands.py, test_keyboards.py, test_main.py, test_start_handler.py
+    - **Notes:** 100% coverage on all changed modules. Handler count is now 10 always-on (was 9)

--- a/src/api/radarr.py
+++ b/src/api/radarr.py
@@ -193,6 +193,23 @@ class RadarrClient(BaseApiClient):
             logger.error(f"❌ Error in add_movie: {str(e)}")
             return False, str(e)
 
+    async def get_calendar(self, start: str, end: str) -> List[Dict]:
+        """Get upcoming movie releases within a date range"""
+        try:
+            logger.info(Fore.BLUE + f"🔍 Getting Radarr calendar: {start} to {end}")
+            results = await self._request(f"calendar?start={start}&end={end}")
+
+            if not results:
+                logger.warning(Fore.YELLOW + "⚠️ No upcoming movies found")
+                return []
+
+            logger.info(Fore.GREEN + f"✅ Found {len(results)} upcoming movies")
+            return results
+
+        except Exception as e:
+            logger.error(Fore.RED + f"❌ Failed to get calendar: {str(e)}")
+            return []
+
     async def get_movies(self) -> List[Dict]:
         """Get all movies in the library"""
         try:

--- a/src/api/sonarr.py
+++ b/src/api/sonarr.py
@@ -199,6 +199,23 @@ class SonarrClient(BaseApiClient):
             logger.error(f"❌ Failed to get series: {str(e)}")
             return None
 
+    async def get_calendar(self, start: str, end: str) -> List[Dict]:
+        """Get upcoming episode airings within a date range"""
+        try:
+            logger.info(Fore.BLUE + f"🔍 Getting Sonarr calendar: {start} to {end}")
+            results = await self._request(f"calendar?start={start}&end={end}")
+
+            if not results:
+                logger.warning(Fore.YELLOW + "⚠️ No upcoming episodes found")
+                return []
+
+            logger.info(Fore.GREEN + f"✅ Found {len(results)} upcoming episodes")
+            return results
+
+        except Exception as e:
+            logger.error(Fore.RED + f"❌ Failed to get calendar: {str(e)}")
+            return []
+
     async def get_all_series(self) -> List[Dict]:
         """Get all series in the library"""
         try:

--- a/src/bot/commands.py
+++ b/src/bot/commands.py
@@ -54,6 +54,9 @@ def build_authenticated_commands() -> list:
         commands.append(BotCommand("music", translation.get_text("CommandMusic")))
         commands.append(BotCommand("allmusic", translation.get_text("CommandAllMusic")))
 
+    if config.get("radarr", {}).get("enable") or config.get("sonarr", {}).get("enable"):
+        commands.append(BotCommand("upcoming", translation.get_text("CommandUpcoming")))
+
     if config.get("transmission", {}).get("enable", False):
         commands.append(BotCommand("transmission", translation.get_text("CommandTransmission")))
 

--- a/src/bot/handlers/__init__.py
+++ b/src/bot/handlers/__init__.py
@@ -10,6 +10,7 @@ Each handler is responsible for managing a specific type of user interaction.
 """
 
 from .auth import AuthHandler
+from .calendar import CalendarHandler
 from .media import MediaHandler
 from .delete import DeleteHandler
 from .library import LibraryHandler
@@ -17,6 +18,6 @@ from .settings import SettingsHandler
 from .system import SystemHandler
 
 __all__ = [
-    'AuthHandler', 'MediaHandler', 'DeleteHandler',
+    'AuthHandler', 'CalendarHandler', 'MediaHandler', 'DeleteHandler',
     'LibraryHandler', 'SettingsHandler', 'SystemHandler',
 ]

--- a/src/bot/handlers/calendar.py
+++ b/src/bot/handlers/calendar.py
@@ -5,6 +5,8 @@ Created Date: 2026-03-03
 Description: Calendar/upcoming releases handler module.
 """
 
+import asyncio
+
 from telegram import Update
 from telegram.ext import CommandHandler, CallbackQueryHandler, ContextTypes
 
@@ -47,8 +49,7 @@ class CalendarHandler:
 
         log_user_interaction(logger, update.effective_user, "/upcoming")
 
-        days = context.user_data.get("cal_days", 7)
-        context.user_data["cal_days"] = days
+        days = context.user_data.setdefault("cal_days", 7)
 
         items = await self.media_service.get_upcoming(days)
         context.user_data["cal_items"] = items
@@ -88,17 +89,20 @@ class CalendarHandler:
         else:
             await query.answer()
 
-    async def _handle_period(self, query, context):
-        """Change the calendar period and re-fetch."""
-        days = int(query.data.split("_")[-1])
+    async def _fetch_and_display(self, query, context, days):
+        """Fetch calendar data, cache it, and update the message."""
         context.user_data["cal_days"] = days
-
         items = await self.media_service.get_upcoming(days)
         context.user_data["cal_items"] = items
 
         text, keyboard = self._build_response(items, days)
         await query.message.edit_text(text, reply_markup=keyboard)
         await query.answer()
+
+    async def _handle_period(self, query, context):
+        """Change the calendar period and re-fetch."""
+        days = int(query.data.split("_")[-1])
+        await self._fetch_and_display(query, context, days)
 
     async def _handle_page(self, query, context):
         """Show a different page of cached calendar items."""
@@ -113,13 +117,7 @@ class CalendarHandler:
     async def _handle_refresh(self, query, context):
         """Clear cache and re-fetch calendar data."""
         days = context.user_data.get("cal_days", 7)
-
-        items = await self.media_service.get_upcoming(days)
-        context.user_data["cal_items"] = items
-
-        text, keyboard = self._build_response(items, days)
-        await query.message.edit_text(text, reply_markup=keyboard)
-        await query.answer()
+        await self._fetch_and_display(query, context, days)
 
     async def _handle_back(self, query):
         """Return to the main menu."""
@@ -138,14 +136,18 @@ class CalendarHandler:
 
         try:
             if media_type == "movie":
-                root_folders = await self.media_service.radarr.get_root_folders()
-                profiles = await self.media_service.radarr.get_quality_profiles()
+                root_folders, profiles = await asyncio.gather(
+                    self.media_service.radarr.get_root_folders(),
+                    self.media_service.radarr.get_quality_profiles(),
+                )
                 success, msg = await self.media_service.add_movie_with_profile(
                     media_id, profiles[0]["id"], root_folders[0]
                 )
             elif media_type == "episode":
-                root_folders = await self.media_service.sonarr.get_root_folders()
-                profiles = await self.media_service.sonarr.get_quality_profiles()
+                root_folders, profiles = await asyncio.gather(
+                    self.media_service.sonarr.get_root_folders(),
+                    self.media_service.sonarr.get_quality_profiles(),
+                )
                 success, msg = await self.media_service.add_series_with_profile(
                     media_id, profiles[0]["id"], root_folders[0]
                 )

--- a/src/bot/handlers/calendar.py
+++ b/src/bot/handlers/calendar.py
@@ -1,0 +1,185 @@
+"""
+Filename: calendar.py
+Author: Addarr Contributors
+Created Date: 2026-03-03
+Description: Calendar/upcoming releases handler module.
+"""
+
+from telegram import Update
+from telegram.ext import CommandHandler, CallbackQueryHandler, ContextTypes
+
+from src.utils.logger import get_logger, log_user_interaction
+from src.bot.handlers.auth import require_auth
+from src.bot.keyboards import (
+    get_calendar_keyboard,
+    get_calendar_items_keyboard,
+    get_main_menu_keyboard,
+)
+from src.services.media import MediaService
+from src.services.translation import TranslationService
+
+logger = get_logger("addarr.calendar")
+
+
+class CalendarHandler:
+    """Handler for upcoming releases calendar"""
+
+    def __init__(self):
+        self.media_service = MediaService()
+        self.translation = TranslationService()
+
+    def get_handler(self):
+        """Get calendar command handlers"""
+        return [
+            CommandHandler("upcoming", self.show_upcoming),
+            CallbackQueryHandler(
+                self.handle_calendar_action, pattern="^cal_"
+            ),
+        ]
+
+    @require_auth
+    async def show_upcoming(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Show upcoming releases with inline keyboard."""
+        if not update.effective_user:  # pragma: no cover
+            return
+
+        log_user_interaction(logger, update.effective_user, "/upcoming")
+
+        days = context.user_data.get("cal_days", 7)
+        context.user_data["cal_days"] = days
+
+        items = await self.media_service.get_upcoming(days)
+        context.user_data["cal_items"] = items
+
+        text, keyboard = self._build_response(items, days)
+
+        if update.callback_query:
+            await update.callback_query.message.edit_text(
+                text, reply_markup=keyboard
+            )
+        else:
+            await update.message.reply_text(text, reply_markup=keyboard)
+
+    @require_auth
+    async def handle_calendar_action(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle calendar callback button presses."""
+        if not update.callback_query:
+            return
+
+        query = update.callback_query
+        data = query.data
+
+        log_user_interaction(logger, query.from_user, data)
+
+        if data.startswith("cal_period_"):
+            await self._handle_period(query, context)
+        elif data.startswith("cal_page_"):
+            await self._handle_page(query, context)
+        elif data == "cal_refresh":
+            await self._handle_refresh(query, context)
+        elif data == "cal_back":
+            await self._handle_back(query)
+        elif data.startswith("cal_add_"):
+            await self._handle_add(query, context)
+        else:
+            await query.answer()
+
+    async def _handle_period(self, query, context):
+        """Change the calendar period and re-fetch."""
+        days = int(query.data.split("_")[-1])
+        context.user_data["cal_days"] = days
+
+        items = await self.media_service.get_upcoming(days)
+        context.user_data["cal_items"] = items
+
+        text, keyboard = self._build_response(items, days)
+        await query.message.edit_text(text, reply_markup=keyboard)
+        await query.answer()
+
+    async def _handle_page(self, query, context):
+        """Show a different page of cached calendar items."""
+        page = int(query.data.split("_")[-1])
+        items = context.user_data.get("cal_items", [])
+        days = context.user_data.get("cal_days", 7)
+
+        text, keyboard = self._build_response(items, days, page)
+        await query.message.edit_text(text, reply_markup=keyboard)
+        await query.answer()
+
+    async def _handle_refresh(self, query, context):
+        """Clear cache and re-fetch calendar data."""
+        days = context.user_data.get("cal_days", 7)
+
+        items = await self.media_service.get_upcoming(days)
+        context.user_data["cal_items"] = items
+
+        text, keyboard = self._build_response(items, days)
+        await query.message.edit_text(text, reply_markup=keyboard)
+        await query.answer()
+
+    async def _handle_back(self, query):
+        """Return to the main menu."""
+        await query.message.edit_text(
+            "\U0001f3e0 Main Menu",
+            reply_markup=get_main_menu_keyboard(),
+        )
+        await query.answer()
+
+    async def _handle_add(self, query, context):
+        """Quick-add media from calendar using first root folder and profile."""
+        # Parse: cal_add_movie_12345 or cal_add_episode_67890
+        parts = query.data.split("_")
+        media_type = parts[2]
+        media_id = parts[3]
+
+        try:
+            if media_type == "movie":
+                root_folders = await self.media_service.radarr.get_root_folders()
+                profiles = await self.media_service.radarr.get_quality_profiles()
+                success, msg = await self.media_service.add_movie_with_profile(
+                    media_id, profiles[0]["id"], root_folders[0]
+                )
+            elif media_type == "episode":
+                root_folders = await self.media_service.sonarr.get_root_folders()
+                profiles = await self.media_service.sonarr.get_quality_profiles()
+                success, msg = await self.media_service.add_series_with_profile(
+                    media_id, profiles[0]["id"], root_folders[0]
+                )
+            else:
+                await query.answer("Unknown media type")
+                return
+
+            if success:
+                await query.answer(
+                    self.translation.get_text("CalendarAddSuccess")
+                )
+            else:
+                await query.answer(
+                    self.translation.get_text("CalendarAddFailed")
+                )
+        except Exception as e:
+            logger.error(f"Error adding media from calendar: {e}")
+            await query.answer(
+                self.translation.get_text("CalendarAddFailed")
+            )
+
+    def _build_response(self, items, days, page=0):
+        """Build calendar text and keyboard from items."""
+        if items:
+            title = self.translation.get_text("CalendarTitle")
+            text = (
+                f"\U0001f4c5 {title}\n\n"
+                f"{len(items)} releases \u2014 {days} days"
+            )
+            keyboard = get_calendar_items_keyboard(items, page, days)
+        else:
+            text = (
+                f"\U0001f4c5 {self.translation.get_text('CalendarTitle')}"
+                f"\n\n{self.translation.get_text('CalendarEmpty')}"
+            )
+            keyboard = get_calendar_keyboard(days)
+        return text, keyboard

--- a/src/bot/handlers/start.py
+++ b/src/bot/handlers/start.py
@@ -19,6 +19,7 @@ from telegram.ext import (
 from src.utils.logger import get_logger, log_user_interaction
 from src.bot.handlers.auth import require_auth
 from src.bot.handlers.media import MediaHandler, SEARCHING, SELECTING
+from src.bot.handlers.calendar import CalendarHandler
 from src.bot.handlers.help import HelpHandler
 from src.bot.handlers.system import SystemHandler
 from src.bot.keyboards import get_main_menu_keyboard
@@ -33,6 +34,7 @@ class StartHandler:
 
     def __init__(self):
         self.media_handler = MediaHandler()
+        self.calendar_handler = CalendarHandler()
         self.help_handler = HelpHandler()
         self.system_handler = SystemHandler()
         self.translation = TranslationService()
@@ -180,6 +182,10 @@ class StartHandler:
             )
 
             return SEARCHING
+
+        if action == "upcoming":
+            await self.calendar_handler.show_upcoming(update, context)
+            return ConversationHandler.END
 
         # For commands that end the conversation
         if action in ["status", "help", "delete"]:

--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -471,6 +471,127 @@ def get_album_selection_keyboard(
     return InlineKeyboardMarkup(keyboard)
 
 
+def get_calendar_keyboard(days: int) -> InlineKeyboardMarkup:
+    """Get calendar period/navigation keyboard.
+
+    Args:
+        days: Currently selected period (7, 14, or 30).
+    """
+    translation = TranslationService()
+    periods = [
+        (7, translation.get_text("CalendarDays7", default="7 days")),
+        (14, translation.get_text("CalendarDays14", default="14 days")),
+        (30, translation.get_text("CalendarDays30", default="30 days")),
+    ]
+    period_row = []
+    for period_days, label in periods:
+        text = f"\u2705 {label}" if period_days == days else label
+        period_row.append(
+            InlineKeyboardButton(text, callback_data=f"cal_period_{period_days}")
+        )
+    keyboard = [
+        period_row,
+        [InlineKeyboardButton(
+            "\U0001f504 Refresh", callback_data="cal_refresh"
+        )],
+        [InlineKeyboardButton(
+            f"\u25c0\ufe0f {translation.get_text('Back')}",
+            callback_data="cal_back"
+        )],
+    ]
+    return InlineKeyboardMarkup(keyboard)
+
+
+def get_calendar_items_keyboard(
+    items: list, page: int, days: int, page_size: int = 5,
+) -> InlineKeyboardMarkup:
+    """Get paginated calendar items keyboard.
+
+    Args:
+        items: Full list of normalized calendar items.
+        page: Current page (0-indexed).
+        days: Currently selected period for period buttons.
+        page_size: Number of items per page.
+    """
+    translation = TranslationService()
+    type_emoji = {
+        "movie": "\U0001f3ac",
+        "episode": "\U0001f4fa",
+    }
+
+    total_pages = max(1, -(-len(items) // page_size))
+    start = page * page_size
+    end = start + page_size
+    page_items = items[start:end]
+
+    keyboard = []
+
+    # Item buttons
+    for item in page_items:
+        emoji = type_emoji.get(item["type"], "\U0001f3ac")
+        title = item["title"]
+        keyboard.append([
+            InlineKeyboardButton(
+                f"{emoji} {title}", callback_data="cal_noop"
+            )
+        ])
+        # Add button for non-library items
+        if not item.get("in_library"):
+            keyboard.append([
+                InlineKeyboardButton(
+                    f"\u2795 {translation.get_text('Add')}",
+                    callback_data=f"cal_add_{item['type']}_{item['media_id']}"
+                )
+            ])
+
+    # Pagination row
+    if total_pages > 1:
+        nav_row = []
+        if page > 0:
+            nav_row.append(
+                InlineKeyboardButton(
+                    "\u25c0\ufe0f Prev", callback_data=f"cal_page_{page - 1}"
+                )
+            )
+        nav_row.append(
+            InlineKeyboardButton(
+                f"{page + 1}/{total_pages}", callback_data="cal_page_noop"
+            )
+        )
+        if page < total_pages - 1:
+            nav_row.append(
+                InlineKeyboardButton(
+                    "Next \u25b6\ufe0f", callback_data=f"cal_page_{page + 1}"
+                )
+            )
+        keyboard.append(nav_row)
+
+    # Period / refresh / back row
+    periods = [
+        (7, translation.get_text("CalendarDays7", default="7d")),
+        (14, translation.get_text("CalendarDays14", default="14d")),
+        (30, translation.get_text("CalendarDays30", default="30d")),
+    ]
+    period_row = []
+    for period_days, label in periods:
+        text = f"\u2705{label}" if period_days == days else label
+        period_row.append(
+            InlineKeyboardButton(text, callback_data=f"cal_period_{period_days}")
+        )
+    keyboard.append(period_row)
+    keyboard.append([
+        InlineKeyboardButton(
+            "\U0001f504 Refresh", callback_data="cal_refresh"
+        ),
+        InlineKeyboardButton(
+            f"\u25c0\ufe0f {translation.get_text('Back')}",
+            callback_data="cal_back"
+        ),
+    ])
+
+    return InlineKeyboardMarkup(keyboard)
+
+
 def get_yes_no_keyboard(callback_prefix: str, yes_text: str = "Yes", no_text: str = "No") -> InlineKeyboardMarkup:
     """Create a Yes/No inline keyboard
 

--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -475,6 +475,27 @@ def get_album_selection_keyboard(
     return InlineKeyboardMarkup(keyboard)
 
 
+def _build_period_row(days: int, translation) -> list:
+    """Build the calendar period button row.
+
+    Args:
+        days: Currently selected period (7, 14, or 30).
+        translation: TranslationService instance.
+    """
+    periods = [
+        (7, translation.get_text("CalendarDays7", default="7 days")),
+        (14, translation.get_text("CalendarDays14", default="14 days")),
+        (30, translation.get_text("CalendarDays30", default="30 days")),
+    ]
+    row = []
+    for period_days, label in periods:
+        text = f"\u2705 {label}" if period_days == days else label
+        row.append(
+            InlineKeyboardButton(text, callback_data=f"cal_period_{period_days}")
+        )
+    return row
+
+
 def get_calendar_keyboard(days: int) -> InlineKeyboardMarkup:
     """Get calendar period/navigation keyboard.
 
@@ -482,19 +503,8 @@ def get_calendar_keyboard(days: int) -> InlineKeyboardMarkup:
         days: Currently selected period (7, 14, or 30).
     """
     translation = TranslationService()
-    periods = [
-        (7, translation.get_text("CalendarDays7", default="7 days")),
-        (14, translation.get_text("CalendarDays14", default="14 days")),
-        (30, translation.get_text("CalendarDays30", default="30 days")),
-    ]
-    period_row = []
-    for period_days, label in periods:
-        text = f"\u2705 {label}" if period_days == days else label
-        period_row.append(
-            InlineKeyboardButton(text, callback_data=f"cal_period_{period_days}")
-        )
     keyboard = [
-        period_row,
+        _build_period_row(days, translation),
         [InlineKeyboardButton(
             "\U0001f504 Refresh", callback_data="cal_refresh"
         )],
@@ -559,7 +569,7 @@ def get_calendar_items_keyboard(
             )
         nav_row.append(
             InlineKeyboardButton(
-                f"{page + 1}/{total_pages}", callback_data="cal_page_noop"
+                f"{page + 1}/{total_pages}", callback_data="cal_noop"
             )
         )
         if page < total_pages - 1:
@@ -571,18 +581,7 @@ def get_calendar_items_keyboard(
         keyboard.append(nav_row)
 
     # Period / refresh / back row
-    periods = [
-        (7, translation.get_text("CalendarDays7", default="7d")),
-        (14, translation.get_text("CalendarDays14", default="14d")),
-        (30, translation.get_text("CalendarDays30", default="30d")),
-    ]
-    period_row = []
-    for period_days, label in periods:
-        text = f"\u2705{label}" if period_days == days else label
-        period_row.append(
-            InlineKeyboardButton(text, callback_data=f"cal_period_{period_days}")
-        )
-    keyboard.append(period_row)
+    keyboard.append(_build_period_row(days, translation))
     keyboard.append([
         InlineKeyboardButton(
             "\U0001f504 Refresh", callback_data="cal_refresh"

--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -37,6 +37,10 @@ def get_main_menu_keyboard() -> InlineKeyboardMarkup:
         ],
         [
             InlineKeyboardButton(
+                f"📅 {translation.get_text('Upcoming')}",
+                callback_data="menu_upcoming"
+            ),
+            InlineKeyboardButton(
                 f"🗑 {translation.get_text('Delete')}",
                 callback_data="menu_delete"
             ),

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ from telegram.ext import Application
 from telegram.error import InvalidToken, NetworkError
 
 from src.bot.handlers.auth import AuthHandler
+from src.bot.handlers.calendar import CalendarHandler
 from src.bot.handlers.delete import DeleteHandler
 from src.bot.handlers.library import LibraryHandler
 from src.bot.handlers.media import MediaHandler
@@ -130,6 +131,11 @@ class AddarrBot:
             # Library handler
             library_handler = LibraryHandler()
             for handler in library_handler.get_handler():
+                self.application.add_handler(handler)
+
+            # Calendar handler
+            calendar_handler = CalendarHandler()
+            for handler in calendar_handler.get_handler():
                 self.application.add_handler(handler)
 
             # Transmission handler (if enabled)

--- a/src/services/media.py
+++ b/src/services/media.py
@@ -8,6 +8,7 @@ This module handles interactions with media services (Radarr, Sonarr, Lidarr).
 """
 
 import asyncio
+import datetime
 from typing import List, Dict, Optional
 
 from src.utils.logger import get_logger
@@ -510,6 +511,100 @@ class MediaService:
         except Exception as e:
             logger.error(f"Error getting artist albums: {e}")
             return []
+
+    async def get_upcoming(self, days: int = 7) -> List[Dict]:
+        """Get upcoming releases from Radarr and Sonarr calendars.
+
+        Returns a normalized, date-sorted list of upcoming items.
+        Skips disabled services and handles errors gracefully.
+        """
+        start = datetime.date.today().isoformat()
+        end = (datetime.date.today() + datetime.timedelta(days=days)).isoformat()
+
+        items = []
+
+        # Fetch from both services concurrently
+        tasks = []
+        if self.radarr:
+            tasks.append(("radarr", self.radarr.get_calendar(start, end)))
+        if self.sonarr:
+            tasks.append(("sonarr", self.sonarr.get_calendar(start, end)))
+
+        if not tasks:
+            return []
+
+        results = await asyncio.gather(
+            *(t[1] for t in tasks), return_exceptions=True
+        )
+
+        for (service_name, _), result in zip(tasks, results):
+            if isinstance(result, Exception):
+                logger.error(f"Calendar fetch failed for {service_name}: {result}")
+                continue
+
+            if service_name == "radarr":
+                for movie in result:
+                    items.append(self._normalize_radarr_calendar(movie))
+            else:
+                for episode in result:
+                    items.append(self._normalize_sonarr_calendar(episode))
+
+        items.sort(key=lambda x: x["date"])
+        return items
+
+    @staticmethod
+    def _normalize_radarr_calendar(movie: Dict) -> Dict:
+        """Normalize a Radarr calendar movie into the unified schema."""
+        # Pick earliest non-null date
+        date_candidates = []
+        for field, label in [
+            ("inCinemas", "Cinema"),
+            ("digitalRelease", "Digital"),
+            ("physicalRelease", "Physical"),
+        ]:
+            val = movie.get(field)
+            if val:
+                date_candidates.append((val[:10], label))
+
+        if date_candidates:
+            date_candidates.sort(key=lambda x: x[0])
+            date, date_label = date_candidates[0]
+        else:
+            date, date_label = "", "Unknown"
+
+        return {
+            "type": "movie",
+            "title": movie.get("title", ""),
+            "series_title": None,
+            "date": date,
+            "date_label": date_label,
+            "year": movie.get("year"),
+            "season": None,
+            "episode": None,
+            "in_library": "id" in movie,
+            "media_id": str(movie.get("tmdbId", "")),
+            "internal_id": movie.get("id"),
+        }
+
+    @staticmethod
+    def _normalize_sonarr_calendar(ep: Dict) -> Dict:
+        """Normalize a Sonarr calendar episode into the unified schema."""
+        series = ep.get("series", {})
+        air_date = ep.get("airDateUtc", "")
+
+        return {
+            "type": "episode",
+            "title": ep.get("title", ""),
+            "series_title": series.get("title"),
+            "date": air_date[:10] if air_date else "",
+            "date_label": "Airing",
+            "year": None,
+            "season": ep.get("seasonNumber"),
+            "episode": ep.get("episodeNumber"),
+            "in_library": "id" in ep,
+            "media_id": str(series.get("tvdbId", "")),
+            "internal_id": series.get("id"),
+        }
 
     async def get_movies(self) -> List[Dict]:
         """Get all movies from Radarr library"""

--- a/src/services/media.py
+++ b/src/services/media.py
@@ -518,8 +518,9 @@ class MediaService:
         Returns a normalized, date-sorted list of upcoming items.
         Skips disabled services and handles errors gracefully.
         """
-        start = datetime.date.today().isoformat()
-        end = (datetime.date.today() + datetime.timedelta(days=days)).isoformat()
+        today = datetime.date.today()
+        start = today.isoformat()
+        end = (today + datetime.timedelta(days=days)).isoformat()
 
         items = []
 

--- a/tests/test_api/test_radarr.py
+++ b/tests/test_api/test_radarr.py
@@ -708,3 +708,45 @@ class TestDeleteMovie:
         )
         result = await radarr_client.delete_movie(1)
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# get_calendar
+# ---------------------------------------------------------------------------
+
+
+class TestRadarrGetCalendar:
+    @pytest.mark.asyncio
+    async def test_get_calendar_success(self, aio_mock, radarr_client):
+        """Happy path: returns list of upcoming movies."""
+        calendar_data = [
+            {"id": 1, "title": "Movie One", "inCinemas": "2026-03-10T00:00:00Z"},
+            {"id": 2, "title": "Movie Two", "digitalRelease": "2026-03-15T00:00:00Z"},
+        ]
+        aio_mock.get(
+            f"{BASE}/calendar?start=2026-03-01&end=2026-03-08",
+            payload=calendar_data,
+            status=200,
+        )
+        results = await radarr_client.get_calendar("2026-03-01", "2026-03-08")
+        assert len(results) == 2
+        assert results[0]["title"] == "Movie One"
+        assert results[1]["title"] == "Movie Two"
+
+    @pytest.mark.asyncio
+    async def test_get_calendar_empty(self, aio_mock, radarr_client):
+        """No upcoming movies returns empty list."""
+        aio_mock.get(
+            f"{BASE}/calendar?start=2026-03-01&end=2026-03-08",
+            payload=[],
+            status=200,
+        )
+        results = await radarr_client.get_calendar("2026-03-01", "2026-03-08")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_get_calendar_exception(self, radarr_client):
+        """Exception during get_calendar returns empty list."""
+        with patch.object(radarr_client, "_make_request", side_effect=Exception("boom")):
+            results = await radarr_client.get_calendar("2026-03-01", "2026-03-08")
+        assert results == []

--- a/tests/test_api/test_sonarr.py
+++ b/tests/test_api/test_sonarr.py
@@ -680,3 +680,55 @@ class TestDeleteSeries:
         )
         result = await sonarr_client.delete_series(1)
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# get_calendar
+# ---------------------------------------------------------------------------
+
+
+class TestSonarrGetCalendar:
+    @pytest.mark.asyncio
+    async def test_get_calendar_success(self, aio_mock, sonarr_client):
+        """Happy path: returns list of upcoming episodes."""
+        calendar_data = [
+            {
+                "id": 101,
+                "title": "Episode One",
+                "airDateUtc": "2026-03-10T20:00:00Z",
+                "series": {"title": "Breaking Bad", "tvdbId": 81189},
+            },
+            {
+                "id": 102,
+                "title": "Episode Two",
+                "airDateUtc": "2026-03-12T20:00:00Z",
+                "series": {"title": "Severance", "tvdbId": 371980},
+            },
+        ]
+        aio_mock.get(
+            f"{BASE}/calendar?start=2026-03-01&end=2026-03-08",
+            payload=calendar_data,
+            status=200,
+        )
+        results = await sonarr_client.get_calendar("2026-03-01", "2026-03-08")
+        assert len(results) == 2
+        assert results[0]["title"] == "Episode One"
+        assert results[1]["series"]["title"] == "Severance"
+
+    @pytest.mark.asyncio
+    async def test_get_calendar_empty(self, aio_mock, sonarr_client):
+        """No upcoming episodes returns empty list."""
+        aio_mock.get(
+            f"{BASE}/calendar?start=2026-03-01&end=2026-03-08",
+            payload=[],
+            status=200,
+        )
+        results = await sonarr_client.get_calendar("2026-03-01", "2026-03-08")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_get_calendar_exception(self, sonarr_client):
+        """Exception during get_calendar returns empty list."""
+        with patch.object(sonarr_client, "_make_request", side_effect=Exception("boom")):
+            results = await sonarr_client.get_calendar("2026-03-01", "2026-03-08")
+        assert results == []

--- a/tests/test_bot/test_commands.py
+++ b/tests/test_bot/test_commands.py
@@ -85,7 +85,7 @@ class TestBuildAuthenticatedCommands:
         ]
 
     def test_radarr_adds_movie_and_allmovies(self, mock_config):
-        """Radarr enabled adds movie + allmovies commands."""
+        """Radarr enabled adds movie + allmovies + upcoming commands."""
         cfg = self._make_config(mock_config, radarr={"enable": True})
 
         with patch("src.bot.commands.config", cfg):
@@ -95,10 +95,10 @@ class TestBuildAuthenticatedCommands:
         names = [c.command for c in commands]
         assert "movie" in names
         assert "allmovies" in names
-        assert len(commands) == 9  # 7 base + 2
+        assert len(commands) == 10  # 7 base + 2 + upcoming
 
     def test_sonarr_adds_series_and_allseries(self, mock_config):
-        """Sonarr enabled adds series + allseries commands."""
+        """Sonarr enabled adds series + allseries + upcoming commands."""
         cfg = self._make_config(mock_config, sonarr={"enable": True})
 
         with patch("src.bot.commands.config", cfg):
@@ -108,7 +108,7 @@ class TestBuildAuthenticatedCommands:
         names = [c.command for c in commands]
         assert "series" in names
         assert "allseries" in names
-        assert len(commands) == 9  # 7 base + 2
+        assert len(commands) == 10  # 7 base + 2 + upcoming
 
     def test_lidarr_adds_music_and_allmusic(self, mock_config):
         """Lidarr enabled adds music + allmusic commands."""
@@ -147,8 +147,41 @@ class TestBuildAuthenticatedCommands:
         assert "sabnzbd" in names
         assert len(commands) == 8  # 7 base + 1
 
+    def test_radarr_adds_upcoming(self, mock_config):
+        """Radarr enabled adds upcoming command."""
+        cfg = self._make_config(mock_config, radarr={"enable": True})
+
+        with patch("src.bot.commands.config", cfg):
+            from src.bot.commands import build_authenticated_commands
+            commands = build_authenticated_commands()
+
+        names = [c.command for c in commands]
+        assert "upcoming" in names
+
+    def test_sonarr_adds_upcoming(self, mock_config):
+        """Sonarr enabled adds upcoming command."""
+        cfg = self._make_config(mock_config, sonarr={"enable": True})
+
+        with patch("src.bot.commands.config", cfg):
+            from src.bot.commands import build_authenticated_commands
+            commands = build_authenticated_commands()
+
+        names = [c.command for c in commands]
+        assert "upcoming" in names
+
+    def test_no_upcoming_when_neither_radarr_nor_sonarr(self, mock_config):
+        """Upcoming command absent when neither Radarr nor Sonarr enabled."""
+        cfg = self._make_config(mock_config)
+
+        with patch("src.bot.commands.config", cfg):
+            from src.bot.commands import build_authenticated_commands
+            commands = build_authenticated_commands()
+
+        names = [c.command for c in commands]
+        assert "upcoming" not in names
+
     def test_all_services_enabled(self, mock_config):
-        """All services enabled returns all 15 commands."""
+        """All services enabled returns all 16 commands."""
         cfg = self._make_config(
             mock_config,
             radarr={"enable": True},
@@ -162,13 +195,13 @@ class TestBuildAuthenticatedCommands:
             from src.bot.commands import build_authenticated_commands
             commands = build_authenticated_commands()
 
-        assert len(commands) == 15
+        assert len(commands) == 16
         names = [c.command for c in commands]
         expected = [
             "start", "auth", "help", "status", "settings",
             "preferences", "delete", "movie", "allmovies",
             "series", "allseries", "music", "allmusic",
-            "transmission", "sabnzbd",
+            "upcoming", "transmission", "sabnzbd",
         ]
         assert names == expected
 

--- a/tests/test_bot/test_keyboards.py
+++ b/tests/test_bot/test_keyboards.py
@@ -42,6 +42,7 @@ class TestMainMenuKeyboard:
             "menu_series",
             "menu_music",
             "menu_status",
+            "menu_upcoming",
             "menu_delete",
             "menu_help",
             "menu_cancel",

--- a/tests/test_bot/test_keyboards.py
+++ b/tests/test_bot/test_keyboards.py
@@ -897,6 +897,195 @@ class TestAlbumSelectionKeyboard:
         assert "menu_cancel" in callbacks
 
 
+# ---------------------------------------------------------------------------
+# Calendar keyboards
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarKeyboard:
+    """Tests for get_calendar_keyboard"""
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_returns_inline_keyboard_markup(self, mock_ts):
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_keyboard
+
+        result = get_calendar_keyboard(days=7)
+        assert isinstance(result, InlineKeyboardMarkup)
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_period_buttons(self, mock_ts):
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_keyboard
+
+        result = get_calendar_keyboard(days=7)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "cal_period_7" in callbacks
+        assert "cal_period_14" in callbacks
+        assert "cal_period_30" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_current_period_highlighted(self, mock_ts):
+        """Current period button should have a checkmark."""
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_keyboard
+
+        result = get_calendar_keyboard(days=14)
+        for row in result.inline_keyboard:
+            for btn in row:
+                if btn.callback_data == "cal_period_14":
+                    assert "\u2705" in btn.text
+                elif btn.callback_data in ("cal_period_7", "cal_period_30"):
+                    assert "\u2705" not in btn.text
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_refresh_button(self, mock_ts):
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_keyboard
+
+        result = get_calendar_keyboard(days=7)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "cal_refresh" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_back_button(self, mock_ts):
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_keyboard
+
+        result = get_calendar_keyboard(days=7)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "cal_back" in callbacks
+
+
+class TestCalendarItemsKeyboard:
+    """Tests for get_calendar_items_keyboard"""
+
+    SAMPLE_ITEMS = [
+        {"type": "movie", "title": "Movie A", "in_library": True,
+         "media_id": "100", "date": "2026-03-10", "date_label": "Cinema"},
+        {"type": "movie", "title": "Movie B", "in_library": False,
+         "media_id": "200", "date": "2026-03-12", "date_label": "Digital"},
+        {"type": "episode", "title": "Pilot", "in_library": False,
+         "media_id": "9000", "series_title": "New Show",
+         "date": "2026-03-15", "date_label": "Airing"},
+    ]
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_returns_inline_keyboard_markup(self, mock_ts):
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_items_keyboard
+
+        result = get_calendar_items_keyboard(self.SAMPLE_ITEMS, page=0, days=7)
+        assert isinstance(result, InlineKeyboardMarkup)
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_item_buttons_present(self, mock_ts):
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_items_keyboard
+
+        result = get_calendar_items_keyboard(self.SAMPLE_ITEMS, page=0, days=7)
+        button_texts = [
+            btn.text
+            for row in result.inline_keyboard for btn in row
+        ]
+        text_joined = " ".join(button_texts)
+        assert "Movie A" in text_joined
+        assert "Movie B" in text_joined
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_add_buttons_only_for_non_library(self, mock_ts):
+        """Non-library items get cal_add_* callback, library items don't."""
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_items_keyboard
+
+        result = get_calendar_items_keyboard(self.SAMPLE_ITEMS, page=0, days=7)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        # Movie B (not in library, movie) should have add button
+        assert "cal_add_movie_200" in callbacks
+        # Pilot (not in library, episode) should have add button
+        assert "cal_add_episode_9000" in callbacks
+        # Movie A (in library) should NOT have add button
+        assert "cal_add_movie_100" not in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_pagination_when_items_exceed_page_size(self, mock_ts):
+        """Pagination buttons appear when items > page_size."""
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_items_keyboard
+
+        items = [
+            {"type": "movie", "title": f"M{i}", "in_library": True,
+             "media_id": str(i), "date": "2026-03-10", "date_label": "Cinema"}
+            for i in range(8)
+        ]
+        result = get_calendar_items_keyboard(items, page=0, days=7, page_size=5)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "cal_page_1" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_pagination_prev_button_on_page_1(self, mock_ts):
+        """Page 1 should have a Prev button pointing to page 0."""
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_items_keyboard
+
+        items = [
+            {"type": "movie", "title": f"M{i}", "in_library": True,
+             "media_id": str(i), "date": "2026-03-10", "date_label": "Cinema"}
+            for i in range(8)
+        ]
+        result = get_calendar_items_keyboard(items, page=1, days=7, page_size=5)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "cal_page_0" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_no_pagination_for_single_page(self, mock_ts):
+        """No pagination buttons when items fit in one page."""
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_items_keyboard
+
+        result = get_calendar_items_keyboard(
+            self.SAMPLE_ITEMS, page=0, days=7, page_size=5
+        )
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert not any(cb.startswith("cal_page_") for cb in callbacks)
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_period_refresh_back_buttons(self, mock_ts):
+        """Bottom row has period, refresh, and back buttons."""
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_calendar_items_keyboard
+
+        result = get_calendar_items_keyboard(self.SAMPLE_ITEMS, page=0, days=7)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "cal_period_7" in callbacks
+        assert "cal_refresh" in callbacks
+        assert "cal_back" in callbacks
+
+
 class TestListDetailKeyboard:
     """Tests for the list detail view keyboard."""
 

--- a/tests/test_handlers/conftest.py
+++ b/tests/test_handlers/conftest.py
@@ -342,6 +342,56 @@ def settings_handler(mock_media_service, mock_translation_service):
 
 
 @pytest.fixture
+def calendar_handler(mock_media_service, mock_translation_service):
+    """Create a CalendarHandler with patched services."""
+    with (
+        patch("src.bot.handlers.calendar.MediaService") as mock_ms_class,
+        patch("src.bot.handlers.calendar.TranslationService") as mock_ts_class,
+        patch("src.bot.handlers.calendar.get_calendar_keyboard") as mock_cal_kbd,
+        patch("src.bot.handlers.calendar.get_calendar_items_keyboard") as mock_items_kbd,
+        patch("src.bot.handlers.calendar.get_main_menu_keyboard") as mock_menu_kbd,
+    ):
+        mock_ts_class.return_value = mock_translation_service
+        mock_ms_class.return_value = mock_media_service
+        mock_media_service.get_upcoming = AsyncMock(return_value=[])
+        mock_media_service.add_movie_with_profile = AsyncMock(
+            return_value=(True, "Added!")
+        )
+        mock_media_service.add_series_with_profile = AsyncMock(
+            return_value=(True, "Added!")
+        )
+        mock_media_service.radarr = MagicMock()
+        mock_media_service.radarr.get_root_folders = AsyncMock(
+            return_value=["/movies"]
+        )
+        mock_media_service.radarr.get_quality_profiles = AsyncMock(
+            return_value=[{"id": 1, "name": "HD"}]
+        )
+        mock_media_service.sonarr = MagicMock()
+        mock_media_service.sonarr.get_root_folders = AsyncMock(
+            return_value=["/tv"]
+        )
+        mock_media_service.sonarr.get_quality_profiles = AsyncMock(
+            return_value=[{"id": 1, "name": "HD"}]
+        )
+        mock_cal_kbd.return_value = MagicMock()
+        mock_items_kbd.return_value = MagicMock()
+        mock_menu_kbd.return_value = MagicMock()
+
+        from src.bot.handlers.calendar import CalendarHandler
+        from src.bot.handlers.auth import AuthHandler
+
+        AuthHandler._authenticated_users = {12345}
+        handler = CalendarHandler()
+        handler._mock_service = mock_media_service
+        handler._mock_ts = mock_translation_service
+        handler._mock_cal_kbd = mock_cal_kbd
+        handler._mock_items_kbd = mock_items_kbd
+        handler._mock_menu_kbd = mock_menu_kbd
+        yield handler
+
+
+@pytest.fixture
 def preferences_handler(mock_translation_service):
     """Create a PreferencesHandler with patched services."""
     with (

--- a/tests/test_handlers/conftest.py
+++ b/tests/test_handlers/conftest.py
@@ -119,6 +119,7 @@ def start_handler(mock_media_service, mock_translation_service):
     """Create a StartHandler with patched services."""
     with (
         patch("src.bot.handlers.start.MediaHandler") as mock_mh_class,
+        patch("src.bot.handlers.start.CalendarHandler") as mock_ch_class,
         patch("src.bot.handlers.start.HelpHandler") as mock_hh_class,
         patch("src.bot.handlers.start.SystemHandler") as mock_sh_class,
         patch("src.bot.handlers.start.TranslationService") as mock_ts_class,
@@ -135,6 +136,9 @@ def start_handler(mock_media_service, mock_translation_service):
         mock_media_handler.handle_view_toggle = AsyncMock()
         mock_media_handler.cancel_search = AsyncMock()
         mock_mh_class.return_value = mock_media_handler
+        mock_calendar_handler = MagicMock()
+        mock_calendar_handler.show_upcoming = AsyncMock()
+        mock_ch_class.return_value = mock_calendar_handler
         mock_help_handler = MagicMock()
         mock_help_handler.show_help = AsyncMock()
         mock_hh_class.return_value = mock_help_handler
@@ -149,6 +153,7 @@ def start_handler(mock_media_service, mock_translation_service):
         AuthHandler._authenticated_users = {12345}
         handler = StartHandler()
         handler._mock_media_handler = mock_media_handler
+        handler._mock_calendar_handler = mock_calendar_handler
         handler._mock_help_handler = mock_help_handler
         handler._mock_system_handler = mock_system_handler
         handler._mock_ts = mock_translation_service

--- a/tests/test_handlers/test_calendar_handler.py
+++ b/tests/test_handlers/test_calendar_handler.py
@@ -1,0 +1,380 @@
+"""
+Tests for src/bot/handlers/calendar.py - CalendarHandler.
+
+CalendarHandler owns /upcoming and cal_* callbacks. show_upcoming and
+handle_calendar_action are decorated with @require_auth.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Sample calendar items for reuse
+# ---------------------------------------------------------------------------
+
+SAMPLE_MOVIE = {
+    "type": "movie", "title": "Test Movie", "series_title": None,
+    "date": "2026-03-10", "date_label": "Cinema", "year": 2026,
+    "season": None, "episode": None, "in_library": False,
+    "media_id": "12345", "internal_id": None,
+}
+
+SAMPLE_EPISODE = {
+    "type": "episode", "title": "Test Episode",
+    "series_title": "Test Series", "date": "2026-03-12",
+    "date_label": "Airing", "year": None, "season": 1,
+    "episode": 5, "in_library": True, "media_id": "67890",
+    "internal_id": 42,
+}
+
+
+# ---------------------------------------------------------------------------
+# show_upcoming
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_show_upcoming_with_results(
+    calendar_handler, make_update, make_context
+):
+    """show_upcoming sends message with calendar text and items keyboard."""
+    items = [SAMPLE_MOVIE, SAMPLE_EPISODE]
+    calendar_handler._mock_service.get_upcoming = AsyncMock(return_value=items)
+    update = make_update(text="/upcoming")
+    context = make_context()
+
+    await calendar_handler.show_upcoming(update, context)
+
+    calendar_handler._mock_service.get_upcoming.assert_awaited_once_with(7)
+    update.message.reply_text.assert_called_once()
+    call_args = update.message.reply_text.call_args
+    assert "CalendarTitle" in call_args[0][0]
+    assert call_args[1]["reply_markup"] == \
+        calendar_handler._mock_items_kbd.return_value
+    assert context.user_data["cal_items"] == items
+    assert context.user_data["cal_days"] == 7
+
+
+@pytest.mark.asyncio
+async def test_show_upcoming_empty_results(
+    calendar_handler, make_update, make_context
+):
+    """show_upcoming sends 'no upcoming' message with period keyboard."""
+    calendar_handler._mock_service.get_upcoming = AsyncMock(return_value=[])
+    update = make_update(text="/upcoming")
+    context = make_context()
+
+    await calendar_handler.show_upcoming(update, context)
+
+    update.message.reply_text.assert_called_once()
+    call_args = update.message.reply_text.call_args
+    assert "CalendarEmpty" in call_args[0][0]
+    assert call_args[1]["reply_markup"] == \
+        calendar_handler._mock_cal_kbd.return_value
+
+
+@pytest.mark.asyncio
+async def test_show_upcoming_via_callback(
+    calendar_handler, make_update, make_context
+):
+    """show_upcoming edits message when invoked via callback query."""
+    items = [SAMPLE_MOVIE]
+    calendar_handler._mock_service.get_upcoming = AsyncMock(return_value=items)
+    update = make_update(callback_data="menu_upcoming")
+    context = make_context()
+
+    await calendar_handler.show_upcoming(update, context)
+
+    update.callback_query.message.edit_text.assert_called_once()
+    call_args = update.callback_query.message.edit_text.call_args
+    assert "CalendarTitle" in call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_show_upcoming_no_user(
+    calendar_handler, make_update, make_context
+):
+    """show_upcoming returns None when effective_user is None."""
+    update = make_update(text="/upcoming")
+    update.effective_user = None
+    context = make_context()
+
+    result = await calendar_handler.show_upcoming(update, context)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# handle_calendar_action — period change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_period_change(
+    calendar_handler, make_update, make_context
+):
+    """cal_period_14 changes period, re-fetches, and edits message."""
+    items = [SAMPLE_MOVIE]
+    calendar_handler._mock_service.get_upcoming = AsyncMock(return_value=items)
+    update = make_update(callback_data="cal_period_14")
+    context = make_context(user_data={"cal_days": 7, "cal_items": []})
+
+    await calendar_handler.handle_calendar_action(update, context)
+
+    calendar_handler._mock_service.get_upcoming.assert_awaited_once_with(14)
+    assert context.user_data["cal_days"] == 14
+    assert context.user_data["cal_items"] == items
+    update.callback_query.message.edit_text.assert_called_once()
+    update.callback_query.answer.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# handle_calendar_action — pagination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pagination(
+    calendar_handler, make_update, make_context
+):
+    """cal_page_1 shows second page from cached items without re-fetching."""
+    items = [
+        {**SAMPLE_MOVIE, "title": f"Movie {i}", "media_id": str(i)}
+        for i in range(8)
+    ]
+    update = make_update(callback_data="cal_page_1")
+    context = make_context(user_data={"cal_days": 7, "cal_items": items})
+
+    await calendar_handler.handle_calendar_action(update, context)
+
+    calendar_handler._mock_service.get_upcoming.assert_not_awaited()
+    update.callback_query.message.edit_text.assert_called_once()
+    update.callback_query.answer.assert_called_once()
+    # Verify keyboard was built with page=1
+    calendar_handler._mock_items_kbd.assert_called_once()
+    kbd_call = calendar_handler._mock_items_kbd.call_args
+    assert kbd_call[0][1] == 1  # page argument
+
+
+# ---------------------------------------------------------------------------
+# handle_calendar_action — refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh(
+    calendar_handler, make_update, make_context
+):
+    """cal_refresh clears cache and re-fetches calendar data."""
+    new_items = [SAMPLE_MOVIE]
+    calendar_handler._mock_service.get_upcoming = AsyncMock(
+        return_value=new_items
+    )
+    update = make_update(callback_data="cal_refresh")
+    context = make_context(user_data={
+        "cal_days": 7, "cal_items": [{"old": "data"}]
+    })
+
+    await calendar_handler.handle_calendar_action(update, context)
+
+    calendar_handler._mock_service.get_upcoming.assert_awaited_once_with(7)
+    assert context.user_data["cal_items"] == new_items
+    update.callback_query.message.edit_text.assert_called_once()
+    update.callback_query.answer.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# handle_calendar_action — back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_back(
+    calendar_handler, make_update, make_context
+):
+    """cal_back returns to main menu."""
+    update = make_update(callback_data="cal_back")
+    context = make_context(user_data={"cal_days": 7, "cal_items": []})
+
+    await calendar_handler.handle_calendar_action(update, context)
+
+    update.callback_query.message.edit_text.assert_called_once()
+    call_args = update.callback_query.message.edit_text.call_args
+    assert call_args[1]["reply_markup"] == \
+        calendar_handler._mock_menu_kbd.return_value
+    update.callback_query.answer.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# handle_calendar_action — add movie
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_movie_success(
+    calendar_handler, make_update, make_context
+):
+    """cal_add_movie_12345 calls add_movie_with_profile and shows success toast."""
+    update = make_update(callback_data="cal_add_movie_12345")
+    context = make_context(user_data={"cal_days": 7, "cal_items": []})
+
+    await calendar_handler.handle_calendar_action(update, context)
+
+    calendar_handler._mock_service.radarr.get_root_folders.assert_awaited_once()
+    calendar_handler._mock_service.radarr.get_quality_profiles.assert_awaited_once()
+    calendar_handler._mock_service.add_movie_with_profile.assert_awaited_once_with(
+        "12345", 1, "/movies"
+    )
+    update.callback_query.answer.assert_called_once()
+    assert "CalendarAddSuccess" in str(update.callback_query.answer.call_args)
+
+
+@pytest.mark.asyncio
+async def test_add_movie_failure(
+    calendar_handler, make_update, make_context
+):
+    """cal_add_movie shows error toast when add fails."""
+    calendar_handler._mock_service.add_movie_with_profile = AsyncMock(
+        return_value=(False, "Already exists")
+    )
+    update = make_update(callback_data="cal_add_movie_12345")
+    context = make_context(user_data={"cal_days": 7, "cal_items": []})
+
+    await calendar_handler.handle_calendar_action(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    assert "CalendarAddFailed" in str(update.callback_query.answer.call_args)
+
+
+# ---------------------------------------------------------------------------
+# handle_calendar_action — add episode (adds series by tvdbId)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_episode_success(
+    calendar_handler, make_update, make_context
+):
+    """cal_add_episode_67890 calls add_series_with_profile, shows success toast."""
+    update = make_update(callback_data="cal_add_episode_67890")
+    context = make_context(user_data={"cal_days": 7, "cal_items": []})
+
+    await calendar_handler.handle_calendar_action(update, context)
+
+    calendar_handler._mock_service.sonarr.get_root_folders.assert_awaited_once()
+    calendar_handler._mock_service.sonarr.get_quality_profiles.assert_awaited_once()
+    calendar_handler._mock_service.add_series_with_profile.assert_awaited_once_with(
+        "67890", 1, "/tv"
+    )
+    update.callback_query.answer.assert_called_once()
+    assert "CalendarAddSuccess" in str(update.callback_query.answer.call_args)
+
+
+# ---------------------------------------------------------------------------
+# handle_calendar_action — add exception
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_movie_exception(
+    calendar_handler, make_update, make_context
+):
+    """cal_add_movie shows error toast when add raises exception."""
+    calendar_handler._mock_service.add_movie_with_profile = AsyncMock(
+        side_effect=Exception("Connection failed")
+    )
+    update = make_update(callback_data="cal_add_movie_12345")
+    context = make_context(user_data={"cal_days": 7, "cal_items": []})
+
+    await calendar_handler.handle_calendar_action(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    assert "CalendarAddFailed" in str(update.callback_query.answer.call_args)
+
+
+# ---------------------------------------------------------------------------
+# handle_calendar_action — unauthenticated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_user(
+    make_update, make_context, mock_media_service, mock_translation_service
+):
+    """show_upcoming rejects unauthenticated users via @require_auth."""
+    with (
+        patch("src.bot.handlers.calendar.MediaService") as mock_ms_class,
+        patch("src.bot.handlers.calendar.TranslationService") as mock_ts_class,
+        patch("src.bot.handlers.calendar.get_calendar_keyboard"),
+        patch("src.bot.handlers.calendar.get_calendar_items_keyboard"),
+        patch("src.bot.handlers.calendar.get_main_menu_keyboard"),
+    ):
+        mock_ts_class.return_value = mock_translation_service
+        mock_ms_class.return_value = mock_media_service
+
+        from src.bot.handlers.calendar import CalendarHandler
+        from src.bot.handlers.auth import AuthHandler
+
+        AuthHandler._authenticated_users = set()
+        handler = CalendarHandler()
+        update = make_update(text="/upcoming")
+        context = make_context()
+
+        result = await handler.show_upcoming(update, context)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# handle_calendar_action — no callback / edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_no_callback(
+    calendar_handler, make_update, make_context
+):
+    """handle_calendar_action returns None when no callback query."""
+    update = make_update(text="/upcoming")
+    context = make_context()
+
+    result = await calendar_handler.handle_calendar_action(update, context)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_handle_unknown_cal_action(
+    calendar_handler, make_update, make_context
+):
+    """Unknown cal_ action answers query without error."""
+    update = make_update(callback_data="cal_noop")
+    context = make_context()
+
+    await calendar_handler.handle_calendar_action(update, context)
+
+    update.callback_query.answer.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_add_unknown_media_type(
+    calendar_handler, make_update, make_context
+):
+    """cal_add with unknown type answers with error."""
+    update = make_update(callback_data="cal_add_unknown_123")
+    context = make_context(user_data={"cal_days": 7, "cal_items": []})
+
+    await calendar_handler.handle_calendar_action(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    assert "Unknown" in str(update.callback_query.answer.call_args)
+
+
+# ---------------------------------------------------------------------------
+# get_handler
+# ---------------------------------------------------------------------------
+
+
+def test_get_handler_returns_list(calendar_handler):
+    """get_handler returns a list of handlers."""
+    handlers = calendar_handler.get_handler()
+    assert isinstance(handlers, list)
+    assert len(handlers) >= 2

--- a/tests/test_handlers/test_start_handler.py
+++ b/tests/test_handlers/test_start_handler.py
@@ -120,6 +120,20 @@ async def test_handle_menu_selection_help(
 
 
 @pytest.mark.asyncio
+async def test_handle_menu_selection_upcoming(
+    start_handler, make_update, make_context
+):
+    """menu_upcoming delegates to calendar_handler.show_upcoming and ends."""
+    update = make_update(callback_data="menu_upcoming")
+    context = make_context()
+
+    result = await start_handler.handle_menu_selection(update, context)
+
+    assert result == ConversationHandler.END
+    start_handler._mock_calendar_handler.show_upcoming.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_handle_menu_selection_settings(
     start_handler, make_update, make_context
 ):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -60,6 +60,7 @@ def _make_handler_patches():
         "SettingsHandler": _mock_handler_class(),
         "DeleteHandler": _mock_handler_class(),
         "LibraryHandler": _mock_handler_class(),
+        "CalendarHandler": _mock_handler_class(),
         "TransmissionHandler": _mock_handler_class(),
         "SabnzbdHandler": _mock_handler_class(),
         "HelpHandler": _mock_handler_class(),
@@ -266,14 +267,14 @@ class TestAddHandlers:
     """Tests for AddarrBot._add_handlers()."""
 
     def test_always_on_handlers_registered(self, bot, mock_app):
-        """All 9 always-on handlers are registered."""
+        """All 10 always-on handlers are registered."""
         bot.application = mock_app
         with patch.multiple("src.main", **_make_handler_patches()):
             bot._add_handlers()
 
-        # 9 always-on handlers (Start, Auth, Media, Settings, Delete,
-        # Library, Help, Preferences, System) each return [handler]
-        assert mock_app.add_handler.call_count == 9
+        # 10 always-on handlers (Start, Auth, Media, Settings, Delete,
+        # Library, Calendar, Help, Preferences, System) each return [handler]
+        assert mock_app.add_handler.call_count == 10
 
     @patch("src.main.config")
     def test_transmission_enabled(self, mock_cfg, bot, mock_app):
@@ -290,8 +291,8 @@ class TestAddHandlers:
         with patch.multiple("src.main", **_make_handler_patches()):
             bot._add_handlers()
 
-        # 9 always-on + 1 transmission
-        assert mock_app.add_handler.call_count == 10
+        # 10 always-on + 1 transmission
+        assert mock_app.add_handler.call_count == 11
 
     @patch("src.main.config")
     def test_sabnzbd_enabled(self, mock_cfg, bot, mock_app):
@@ -308,8 +309,8 @@ class TestAddHandlers:
         with patch.multiple("src.main", **_make_handler_patches()):
             bot._add_handlers()
 
-        # 9 always-on + 1 sabnzbd
-        assert mock_app.add_handler.call_count == 10
+        # 10 always-on + 1 sabnzbd
+        assert mock_app.add_handler.call_count == 11
 
     @patch("src.main.config")
     def test_both_optional_enabled(self, mock_cfg, bot, mock_app):
@@ -326,8 +327,8 @@ class TestAddHandlers:
         with patch.multiple("src.main", **_make_handler_patches()):
             bot._add_handlers()
 
-        # 9 + 2
-        assert mock_app.add_handler.call_count == 11
+        # 10 + 2
+        assert mock_app.add_handler.call_count == 12
 
     def test_handler_error_reraises(self, bot, mock_app):
         """Exception during handler registration is re-raised."""

--- a/tests/test_services/conftest.py
+++ b/tests/test_services/conftest.py
@@ -16,6 +16,7 @@ def mock_radarr_client():
     client.get_quality_profiles = AsyncMock(
         return_value=[{"id": 1, "name": "HD-1080p"}]
     )
+    client.get_calendar = AsyncMock(return_value=[])
     client.get_movies = AsyncMock(return_value=[])
     client.get_movie_by_id = AsyncMock(return_value=None)
     client.delete_movie = AsyncMock(return_value=True)
@@ -34,6 +35,7 @@ def mock_sonarr_client():
         return_value=[{"id": 1, "name": "HD-1080p"}]
     )
     client.get_seasons = AsyncMock(return_value=[])
+    client.get_calendar = AsyncMock(return_value=[])
     client.get_all_series = AsyncMock(return_value=[])
     client.get_series_by_id = AsyncMock(return_value=None)
     client.delete_series = AsyncMock(return_value=True)

--- a/tests/test_services/test_media_service.py
+++ b/tests/test_services/test_media_service.py
@@ -1624,3 +1624,262 @@ class TestGetArtistAlbums:
         albums = await service.get_artist_albums("some-mbid-123")
 
         assert albums == []
+
+
+# ---------------------------------------------------------------------------
+# get_upcoming — calendar aggregation
+# ---------------------------------------------------------------------------
+
+
+# Sample Radarr calendar data
+RADARR_CALENDAR_MOVIE_CINEMA = {
+    "id": 1,
+    "title": "Movie A",
+    "tmdbId": 100,
+    "year": 2026,
+    "inCinemas": "2026-03-10T00:00:00Z",
+    "digitalRelease": "2026-04-10T00:00:00Z",
+    "physicalRelease": "2026-05-10T00:00:00Z",
+}
+
+RADARR_CALENDAR_MOVIE_DIGITAL = {
+    "id": 2,
+    "title": "Movie B",
+    "tmdbId": 200,
+    "year": 2026,
+    "digitalRelease": "2026-03-15T00:00:00Z",
+}
+
+RADARR_CALENDAR_MOVIE_NO_ID = {
+    "title": "Movie C",
+    "tmdbId": 300,
+    "year": 2026,
+    "physicalRelease": "2026-03-05T00:00:00Z",
+}
+
+# Sample Sonarr calendar data
+SONARR_CALENDAR_EPISODE = {
+    "id": 501,
+    "title": "Pilot",
+    "airDateUtc": "2026-03-08T20:00:00Z",
+    "seasonNumber": 1,
+    "episodeNumber": 1,
+    "series": {"title": "New Show", "tvdbId": 9000, "id": 10},
+}
+
+SONARR_CALENDAR_EPISODE_NO_ID = {
+    "title": "Unmonitored Ep",
+    "airDateUtc": "2026-03-12T20:00:00Z",
+    "seasonNumber": 2,
+    "episodeNumber": 5,
+    "series": {"title": "Another Show", "tvdbId": 9001},
+}
+
+
+class TestGetUpcoming:
+    @pytest.mark.asyncio
+    async def test_both_services_combined_sorted(
+        self, mock_radarr_client, mock_sonarr_client
+    ):
+        """Both services enabled — returns combined, date-sorted list."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = mock_sonarr_client
+        mock_radarr_client.get_calendar.return_value = [
+            RADARR_CALENDAR_MOVIE_DIGITAL,  # 2026-03-15
+        ]
+        mock_sonarr_client.get_calendar.return_value = [
+            SONARR_CALENDAR_EPISODE,  # 2026-03-08
+        ]
+
+        results = await service.get_upcoming(days=14)
+
+        assert len(results) == 2
+        # Sonarr episode (03-08) should come before Radarr movie (03-15)
+        assert results[0]["type"] == "episode"
+        assert results[0]["title"] == "Pilot"
+        assert results[1]["type"] == "movie"
+        assert results[1]["title"] == "Movie B"
+
+    @pytest.mark.asyncio
+    async def test_only_radarr_enabled(self, mock_radarr_client):
+        """Only Radarr enabled — returns only movies."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = None
+        mock_radarr_client.get_calendar.return_value = [
+            RADARR_CALENDAR_MOVIE_CINEMA,
+        ]
+
+        results = await service.get_upcoming(days=7)
+
+        assert len(results) == 1
+        assert results[0]["type"] == "movie"
+        assert results[0]["title"] == "Movie A"
+
+    @pytest.mark.asyncio
+    async def test_only_sonarr_enabled(self, mock_sonarr_client):
+        """Only Sonarr enabled — returns only episodes."""
+        service = MediaService()
+        MediaService._radarr = None
+        MediaService._sonarr = mock_sonarr_client
+        mock_sonarr_client.get_calendar.return_value = [
+            SONARR_CALENDAR_EPISODE,
+        ]
+
+        results = await service.get_upcoming(days=7)
+
+        assert len(results) == 1
+        assert results[0]["type"] == "episode"
+        assert results[0]["series_title"] == "New Show"
+
+    @pytest.mark.asyncio
+    async def test_neither_enabled(self):
+        """Neither enabled — returns empty list."""
+        service = MediaService()
+        MediaService._radarr = None
+        MediaService._sonarr = None
+
+        results = await service.get_upcoming(days=7)
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_radarr_movie_date_selection_earliest(
+        self, mock_radarr_client
+    ):
+        """Picks earliest of inCinemas/digitalRelease/physicalRelease."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = None
+        mock_radarr_client.get_calendar.return_value = [
+            RADARR_CALENDAR_MOVIE_CINEMA,
+        ]
+
+        results = await service.get_upcoming(days=30)
+
+        assert results[0]["date"] == "2026-03-10"
+        assert results[0]["date_label"] == "Cinema"
+
+    @pytest.mark.asyncio
+    async def test_radarr_movie_digital_only(self, mock_radarr_client):
+        """Movie with only digitalRelease uses that date."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = None
+        mock_radarr_client.get_calendar.return_value = [
+            RADARR_CALENDAR_MOVIE_DIGITAL,
+        ]
+
+        results = await service.get_upcoming(days=30)
+
+        assert results[0]["date"] == "2026-03-15"
+        assert results[0]["date_label"] == "Digital"
+
+    @pytest.mark.asyncio
+    async def test_in_library_flag(
+        self, mock_radarr_client, mock_sonarr_client
+    ):
+        """Items with 'id' field have in_library=True, without have False."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = mock_sonarr_client
+        mock_radarr_client.get_calendar.return_value = [
+            RADARR_CALENDAR_MOVIE_CINEMA,   # has id=1
+            RADARR_CALENDAR_MOVIE_NO_ID,    # no id
+        ]
+        mock_sonarr_client.get_calendar.return_value = [
+            SONARR_CALENDAR_EPISODE,        # has id=501
+            SONARR_CALENDAR_EPISODE_NO_ID,  # no id
+        ]
+
+        results = await service.get_upcoming(days=30)
+
+        by_title = {r["title"]: r for r in results}
+        assert by_title["Movie A"]["in_library"] is True
+        assert by_title["Movie C"]["in_library"] is False
+        assert by_title["Pilot"]["in_library"] is True
+        assert by_title["Unmonitored Ep"]["in_library"] is False
+
+    @pytest.mark.asyncio
+    async def test_api_error_one_service_still_returns_other(
+        self, mock_radarr_client, mock_sonarr_client
+    ):
+        """API error on one service still returns results from the other."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = mock_sonarr_client
+        mock_radarr_client.get_calendar.side_effect = Exception("Radarr down")
+        mock_sonarr_client.get_calendar.return_value = [
+            SONARR_CALENDAR_EPISODE,
+        ]
+
+        results = await service.get_upcoming(days=7)
+
+        assert len(results) == 1
+        assert results[0]["type"] == "episode"
+
+    @pytest.mark.asyncio
+    async def test_radarr_movie_no_dates(self, mock_radarr_client):
+        """Movie with no date fields gets empty date and Unknown label."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = None
+        mock_radarr_client.get_calendar.return_value = [
+            {"title": "No Dates", "tmdbId": 999, "year": 2026},
+        ]
+
+        results = await service.get_upcoming(days=7)
+
+        assert results[0]["date"] == ""
+        assert results[0]["date_label"] == "Unknown"
+
+    @pytest.mark.asyncio
+    async def test_normalized_schema_movie(self, mock_radarr_client):
+        """Movie items have all expected schema fields."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = None
+        mock_radarr_client.get_calendar.return_value = [
+            RADARR_CALENDAR_MOVIE_CINEMA,
+        ]
+
+        results = await service.get_upcoming(days=30)
+        item = results[0]
+
+        assert item["type"] == "movie"
+        assert item["title"] == "Movie A"
+        assert item["series_title"] is None
+        assert item["date"] == "2026-03-10"
+        assert item["date_label"] == "Cinema"
+        assert item["year"] == 2026
+        assert item["season"] is None
+        assert item["episode"] is None
+        assert item["in_library"] is True
+        assert item["media_id"] == "100"
+        assert item["internal_id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_normalized_schema_episode(self, mock_sonarr_client):
+        """Episode items have all expected schema fields."""
+        service = MediaService()
+        MediaService._radarr = None
+        MediaService._sonarr = mock_sonarr_client
+        mock_sonarr_client.get_calendar.return_value = [
+            SONARR_CALENDAR_EPISODE,
+        ]
+
+        results = await service.get_upcoming(days=30)
+        item = results[0]
+
+        assert item["type"] == "episode"
+        assert item["title"] == "Pilot"
+        assert item["series_title"] == "New Show"
+        assert item["date"] == "2026-03-08"
+        assert item["date_label"] == "Airing"
+        assert item["year"] is None
+        assert item["season"] == 1
+        assert item["episode"] == 1
+        assert item["in_library"] is True
+        assert item["media_id"] == "9000"
+        assert item["internal_id"] == 10

--- a/translations/addarr.de-de.yml
+++ b/translations/addarr.de-de.yml
@@ -219,3 +219,21 @@ de-de:
 
   # Rate limiting
   RateLimitExceeded: "Langsam! Bitte warte %(seconds)s Sekunden, bevor du es erneut versuchst."
+
+  # Calendar / Upcoming releases
+  Upcoming: "📅 Upcoming"
+  CommandUpcoming: "Browse upcoming releases"
+  CalendarTitle: "📅 Upcoming Releases"
+  CalendarEmpty: "No upcoming releases found."
+  CalendarMovie: "🎬 Movie"
+  CalendarEpisode: "📺 Episode"
+  CalendarCinema: "Cinema"
+  CalendarDigital: "Digital"
+  CalendarPhysical: "Physical"
+  CalendarAiring: "Airing"
+  CalendarDays7: "7 days"
+  CalendarDays14: "14 days"
+  CalendarDays30: "30 days"
+  CalendarAddSuccess: "✅ Added to library!"
+  CalendarAddFailed: "❌ Failed to add."
+  CalendarAlreadyInLibrary: "Already in your library."

--- a/translations/addarr.en-us.yml
+++ b/translations/addarr.en-us.yml
@@ -222,3 +222,21 @@ en-us:
 
   # Rate limiting
   RateLimitExceeded: "Slow down! Please wait %(seconds)s seconds before trying again."
+
+  # Calendar / Upcoming releases
+  Upcoming: "📅 Upcoming"
+  CommandUpcoming: "Browse upcoming releases"
+  CalendarTitle: "📅 Upcoming Releases"
+  CalendarEmpty: "No upcoming releases found."
+  CalendarMovie: "🎬 Movie"
+  CalendarEpisode: "📺 Episode"
+  CalendarCinema: "Cinema"
+  CalendarDigital: "Digital"
+  CalendarPhysical: "Physical"
+  CalendarAiring: "Airing"
+  CalendarDays7: "7 days"
+  CalendarDays14: "14 days"
+  CalendarDays30: "30 days"
+  CalendarAddSuccess: "✅ Added to library!"
+  CalendarAddFailed: "❌ Failed to add."
+  CalendarAlreadyInLibrary: "Already in your library."

--- a/translations/addarr.es-es.yml
+++ b/translations/addarr.es-es.yml
@@ -219,3 +219,21 @@ es-es:
 
   # Rate limiting
   RateLimitExceeded: "Demasiado rapido! Por favor espera %(seconds)s segundos antes de intentarlo de nuevo."
+
+  # Calendar / Upcoming releases
+  Upcoming: "📅 Upcoming"
+  CommandUpcoming: "Browse upcoming releases"
+  CalendarTitle: "📅 Upcoming Releases"
+  CalendarEmpty: "No upcoming releases found."
+  CalendarMovie: "🎬 Movie"
+  CalendarEpisode: "📺 Episode"
+  CalendarCinema: "Cinema"
+  CalendarDigital: "Digital"
+  CalendarPhysical: "Physical"
+  CalendarAiring: "Airing"
+  CalendarDays7: "7 days"
+  CalendarDays14: "14 days"
+  CalendarDays30: "30 days"
+  CalendarAddSuccess: "✅ Added to library!"
+  CalendarAddFailed: "❌ Failed to add."
+  CalendarAlreadyInLibrary: "Already in your library."

--- a/translations/addarr.fr-fr.yml
+++ b/translations/addarr.fr-fr.yml
@@ -219,3 +219,21 @@ fr-fr:
 
   # Rate limiting
   RateLimitExceeded: "Doucement ! Veuillez patienter %(seconds)s secondes avant de reessayer."
+
+  # Calendar / Upcoming releases
+  Upcoming: "📅 Upcoming"
+  CommandUpcoming: "Browse upcoming releases"
+  CalendarTitle: "📅 Upcoming Releases"
+  CalendarEmpty: "No upcoming releases found."
+  CalendarMovie: "🎬 Movie"
+  CalendarEpisode: "📺 Episode"
+  CalendarCinema: "Cinema"
+  CalendarDigital: "Digital"
+  CalendarPhysical: "Physical"
+  CalendarAiring: "Airing"
+  CalendarDays7: "7 days"
+  CalendarDays14: "14 days"
+  CalendarDays30: "30 days"
+  CalendarAddSuccess: "✅ Added to library!"
+  CalendarAddFailed: "❌ Failed to add."
+  CalendarAlreadyInLibrary: "Already in your library."

--- a/translations/addarr.it-it.yml
+++ b/translations/addarr.it-it.yml
@@ -219,3 +219,21 @@ it-it:
 
   # Rate limiting
   RateLimitExceeded: "Rallenta! Attendi %(seconds)s secondi prima di riprovare."
+
+  # Calendar / Upcoming releases
+  Upcoming: "📅 Upcoming"
+  CommandUpcoming: "Browse upcoming releases"
+  CalendarTitle: "📅 Upcoming Releases"
+  CalendarEmpty: "No upcoming releases found."
+  CalendarMovie: "🎬 Movie"
+  CalendarEpisode: "📺 Episode"
+  CalendarCinema: "Cinema"
+  CalendarDigital: "Digital"
+  CalendarPhysical: "Physical"
+  CalendarAiring: "Airing"
+  CalendarDays7: "7 days"
+  CalendarDays14: "14 days"
+  CalendarDays30: "30 days"
+  CalendarAddSuccess: "✅ Added to library!"
+  CalendarAddFailed: "❌ Failed to add."
+  CalendarAlreadyInLibrary: "Already in your library."

--- a/translations/addarr.nl-be.yml
+++ b/translations/addarr.nl-be.yml
@@ -219,3 +219,21 @@ nl-be:
 
   # Rate limiting
   RateLimitExceeded: "Rustig aan! Wacht %(seconds)s seconden voor je het opnieuw probeert."
+
+  # Calendar / Upcoming releases
+  Upcoming: "📅 Upcoming"
+  CommandUpcoming: "Browse upcoming releases"
+  CalendarTitle: "📅 Upcoming Releases"
+  CalendarEmpty: "No upcoming releases found."
+  CalendarMovie: "🎬 Movie"
+  CalendarEpisode: "📺 Episode"
+  CalendarCinema: "Cinema"
+  CalendarDigital: "Digital"
+  CalendarPhysical: "Physical"
+  CalendarAiring: "Airing"
+  CalendarDays7: "7 days"
+  CalendarDays14: "14 days"
+  CalendarDays30: "30 days"
+  CalendarAddSuccess: "✅ Added to library!"
+  CalendarAddFailed: "❌ Failed to add."
+  CalendarAlreadyInLibrary: "Already in your library."

--- a/translations/addarr.pl-pl.yml
+++ b/translations/addarr.pl-pl.yml
@@ -219,3 +219,21 @@ pl-pl:
 
   # Rate limiting
   RateLimitExceeded: "Zwolnij! Poczekaj %(seconds)s sekund przed ponowna proba."
+
+  # Calendar / Upcoming releases
+  Upcoming: "📅 Upcoming"
+  CommandUpcoming: "Browse upcoming releases"
+  CalendarTitle: "📅 Upcoming Releases"
+  CalendarEmpty: "No upcoming releases found."
+  CalendarMovie: "🎬 Movie"
+  CalendarEpisode: "📺 Episode"
+  CalendarCinema: "Cinema"
+  CalendarDigital: "Digital"
+  CalendarPhysical: "Physical"
+  CalendarAiring: "Airing"
+  CalendarDays7: "7 days"
+  CalendarDays14: "14 days"
+  CalendarDays30: "30 days"
+  CalendarAddSuccess: "✅ Added to library!"
+  CalendarAddFailed: "❌ Failed to add."
+  CalendarAlreadyInLibrary: "Already in your library."

--- a/translations/addarr.pt-pt.yml
+++ b/translations/addarr.pt-pt.yml
@@ -219,3 +219,21 @@ pt-pt:
 
   # Rate limiting
   RateLimitExceeded: "Devagar! Por favor aguarde %(seconds)s segundos antes de tentar novamente."
+
+  # Calendar / Upcoming releases
+  Upcoming: "📅 Upcoming"
+  CommandUpcoming: "Browse upcoming releases"
+  CalendarTitle: "📅 Upcoming Releases"
+  CalendarEmpty: "No upcoming releases found."
+  CalendarMovie: "🎬 Movie"
+  CalendarEpisode: "📺 Episode"
+  CalendarCinema: "Cinema"
+  CalendarDigital: "Digital"
+  CalendarPhysical: "Physical"
+  CalendarAiring: "Airing"
+  CalendarDays7: "7 days"
+  CalendarDays14: "14 days"
+  CalendarDays30: "30 days"
+  CalendarAddSuccess: "✅ Added to library!"
+  CalendarAddFailed: "❌ Failed to add."
+  CalendarAlreadyInLibrary: "Already in your library."

--- a/translations/addarr.ru-ru.yml
+++ b/translations/addarr.ru-ru.yml
@@ -219,3 +219,21 @@ ru-ru:
 
   # Rate limiting
   RateLimitExceeded: "Podozhdite %(seconds)s sekund pered povtornoj popytkoj."
+
+  # Calendar / Upcoming releases
+  Upcoming: "📅 Upcoming"
+  CommandUpcoming: "Browse upcoming releases"
+  CalendarTitle: "📅 Upcoming Releases"
+  CalendarEmpty: "No upcoming releases found."
+  CalendarMovie: "🎬 Movie"
+  CalendarEpisode: "📺 Episode"
+  CalendarCinema: "Cinema"
+  CalendarDigital: "Digital"
+  CalendarPhysical: "Physical"
+  CalendarAiring: "Airing"
+  CalendarDays7: "7 days"
+  CalendarDays14: "14 days"
+  CalendarDays30: "30 days"
+  CalendarAddSuccess: "✅ Added to library!"
+  CalendarAddFailed: "❌ Failed to add."
+  CalendarAlreadyInLibrary: "Already in your library."

--- a/translations/addarr.template.yml
+++ b/translations/addarr.template.yml
@@ -243,3 +243,21 @@ template:
 
   # Rate limiting
   RateLimitExceeded: "Slow down! Please wait %(seconds)s seconds before trying again."
+
+  # Calendar / Upcoming releases
+  Upcoming: "📅 Upcoming"
+  CommandUpcoming: "Browse upcoming releases"
+  CalendarTitle: "📅 Upcoming Releases"
+  CalendarEmpty: "No upcoming releases found."
+  CalendarMovie: "🎬 Movie"
+  CalendarEpisode: "📺 Episode"
+  CalendarCinema: "Cinema"
+  CalendarDigital: "Digital"
+  CalendarPhysical: "Physical"
+  CalendarAiring: "Airing"
+  CalendarDays7: "7 days"
+  CalendarDays14: "14 days"
+  CalendarDays30: "30 days"
+  CalendarAddSuccess: "✅ Added to library!"
+  CalendarAddFailed: "❌ Failed to add."
+  CalendarAlreadyInLibrary: "Already in your library."


### PR DESCRIPTION
## Summary

Implements the `/upcoming` command (#104) — a calendar view showing upcoming movie and TV releases from Radarr and Sonarr with inline keyboard navigation, pagination, and quick-add to library.

- **API layer**: Add `get_calendar(start, end)` to RadarrClient and SonarrClient
- **Service layer**: Add `MediaService.get_upcoming(days)` with concurrent fetching, normalization, and date sorting
- **UI**: Calendar keyboards with period selection (7/14/30 days), pagination, refresh, back-to-menu
- **Handler**: `CalendarHandler` with `/upcoming` command, `cal_*` callback routing, quick-add via first root folder and quality profile
- **Wiring**: Handler registered in bot, `/upcoming` in command menu (when Radarr/Sonarr enabled), main menu button, StartHandler routing
- **i18n**: 16 new translation keys across all 10 locale files

## Test plan

- [x] 1484 tests pass (`pytest --tb=short -q`)
- [x] 100% coverage on all 8 changed source modules
- [x] Flake8 clean
- [x] i18n validation passes
- [x] Architecture tests pass (layer boundaries, conventions)
- [ ] Manual test: `/upcoming` shows calendar with items from Radarr/Sonarr
- [ ] Manual test: Period buttons (7d/14d/30d) switch and re-fetch
- [ ] Manual test: Pagination works on multi-page results
- [ ] Manual test: Quick-add from calendar adds media to library
- [ ] Manual test: Main menu "Upcoming" button opens calendar

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
