### PR TITLE
feat: add SABnzbd queue dashboard with /downloads command

### DIFF
--- a/.claude/skills/addarr-workflow/SKILL.md
+++ b/.claude/skills/addarr-workflow/SKILL.md
@@ -11,6 +11,17 @@ Self-driving development workflow for Addarr. Entry point: `/addarr [argument]`
 
 **Execution model:** Each flow is an ordered sequence. Execute every step automatically. Only pause for user input at steps marked `ASK`. All other steps execute without waiting.
 
+## Token Discipline
+
+**This is a hard requirement for all automated execution.**
+
+- Go straight from tool result to next tool call. No narration between steps.
+- Only output text when: reporting a blocker, asking for user input, or summarizing a completed phase.
+- Never restate what a tool result already shows (test counts, lint output, etc.).
+- Never explain what you're about to do — just do it.
+- Phase/task summaries: 1-2 sentences max.
+- Agent prompts: instruct agents to return only actionable findings. "Skip items consistent with existing codebase patterns. Only report issues you would actually fix."
+
 ## Entry Points
 
 | Command | Flow | Description |
@@ -84,18 +95,18 @@ Step 7  RUN     Push changes, report what was addressed
 See [references/create-pr.md](references/create-pr.md) for detailed instructions.
 
 ```
-Step 1  INVOKE  @find-bugs on all branch changes — fix any findings
-Step 2  INVOKE  @simplify on changed files — quick pass for reuse, quality, efficiency
-Step 2b INVOKE  @code-simplifier on changed files — deeper focused refactoring
-Step 3  INVOKE  @superpowers:verification-before-completion — run pytest, confirm green
-Step 3b RUN     Coverage check: run pytest with --cov on all changed source modules
+Step 1  RUN     Pre-PR review: single consolidated pass over branch diff
+                covering bugs, security, code quality, and efficiency.
+                Run directly (not via skill invocation) — see create-pr.md.
+                Fix any actionable findings. Skip pre-existing patterns.
+Step 2  RUN     Coverage check: run pytest with --cov on all changed source modules
                 and --cov-report=term-missing. Target 100% on all new/modified code.
                 Fix any gaps by adding tests for uncovered lines.
-Step 4  RUN     Flow: preflight (all checks must pass)
-Step 5  RUN     Verify readiness (not on main/development, all committed, push if needed)
-Step 6  RUN     Generate PR title + body from commits and issue context
-Step 7  RUN     gh pr create --base development
-Step 8  RUN     Report PR URL and CI expectations
+Step 3  RUN     Flow: preflight (all checks must pass)
+Step 4  RUN     Verify readiness (not on main/development, all committed, push if needed)
+Step 5  RUN     Generate PR title + body from commits and issue context
+Step 6  RUN     gh pr create --base development
+Step 7  RUN     Report PR URL
 ```
 
 ## Flow: preflight
@@ -111,7 +122,7 @@ Step 2  RUN     flake8 .
                 On failure: auto-fix formatting, report logic issues
 Step 3  RUN     PYTHONIOENCODING=utf-8 python run.py --validate-i18n
                 On failure: report missing/malformed keys
-Step 4  RUN     Report results summary
+Step 4  RUN     Report results summary (1-2 lines)
 ```
 
 ---
@@ -120,44 +131,52 @@ Step 4  RUN     Report results summary
 
 This is the core implementation cycle used by new-task, continue, and feedback flows.
 
+**Skill loading — on-demand, not per-loop:**
+
+All skills below are mandatory (must be available) but should only be invoked
+when the specific trigger condition is met — never routinely per task or per behavior.
+
+| Skill | Trigger (invoke ONLY when this happens) |
+|-------|----------------------------------------|
+| `@addarr-handlers` | First task in a session that touches `src/bot/handlers/` |
+| `@addarr-services` | First task in a session that touches `src/services/` or `src/api/` |
+| `@addarr-testing` | First task in a session that touches `tests/` |
+| `@python-testing-pro` | Facing a non-trivial test design question (parametrize strategy, complex mock setup, fixture architecture) |
+| `@superpowers:test-driven-development` | First task in a session (load once to set TDD discipline) |
+| `@superpowers:verification-before-completion` | After all tasks complete, before create-pr flow |
+| `@code-simplifier` | Refactor step produces code that feels overly complex |
+| `@superpowers:systematic-debugging` | Unexpected test failure (not a simple typo/import fix) |
+
+"First task in a session" means: invoke once when the trigger first applies, then
+the skill stays in context for the rest of the session. Do not re-invoke.
+
 **For each task in TASKS.md:**
 
 ```
 1  RUN     Mark task in-progress
-2  CHECK   Determine if task touches handlers or services based on:
-           - Task scope, file paths, and action items mentioning handlers/services
-           - Issue context (e.g., "new command", "API client", "service layer")
-           If task touches src/bot/handlers/ → INVOKE @addarr-handlers
-           If task touches src/services/ or src/api/ → INVOKE @addarr-services
-           (Skip if task is pure config, translations, or utilities)
-3  INVOKE  @superpowers:test-driven-development (governs the entire cycle below)
 
-   For each behavior in the task:
-   a  RED     Write failing test — use @python-testing-pro for strategy,
-              @addarr-testing for project-specific patterns
+2  RUN     TDD cycle — for each behavior in the task:
+   a  RED     Write failing test
    b  RUN     pytest tests/path/test_file.py::test_name -v — confirm fails correctly
-   c  GREEN   Write minimal implementation — follow @addarr-handlers / @addarr-services
-              patterns if those skills were loaded in step 2
-   d  RUN     pytest --tb=short -q — confirm all pass
-   e  INVOKE  @code-simplifier on changed code (refactor phase)
-   f  RUN     pytest --tb=short -q — confirm still green after refactor
+   c  GREEN   Write minimal implementation
+   d  RUN     pytest tests/path/test_file.py -v — confirm relevant tests pass
 
-   On unexpected test failure at any point:
+   On unexpected test failure:
    -> INVOKE @superpowers:systematic-debugging — find root cause before fixing
 
-4  INVOKE  @superpowers:verification-before-completion — run full test suite, confirm output
-5  RUN     Coverage check: run pytest with --cov on changed source modules
+3  RUN     Full suite check: pytest --tb=short -q (once per task, not per behavior)
+4  RUN     Coverage check: run pytest with --cov on changed source modules
            and --cov-report=term-missing. Target 100% on all new/modified code.
            Fix any gaps by adding tests for uncovered lines.
-6  RUN     Mark task complete in TASKS.md and add completion metadata:
+5  RUN     Mark task complete in TASKS.md and add completion metadata:
            - **Completed:** <date>
            - **Learnings:** Key insights, gotchas, or discoveries from this task
            - **Key Changes:** Summary of what was modified (files, functions, patterns)
            - **Notes:** Any important context for future work
-7  RUN     Commit changes for this task — creates a restore point in case
+6  RUN     Commit changes for this task — creates a restore point in case
            later tasks break something. Use a descriptive message referencing
            the task number (e.g., "feat: add command builder module (task 1.1)")
-8  RUN     Next task (loop back to 1)
+7  RUN     Next task (loop back to 1)
 ```
 
 **Completion metadata example:**
@@ -180,19 +199,19 @@ This is the core implementation cycle used by new-task, continue, and feedback f
 
 ## Skill Reference
 
-Skills invoked during workflow execution and their roles:
+All skills are mandatory but invoke only when the trigger applies — see the
+on-demand table in the Execution Loop section for per-task triggers.
 
-| Skill | Role | Invoked during |
-|-------|------|---------------|
-| `@superpowers:brainstorming` | Explore design space for complex tasks | new-task step 3b |
+| Skill | Role | Invoked when |
+|-------|------|-------------|
+| `@superpowers:brainstorming` | Explore design space | new-task step 3b (only if complex/ambiguous) |
+| `@superpowers:writing-plans` | Guide plan creation | new-task step 4 |
 | `@task-writer` | Convert plan into sized TASKS.md | new-task step 4c |
-| `@superpowers:test-driven-development` | Govern red-green-refactor cycle | Execution loop |
-| `@python-testing-pro` | Pytest strategies, mocking, parametrization | Execution loop (RED phase) |
-| `@addarr-testing` | Project-specific test patterns and fixtures | Execution loop (RED phase) |
-| `@addarr-handlers` | Handler class patterns and conventions | Execution loop (GREEN phase, handler work) |
-| `@addarr-services` | Service/API client patterns | Execution loop (GREEN phase, service work) |
-| `@code-simplifier` | Clean up changed code | Execution loop (refactor) + create-pr step 2b |
-| `@simplify` | Quick pass for reuse, quality, efficiency | create-pr step 2 |
-| `@superpowers:systematic-debugging` | Investigate unexpected failures | Execution loop (on failure) + feedback step 5 |
-| `@superpowers:verification-before-completion` | Verify before claiming done | Execution loop step 3 + create-pr step 3 |
-| `@find-bugs` | Review branch for bugs/security | create-pr step 1 |
+| `@superpowers:test-driven-development` | Enforce TDD discipline | First task in session (once) |
+| `@superpowers:verification-before-completion` | Final verification gate | After all tasks, before create-pr |
+| `@superpowers:systematic-debugging` | Investigate unexpected failures | On unexpected test failure |
+| `@addarr-handlers` | Handler class patterns | First handler task in session |
+| `@addarr-services` | Service/API client patterns | First service/API task in session |
+| `@addarr-testing` | Project-specific test patterns | First test-writing task in session |
+| `@python-testing-pro` | Advanced pytest strategies | Non-trivial test design questions |
+| `@code-simplifier` | Focused refactoring | When refactor step produces complex code |

--- a/.claude/skills/addarr-workflow/references/create-pr.md
+++ b/.claude/skills/addarr-workflow/references/create-pr.md
@@ -2,41 +2,62 @@
 
 Sequence is defined in SKILL.md. This file provides implementation details per step.
 
-## Step 1: Find Bugs
+## Step 1: Pre-PR Review (Consolidated)
 
-`INVOKE` @find-bugs — review the full branch diff:
+Single pass over the branch diff covering bugs, security, quality, and efficiency.
+Do NOT invoke @find-bugs, @simplify, or @code-simplifier as separate skills.
+Run the review directly to avoid loading 3+ skill definitions into context.
 
-```bash
-git diff $(git merge-base HEAD development)...HEAD
-```
-
-Follow the find-bugs skill process completely (attack surface mapping, security checklist, verification). Fix any findings before proceeding. If fixes are made, run `pytest --tb=short -q` to confirm no regressions.
-
-## Step 2: Simplify
-
-`INVOKE` @code-simplifier on all files changed in this branch:
+### Get the diff
 
 ```bash
-git diff --name-only $(git merge-base HEAD development)...HEAD
+git diff origin/development...HEAD
 ```
 
-Apply simplifications while keeping tests green. Run `pytest --tb=short -q` after changes.
+If truncated, read each changed source file individually.
 
-## Step 3: Verification Gate
+### Review checklist (check every changed file)
 
-`INVOKE` @superpowers:verification-before-completion — run the full test suite and confirm output before proceeding:
+**Security & Bugs:**
+- Injection (command, template, URL parameter)
+- Missing `@require_auth` on entry points
+- Missing `query.answer()` on callback handlers
+- `reply_text` on callbacks (should be `edit_text`/`edit_caption`)
+- Direct `config["key"]` indexing (should be `.get()`)
+- Missing `await`, unclosed sessions
+- API keys in log messages
+
+**Code Quality:**
+- Copy-paste blocks that should be unified (3+ near-identical blocks = fix)
+- New code that duplicates an existing utility (search before writing)
+- Leaky abstractions crossing layer boundaries
+
+**Efficiency:**
+- Redundant API calls (same data fetched multiple times)
+- N+1 patterns
+- Unbounded data structures
+
+### Output rules
+
+- Only report issues you would actually fix.
+- Skip items consistent with existing codebase patterns (pre-existing tech debt).
+- Skip stylistic issues (flake8 catches those).
+- Fix actionable findings immediately. Run `pytest --tb=short -q` after fixes.
+
+## Step 2: Coverage Check
 
 ```bash
-pytest --tb=short -q
+pytest <test_files> --cov=<changed_modules> --cov-report=term-missing -q
 ```
 
-Do NOT proceed unless output confirms all tests pass.
+Use dotted module paths for `--cov` (e.g., `--cov=src.bot.handlers.sabnzbd`).
+Target 100% on all new/modified code. Add tests for uncovered lines.
 
-## Step 4: Preflight
+## Step 3: Preflight
 
-Run the full preflight flow (see [preflight.md](preflight.md)). All checks must pass before continuing.
+Run the full preflight flow (see [preflight.md](preflight.md)). All checks must pass.
 
-## Step 5: Verify Readiness
+## Step 4: Verify Readiness
 
 Check:
 - Branch is not `development` or `main`
@@ -45,41 +66,20 @@ Check:
 
 If not pushed:
 ```bash
-git push -u origin $(git branch --show-current)
+git push -u origin <branch-name>
 ```
 
-## Step 6: Generate PR Info
+## Step 5: Generate PR Info
 
 - **Title**: From issue title if linked, otherwise from branch name. Keep under 70 chars.
-- **Body**: Generate from commits on this branch:
-  ```bash
-  git log development..HEAD --oneline
-  ```
+- **Body**: Generate from commits and issue context. Write to temp file, use `--body-file`.
 
-## Step 7: Create PR
+## Step 6: Create PR
 
 ```bash
-gh pr create --base development --title "<title>" --body "$(cat <<'EOF'
-## Summary
-<1-3 bullet points describing the changes>
-
-## Changes
-<List of key changes by area: handlers, services, API, config, i18n>
-
-## Test plan
-<Manual testing steps to verify the changes>
-
-## Related issue
-<Closes #N or Relates to #N, if applicable>
-EOF
-)"
+gh pr create --base development --title "<title>" --body-file /tmp/pr_body.md
 ```
 
-## Step 8: Report Result
+## Step 7: Report Result
 
-Show the PR URL and confirm CI will run automatically:
-- Pytest with coverage
-- Flake8 lint
-- Translation validation
-- Docker build test
-- AI-powered review via Groq (auto-approve if all pass)
+Show the PR URL. One line.

--- a/.claude/skills/find-bugs/SKILL.md
+++ b/.claude/skills/find-bugs/SKILL.md
@@ -7,73 +7,50 @@ description: Use when reviewing branch changes for bugs, security vulnerabilitie
 
 Review changes on the current branch for bugs, security vulnerabilities, and code quality issues. Adapted from [Sentry's find-bugs skill](https://github.com/getsentry/sentry-skills) with Addarr-specific checks.
 
-## Phase 1: Complete Input Gathering
+## Phase 1: Input Gathering
 
-1. Get the FULL diff: `git diff $(git merge-base HEAD development)...HEAD`
-2. If output is truncated, read each changed file individually until you have seen every changed line
-3. List all files modified in this branch before proceeding
+1. Get the diff: `git diff origin/development...HEAD`
+2. If truncated, read each changed source file individually
+3. Note all modified files before proceeding
 
-## Phase 2: Attack Surface Mapping
+## Phase 2: Security & Bug Checklist
 
-For each changed file, identify and list:
+For each changed file, check:
 
-* All user inputs (Telegram message text, callback_data, command arguments)
-* All API calls (Radarr, Sonarr, Lidarr, SABnzbd, Transmission)
-* All authentication/authorization checks (`@require_auth`, user ID validation)
-* All config access patterns (safe `.get()` vs direct indexing)
-* All async operations (`await`, session management, `aiohttp` calls)
-* All singleton state mutations (class-level variables)
-
-## Phase 3: Security & Bug Checklist
-
-Check EVERY item for EVERY changed file:
-
-* [ ] **Injection**: Command injection via `subprocess`, template injection, YAML injection in config
+* [ ] **Injection**: Command injection via `subprocess`, template injection, URL parameter injection
 * [ ] **Authentication bypass**: Missing `@require_auth` on entry points, user ID spoofing
 * [ ] **Authorization/IDOR**: Access control on per-user operations (e.g., user_data isolation)
-* [ ] **Information disclosure**: API keys in logs, error messages leaking internal state, secrets in Telegram messages
+* [ ] **Information disclosure**: API keys in logs, error messages leaking internal state
 * [ ] **Race conditions**: TOCTOU in singleton initialization, concurrent user_data access
-* [ ] **Resource exhaustion**: Unbounded search results, missing timeouts on API calls, session leaks
-* [ ] **Business logic**: State machine violations (ConversationHandler states), numeric edge cases in quality/season selection
+* [ ] **Resource exhaustion**: Unbounded data, missing timeouts, session leaks
+* [ ] **Business logic**: State machine violations, numeric edge cases
 * [ ] **Async bugs**: Missing `await`, unclosed sessions, fire-and-forget coroutines
-* [ ] **Singleton issues**: State in `__init__` vs `_initialize`, missing `is_enabled()` checks, incomplete reset
-* [ ] **Config safety**: Direct `config["key"]` indexing without enable check, missing `.get()` defaults
+* [ ] **Singleton issues**: State in `__init__` vs `_initialize`, missing `is_enabled()` checks
+* [ ] **Config safety**: Direct `config["key"]` indexing, missing `.get()` defaults
 * [ ] **Telegram API misuse**: Missing `query.answer()`, `reply_text` on callbacks, `edit_text` on photo messages
 * [ ] **Error handling**: Bare `except:`, swallowing exceptions silently, raising from `_initialize`
 
-## Phase 4: Verification
+## Phase 3: Verification
 
-For each potential issue:
+For each potential issue, verify it's real:
+* Not already handled elsewhere in the changed code
+* Not covered by existing tests
+* Not consistent with existing codebase patterns (skip pre-existing tech debt)
 
-* Check if it's already handled elsewhere in the changed code
-* Search for existing tests covering the scenario
-* Read surrounding context to verify the issue is real
-* Check if the pattern matches existing code conventions (see `@addarr-services` and `@addarr-handlers` anti-patterns)
+## Output
 
-## Phase 5: Pre-Conclusion Audit
+**Only report actionable findings.** Skip:
+- Stylistic/formatting issues (flake8 catches those)
+- Pre-existing patterns you wouldn't change in this PR
+- Items where "no change recommended"
 
-Before finalizing, you MUST:
-
-1. List every file you reviewed and confirm you read it completely
-2. List every checklist item and note whether you found issues or confirmed it's clean
-3. List any areas you could NOT fully verify and why
-4. Only then provide your final findings
-
-## Output Format
-
-**Prioritize**: security vulnerabilities > async/singleton bugs > Telegram API misuse > code quality
-
-**Skip**: stylistic/formatting issues, flake8 catches
-
-For each issue:
+For each real issue:
 
 * **File:Line** — Brief description
 * **Severity**: Critical / High / Medium / Low
 * **Problem**: What's wrong
-* **Evidence**: Why this is real (not already fixed, no existing test, etc.)
 * **Fix**: Concrete suggestion
-* **References**: Link to relevant anti-pattern in `@addarr-services` or `@addarr-handlers` if applicable
 
-If you find nothing significant, say so — don't invent issues.
+If nothing significant found, say so in one line. Do not pad output with "clean" confirmations per checklist item.
 
 Do not make changes — just report findings.

--- a/.claude/skills/task-writer/SKILL.md
+++ b/.claude/skills/task-writer/SKILL.md
@@ -73,6 +73,22 @@ Phase: [Large Feature] (3-4 tasks)
 - Action items MUST list [RED] test-writing steps BEFORE [GREEN] implementation steps
 - **Context block is REQUIRED** for every implementation task
 
+**Compact mode:** When tasks will be executed sequentially in the same session
+(i.e., immediately after planning), use compact context blocks:
+
+```markdown
+- [ ] **N.1** Implement [feature/layer]
+    - **Context:** See plan.md Phase N. Key refs: `file.py:line` (pattern template)
+    - **Watch out:** [Only non-obvious gotchas not in the plan]
+    - **Scope:** Brief description
+    - **Touches:** Key files
+    - **Action items:** ...
+    - **Success:** ...
+```
+
+Use full context blocks only when tasks may be picked up after context loss
+(e.g., across sessions, by a different person, or when plan.md doesn't exist).
+
 ## What Goes IN a Single Task
 
 Bundle these together (one logical unit):

--- a/docs/issues/issue-101/TASKS.md
+++ b/docs/issues/issue-101/TASKS.md
@@ -53,7 +53,7 @@ Add a `/downloads` command that displays a SABnzbd queue dashboard with active d
 
 **Goal:** Add keyboard builders for the downloads dashboard and all required translation keys.
 
-- [ ] **2.1** Add downloads dashboard keyboards and translation keys
+- [x] **2.1** Add downloads dashboard keyboards and translation keys
     - **Context:**
         - **Why:** The handler needs keyboard functions for the queue view (with per-item pause/resume buttons, pagination, tab switching) and history view (pagination, tab switching, refresh). Translation keys needed for all user-facing strings.
         - **Architecture:** Follow existing keyboard patterns in `src/bot/keyboards.py`. Each function returns `InlineKeyboardMarkup`. Pagination follows the `get_queue_items_keyboard` pattern (ceil division, nav_row with Prev/Next). Callback data convention: `dl_` prefix for all downloads dashboard buttons.
@@ -67,6 +67,10 @@ Add a `/downloads` command that displays a SABnzbd queue dashboard with active d
         - [GREEN] Implement both keyboard functions
         - [GREEN] Add translation keys to `translations/addarr.en-us.yml`: `CommandDownloads`, `DownloadsTitle`, `DownloadsEmpty`, `DownloadsHistoryTitle`, `DownloadsHistoryEmpty`, `DownloadsSpeed`, `DownloadsRemaining`, `DownloadsItems`, `DownloadsPaused`, `DownloadsItemPaused`, `DownloadsItemResumed`, `DownloadsPauseError`, `DownloadsResumeError`, `DownloadsNotEnabled`
     - **Success:** Keyboard tests pass, translation keys present in en-us file
+    - **Completed:** 2026-03-06
+    - **Learnings:** Template file has duplicated command sections — need to add keys to both. Other locales will show warnings for missing new keys, which is expected.
+    - **Key Changes:** Added `get_downloads_queue_keyboard()` and `get_downloads_history_keyboard()` to `src/bot/keyboards.py`. 14 new tests. 16 new translation keys in en-us and template files.
+    - **Notes:** Translation warnings for other locales are expected — keys need to be added when translators update.
 
 ---
 

--- a/docs/issues/issue-101/TASKS.md
+++ b/docs/issues/issue-101/TASKS.md
@@ -1,0 +1,98 @@
+# Issue #101: SABnzbd Queue Dashboard — Tasks
+
+## Summary
+
+Add a `/downloads` command that displays a SABnzbd queue dashboard with active downloads, history, per-item pause/resume, pagination, and refresh.
+
+---
+
+### Phase 1: API + Service Layer (2 tasks)
+
+**Goal:** Add per-item pause/resume to API client and service, plus a detailed queue method for dashboard display.
+
+- [x] **1.1** Add per-item pause/resume to API client
+    - **Context:**
+        - **Why:** SABnzbd supports pausing/resuming individual queue items, but `SabnzbdClient` only has whole-queue `pause_queue()`/`resume_queue()`. Per-item control is needed for the dashboard's inline buttons.
+        - **Architecture:** Follow existing method pattern in `SabnzbdClient` — each method builds a URL with query params, makes an async GET via `aiohttp.ClientSession`, returns `bool` on success. SABnzbd API uses `mode=queue&name=pause&value=<nzo_id>` and `mode=queue&name=resume&value=<nzo_id>`.
+        - **Key refs:** `src/api/sabnzbd.py:98-118` (`pause_queue`/`resume_queue` as template), `tests/test_api/test_sabnzbd_api.py` (existing test patterns with `aio_mock` fixture and URL-based matching)
+        - **Watch out:** URL construction uses f-strings with `self.api_url` and `self.api_key` appended as query params (not `aiohttp.params` dict). Follow the same pattern for consistency.
+    - **Scope:** Two new methods on `SabnzbdClient`: `pause_item(nzo_id)` and `resume_item(nzo_id)`
+    - **Touches:** `src/api/sabnzbd.py`, `tests/test_api/test_sabnzbd_api.py`
+    - **Action items:**
+        - [RED] Write tests for `pause_item()` — success (HTTP 200), HTTP error (500), connection error
+        - [RED] Write tests for `resume_item()` — success, HTTP error, connection error
+        - [GREEN] Implement `pause_item(nzo_id: str) -> bool` and `resume_item(nzo_id: str) -> bool`
+    - **Success:** `python -m pytest tests/test_api/test_sabnzbd_api.py -v` all pass
+    - **Completed:** 2026-03-06
+    - **Learnings:** API client follows f-string URL pattern (not params dict). Methods are straightforward — SABnzbd uses `mode=queue&name=pause&value=<nzo_id>` for per-item control.
+    - **Key Changes:** Added `pause_item(nzo_id)` and `resume_item(nzo_id)` to `src/api/sabnzbd.py`, 6 new tests in `tests/test_api/test_sabnzbd_api.py`
+    - **Notes:** None
+
+- [x] **1.2** Add per-item control and queue details to service layer
+    - **Context:**
+        - **Why:** `SABnzbdService` needs per-item methods to delegate to the API client, and a `get_queue_details()` method that returns normalized queue data with all fields the handler needs for display (title, progress, ETA, nzo_id, status per slot).
+        - **Architecture:** Singleton service pattern — service makes its own `aiohttp` calls to `self.base_url/api` with `params` dict. `get_queue_details()` should parse the raw queue response into a normalized dict: `{'paused': bool, 'speed': str, 'size_remaining': str, 'items_count': int, 'items': [{'nzo_id': str, 'title': str, 'status': str, 'progress': int, 'size': str, 'timeleft': str}]}`.
+        - **Key refs:** `src/services/sabnzbd.py:63-100` (`get_status` as template), `src/services/sabnzbd.py:154-196` (`pause_queue`/`resume_queue` as template for per-item), `tests/test_services/test_sabnzbd_service.py` (uses `aioresponses` context manager and `SABNZBD_API_PATTERN` regex for URL matching)
+        - **Watch out:** The service uses `params` dicts (not f-string URLs) for `aiohttp` calls, unlike the API client. Per-item pause uses `mode=queue&name=pause&value=<nzo_id>`. Queue slot fields from SABnzbd: `nzo_id`, `filename`, `status`, `percentage`, `size`, `timeleft`.
+    - **Scope:** Three new methods: `pause_item(nzo_id)`, `resume_item(nzo_id)`, `get_queue_details()`
+    - **Touches:** `src/services/sabnzbd.py`, `tests/test_services/test_sabnzbd_service.py`
+    - **Action items:**
+        - [RED] Write tests for `pause_item()` — success, HTTP error, connection error
+        - [RED] Write tests for `resume_item()` — success, HTTP error, connection error
+        - [RED] Write tests for `get_queue_details()` — success with items (verify normalized structure), empty queue, HTTP error, connection error
+        - [GREEN] Implement all three methods
+    - **Success:** `python -m pytest tests/test_services/test_sabnzbd_service.py -v` all pass
+    - **Completed:** 2026-03-06
+    - **Learnings:** Service uses params dict pattern (not f-string URLs). `SABNZBD_QUEUE` fixture in test file has `noofslots: 3` with 1 slot — must create separate empty queue fixture for empty-state tests. `percentage` comes as string from SABnzbd API, needs int conversion.
+    - **Key Changes:** Added `pause_item()`, `resume_item()`, `get_queue_details()` to `src/services/sabnzbd.py`. 10 new tests in `tests/test_services/test_sabnzbd_service.py`.
+    - **Notes:** `get_queue_details()` returns normalized dict ready for handler consumption.
+
+---
+
+### Phase 2: Keyboards + Translations (1 task)
+
+**Goal:** Add keyboard builders for the downloads dashboard and all required translation keys.
+
+- [ ] **2.1** Add downloads dashboard keyboards and translation keys
+    - **Context:**
+        - **Why:** The handler needs keyboard functions for the queue view (with per-item pause/resume buttons, pagination, tab switching) and history view (pagination, tab switching, refresh). Translation keys needed for all user-facing strings.
+        - **Architecture:** Follow existing keyboard patterns in `src/bot/keyboards.py`. Each function returns `InlineKeyboardMarkup`. Pagination follows the `get_queue_items_keyboard` pattern (ceil division, nav_row with Prev/Next). Callback data convention: `dl_` prefix for all downloads dashboard buttons.
+        - **Key refs:** `src/bot/keyboards.py:727-822` (`get_queue_items_keyboard` — closest pagination pattern), `src/bot/keyboards.py:712-724` (`get_queue_empty_keyboard` — empty state pattern), `translations/addarr.en-us.yml` for existing key format
+        - **Watch out:** Callback data has a 64-byte limit in Telegram. `dl_pause_{nzo_id}` must fit — SABnzbd nzo_ids are typically ~20 chars (e.g., `SABnzbd_nzo_abc123`), so total is ~30 bytes, well within limits. Translation keys must be flat top-level (not nested) per `TranslationService.get_text()` limitation.
+    - **Scope:** New keyboard functions + translation keys
+    - **Touches:** `src/bot/keyboards.py`, `translations/addarr.en-us.yml`, `tests/test_bot/test_keyboards.py` (or new test file)
+    - **Action items:**
+        - [RED] Write tests for `get_downloads_queue_keyboard(items, page, paused)` — items with pagination, empty queue, per-item pause/resume buttons based on item status, paused queue shows "Resume All" instead of "Pause All"
+        - [RED] Write tests for `get_downloads_history_keyboard(items, page)` — items with pagination, empty history
+        - [GREEN] Implement both keyboard functions
+        - [GREEN] Add translation keys to `translations/addarr.en-us.yml`: `CommandDownloads`, `DownloadsTitle`, `DownloadsEmpty`, `DownloadsHistoryTitle`, `DownloadsHistoryEmpty`, `DownloadsSpeed`, `DownloadsRemaining`, `DownloadsItems`, `DownloadsPaused`, `DownloadsItemPaused`, `DownloadsItemResumed`, `DownloadsPauseError`, `DownloadsResumeError`, `DownloadsNotEnabled`
+    - **Success:** Keyboard tests pass, translation keys present in en-us file
+
+---
+
+### Phase 3: Handler + Command Registration (1 task)
+
+**Goal:** Wire everything together — `/downloads` command, callback handlers for all interactions, command registration.
+
+- [ ] **3.1** Implement downloads handler and register command
+    - **Context:**
+        - **Why:** This is the user-facing integration: `/downloads` sends the dashboard message, callbacks handle tab switching, pagination, per-item pause/resume, pause/resume all, and refresh.
+        - **Architecture:** Extend `SabnzbdHandler` in `src/bot/handlers/sabnzbd.py`. Add `handle_downloads` command method (with `@require_auth`), and callback methods for each action. Register callbacks with `pattern=r"^dl_"` prefix. Store current view state (tab, page) in `context.user_data`. Register `/downloads` command in `src/bot/commands.py` under the `sabnzbd.enable` conditional.
+        - **Key refs:** `src/bot/handlers/sabnzbd.py:25-34` (`get_handler` — extend with new handlers), `src/bot/handlers/sabnzbd.py:36-73` (`handle_sabnzbd` — command method pattern), `src/bot/handlers/transmission.py` (similar simple handler pattern), `src/bot/commands.py:69-70` (existing sabnzbd command registration)
+        - **Watch out:** Handler pattern regex `^dl_` must not collide with existing `dl_` callbacks from settings handler (`dl_sabnzbd`, `dl_sab_toggle`, etc.). Use more specific patterns: `^dl_tab_`, `^dl_page_`, `^dl_pause_`, `^dl_resume_`, `^dl_refresh$`, `^dl_pauseall$`, `^dl_resumeall$`. The `@require_auth` decorator checks `update.effective_user.id` against `AuthHandler._authenticated_users`. Existing test pattern: patch `SABnzbdService` and `TranslationService` at the import site.
+    - **Scope:** New command handler, 6+ callback handlers, command registration, message formatting
+    - **Touches:** `src/bot/handlers/sabnzbd.py`, `src/bot/commands.py`, `tests/test_handlers/test_sabnzbd_handler.py`
+    - **Action items:**
+        - [RED] Write tests for `handle_downloads` command — shows queue view when service enabled, shows error when disabled, no effective_user returns early
+        - [RED] Write tests for tab switching callbacks — `dl_tab_queue` shows queue, `dl_tab_history` shows history
+        - [RED] Write tests for pagination — `dl_page_0`, `dl_page_1` update the displayed page
+        - [RED] Write tests for per-item pause/resume — `dl_pause_<nzo_id>` calls service, updates message; `dl_resume_<nzo_id>` likewise; error handling
+        - [RED] Write tests for pause/resume all — `dl_pauseall` and `dl_resumeall` call service queue methods
+        - [RED] Write tests for refresh — `dl_refresh` re-fetches and edits message
+        - [RED] Write test for command registration — `build_authenticated_commands()` includes `downloads` when sabnzbd enabled
+        - [GREEN] Implement `handle_downloads` command method with `@require_auth`
+        - [GREEN] Implement callback handlers for each action
+        - [GREEN] Implement message formatting (queue view and history view text builders)
+        - [GREEN] Add `CommandHandler("downloads", self.handle_downloads)` and callback handlers to `get_handler()`
+        - [GREEN] Register `/downloads` in `build_authenticated_commands()` under sabnzbd conditional
+    - **Success:** `python -m pytest tests/test_handlers/test_sabnzbd_handler.py -v` all pass, `python -m pytest --tb=short -q` full suite green, `python -m flake8 .` clean

--- a/docs/issues/issue-101/TASKS.md
+++ b/docs/issues/issue-101/TASKS.md
@@ -78,7 +78,7 @@ Add a `/downloads` command that displays a SABnzbd queue dashboard with active d
 
 **Goal:** Wire everything together — `/downloads` command, callback handlers for all interactions, command registration.
 
-- [ ] **3.1** Implement downloads handler and register command
+- [x] **3.1** Implement downloads handler and register command
     - **Context:**
         - **Why:** This is the user-facing integration: `/downloads` sends the dashboard message, callbacks handle tab switching, pagination, per-item pause/resume, pause/resume all, and refresh.
         - **Architecture:** Extend `SabnzbdHandler` in `src/bot/handlers/sabnzbd.py`. Add `handle_downloads` command method (with `@require_auth`), and callback methods for each action. Register callbacks with `pattern=r"^dl_"` prefix. Store current view state (tab, page) in `context.user_data`. Register `/downloads` command in `src/bot/commands.py` under the `sabnzbd.enable` conditional.
@@ -100,3 +100,7 @@ Add a `/downloads` command that displays a SABnzbd queue dashboard with active d
         - [GREEN] Add `CommandHandler("downloads", self.handle_downloads)` and callback handlers to `get_handler()`
         - [GREEN] Register `/downloads` in `build_authenticated_commands()` under sabnzbd conditional
     - **Success:** `python -m pytest tests/test_handlers/test_sabnzbd_handler.py -v` all pass, `python -m pytest --tb=short -q` full suite green, `python -m flake8 .` clean
+    - **Completed:** 2026-03-06
+    - **Learnings:** Callback pattern `^dl_pause_(?!all)` needed negative lookahead to avoid matching `dl_pauseall`. Existing command count tests had hardcoded numbers that needed updating. Edge case tests for empty queue, paused state, history-tab pagination, and resume failure were needed for 100% coverage.
+    - **Key Changes:** Rewrote `src/bot/handlers/sabnzbd.py` with full `/downloads` command, 7 callback handlers, and text formatters. Added `/downloads` to `src/bot/commands.py`. Updated command count expectations in `tests/test_bot/test_commands.py`. 32 handler tests total (17 new).
+    - **Notes:** Handler uses `context.user_data["dl_tab"]` and `context.user_data["dl_page"]` for state between callbacks. No ConversationHandler needed.

--- a/docs/issues/issue-101/plan.md
+++ b/docs/issues/issue-101/plan.md
@@ -1,0 +1,132 @@
+# Issue #101: SABnzbd Queue Dashboard
+
+## Context
+
+Users have no visibility into SABnzbd download status from Telegram. The API client (`SabnzbdClient`) and service (`SABnzbdService`) already provide `get_queue()`, `get_history()`, `pause_queue()`, `resume_queue()`, and `get_status()`, but no handler exposes this data. The current `/sabnzbd` handler only offers speed limit controls.
+
+## Goal
+
+Add a `/downloads` command that displays a SABnzbd queue dashboard with:
+- Active downloads showing title, progress %, speed, ETA, and queue size
+- Recent download history
+- Per-item pause/resume inline buttons
+- Pagination for large queues
+- Refresh button to update the display
+
+## Design Decisions
+
+### 1. New `/downloads` command (not extending `/sabnzbd`)
+
+**Rationale:** `/sabnzbd` is for speed control (settings-oriented). `/downloads` is for monitoring (dashboard-oriented). Different concerns, different handlers.
+
+### 2. No ConversationHandler needed
+
+The dashboard is a single-message display with inline buttons for actions (refresh, pagination, tab switching, per-item controls). All interactions are callback queries that edit the same message. A `CommandHandler` + `CallbackQueryHandler` pattern (like `TransmissionHandler`) is sufficient.
+
+### 3. Tab-based view: Queue vs History
+
+Two views switchable via inline buttons:
+- **Queue tab** (default): Active/queued downloads with progress, speed, ETA
+- **History tab**: Recently completed downloads with status and size
+
+### 4. Per-item pause/resume
+
+SABnzbd API supports per-item control via:
+- `mode=queue&name=pause&value=<nzo_id>` — pause individual item
+- `mode=queue&name=resume&value=<nzo_id>` — resume individual item
+
+Need to add these methods to both `SabnzbdClient` and `SABnzbdService`.
+
+### 5. Callback data conventions
+
+Following existing patterns (`sabnzbd_speed_`, `queue_page_`, etc.):
+- `dl_tab_queue` / `dl_tab_history` — tab switching
+- `dl_page_{n}` — pagination
+- `dl_pause_{nzo_id}` — pause individual item
+- `dl_resume_{nzo_id}` — resume individual item
+- `dl_pause_all` / `dl_resume_all` — pause/resume entire queue
+- `dl_refresh` — refresh current view
+
+### 6. Queue slot fields (from SABnzbd API)
+
+Queue slots contain: `nzo_id`, `filename`, `status` (Downloading/Queued/Paused), `percentage`, `mb`/`mbleft`, `timeleft`, `avg_age`, `size`.
+
+History slots contain: `nzo_id`, `name`, `status` (Completed/Failed), `size`, `download_time`, `completed_stamps`.
+
+## Target Structure
+
+### Files to modify
+- `src/api/sabnzbd.py` — Add `pause_item()`, `resume_item()` methods
+- `src/services/sabnzbd.py` — Add `pause_item()`, `resume_item()`, `get_queue_details()` methods
+- `src/bot/handlers/sabnzbd.py` — Extend with `/downloads` command and callback handlers
+- `src/bot/keyboards.py` — Add `get_downloads_dashboard_keyboard()`, `get_downloads_history_keyboard()`
+- `src/bot/commands.py` — Register `/downloads` command
+- `translations/addarr.en-us.yml` — Add translation keys
+
+### Files to create
+- `tests/bot/handlers/test_downloads_handler.py` — Handler tests
+- `tests/api/test_sabnzbd_downloads.py` — API client tests for new methods
+- `tests/services/test_sabnzbd_downloads.py` — Service tests for new methods
+- `tests/bot/test_keyboards_downloads.py` — Keyboard builder tests
+
+### No new files in src/
+The feature extends existing modules. No new handler class needed — extend `SabnzbdHandler` with the downloads dashboard functionality.
+
+## Phased Approach
+
+### Phase 1: API + Service Layer (per-item control + queue details)
+Add `pause_item()` and `resume_item()` to API client and service. Add `get_queue_details()` to service that returns normalized queue data with all fields needed for display.
+
+### Phase 2: Keyboard Builders
+Add keyboard functions for the downloads dashboard (queue view, history view, pagination, per-item controls).
+
+### Phase 3: Handler + Command Registration
+Extend `SabnzbdHandler` with `/downloads` command, tab switching, pagination, per-item pause/resume, and refresh callbacks. Register the command in `commands.py`.
+
+### Phase 4: Translations
+Add all user-facing strings as translation keys.
+
+## Message Format (Queue Tab)
+
+```
+📥 SABnzbd Downloads
+
+⚡ Speed: 5.2 MB/s | 📦 Queue: 3 items | 💾 Remaining: 1.2 GB
+
+1. Movie.Name.2024.1080p
+   ▓▓▓▓▓▓▓░░░ 72% | 15m left | ⏸ Pause
+
+2. TV.Show.S03E05
+   ▓▓▓░░░░░░░ 30% | 45m left | ⏸ Pause
+
+3. Another.Movie [Paused]
+   ▓░░░░░░░░░ 12% | — | ▶️ Resume
+
+[◀️ Prev] [1/2] [Next ▶️]
+[📋 Queue ✓] [📜 History]
+[⏸ Pause All] [🔄 Refresh]
+```
+
+## Message Format (History Tab)
+
+```
+📜 SABnzbd History
+
+1. ✅ Movie.Name.2024 — 4.2 GB — 2h 15m
+2. ✅ TV.Show.S03E04 — 1.1 GB — 35m
+3. ❌ Failed.Download — 0 B — Failed
+
+[◀️ Prev] [1/2] [Next ▶️]
+[📋 Queue] [📜 History ✓]
+[🔄 Refresh]
+```
+
+## Verification
+
+1. `python -m pytest tests/api/test_sabnzbd_downloads.py -v` — API client tests pass
+2. `python -m pytest tests/services/test_sabnzbd_downloads.py -v` — Service tests pass
+3. `python -m pytest tests/bot/handlers/test_downloads_handler.py -v` — Handler tests pass
+4. `python -m pytest tests/bot/test_keyboards_downloads.py -v` — Keyboard tests pass
+5. `python -m pytest --tb=short -q` — Full suite green
+6. `python -m flake8 .` — No lint errors
+7. `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` — Translations valid

--- a/src/api/sabnzbd.py
+++ b/src/api/sabnzbd.py
@@ -117,6 +117,28 @@ class SabnzbdClient:
             logger.error(f"Error resuming SABnzbd queue: {e}")
             return False
 
+    async def pause_item(self, nzo_id: str) -> bool:
+        """Pause an individual queue item"""
+        try:
+            async with aiohttp.ClientSession() as session:
+                url = f"{self.api_url}/api?mode=queue&name=pause&value={nzo_id}&output=json&apikey={self.api_key}"
+                async with session.get(url) as response:
+                    return response.status == 200
+        except Exception as e:
+            logger.error(f"Error pausing SABnzbd item {nzo_id}: {e}")
+            return False
+
+    async def resume_item(self, nzo_id: str) -> bool:
+        """Resume an individual queue item"""
+        try:
+            async with aiohttp.ClientSession() as session:
+                url = f"{self.api_url}/api?mode=queue&name=resume&value={nzo_id}&output=json&apikey={self.api_key}"
+                async with session.get(url) as response:
+                    return response.status == 200
+        except Exception as e:
+            logger.error(f"Error resuming SABnzbd item {nzo_id}: {e}")
+            return False
+
     async def get_history(self, limit: int = 10) -> dict:
         """Get SABnzbd download history"""
         try:

--- a/src/api/sabnzbd.py
+++ b/src/api/sabnzbd.py
@@ -7,6 +7,7 @@ Description: SABnzbd API client module.
 
 import aiohttp
 from colorama import Fore
+from urllib.parse import quote
 
 from src.config.settings import config
 from src.utils.logger import get_logger
@@ -121,7 +122,7 @@ class SabnzbdClient:
         """Pause an individual queue item"""
         try:
             async with aiohttp.ClientSession() as session:
-                url = f"{self.api_url}/api?mode=queue&name=pause&value={nzo_id}&output=json&apikey={self.api_key}"
+                url = f"{self.api_url}/api?mode=queue&name=pause&value={quote(nzo_id, safe='')}&output=json&apikey={self.api_key}"
                 async with session.get(url) as response:
                     return response.status == 200
         except Exception as e:
@@ -132,7 +133,7 @@ class SabnzbdClient:
         """Resume an individual queue item"""
         try:
             async with aiohttp.ClientSession() as session:
-                url = f"{self.api_url}/api?mode=queue&name=resume&value={nzo_id}&output=json&apikey={self.api_key}"
+                url = f"{self.api_url}/api?mode=queue&name=resume&value={quote(nzo_id, safe='')}&output=json&apikey={self.api_key}"
                 async with session.get(url) as response:
                     return response.status == 200
         except Exception as e:

--- a/src/bot/commands.py
+++ b/src/bot/commands.py
@@ -68,6 +68,7 @@ def build_authenticated_commands() -> list:
 
     if config.get("sabnzbd", {}).get("enable", False):
         commands.append(BotCommand("sabnzbd", translation.get_text("CommandSabnzbd")))
+        commands.append(BotCommand("downloads", translation.get_text("CommandDownloads")))
 
     return commands
 

--- a/src/bot/handlers/sabnzbd.py
+++ b/src/bot/handlers/sabnzbd.py
@@ -43,6 +43,7 @@ class SabnzbdHandler:
             CallbackQueryHandler(self.handle_downloads_pauseall, pattern=r"^dl_pauseall$"),
             CallbackQueryHandler(self.handle_downloads_resumeall, pattern=r"^dl_resumeall$"),
             CallbackQueryHandler(self.handle_downloads_refresh, pattern=r"^dl_refresh$"),
+            CallbackQueryHandler(self.handle_downloads_noop, pattern=r"^dl_noop$"),
         ]
 
     @require_auth
@@ -145,48 +146,19 @@ class SabnzbdHandler:
         query = update.callback_query
         await query.answer()
 
-        tab = query.data.replace("dl_tab_", "")
-        context.user_data["dl_tab"] = tab
+        context.user_data["dl_tab"] = query.data.replace("dl_tab_", "")
         context.user_data["dl_page"] = 0
 
-        if tab == "history":
-            history = await self.sabnzbd_service.get_history()
-            text = self._format_history_text(history)
-            keyboard = get_downloads_history_keyboard(
-                history["items"], page=0
-            )
-        else:
-            queue = await self.sabnzbd_service.get_queue_details()
-            text = self._format_queue_text(queue)
-            keyboard = get_downloads_queue_keyboard(
-                queue["items"], page=0, paused=queue["paused"]
-            )
-
-        await query.message.edit_text(text, reply_markup=keyboard)
+        await self._refresh_current_view(query, context)
 
     async def handle_downloads_page(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Handle pagination."""
         query = update.callback_query
         await query.answer()
 
-        page = int(query.data.replace("dl_page_", ""))
-        context.user_data["dl_page"] = page
-        tab = context.user_data.get("dl_tab", "queue")
+        context.user_data["dl_page"] = int(query.data.replace("dl_page_", ""))
 
-        if tab == "history":
-            history = await self.sabnzbd_service.get_history()
-            text = self._format_history_text(history)
-            keyboard = get_downloads_history_keyboard(
-                history["items"], page=page
-            )
-        else:
-            queue = await self.sabnzbd_service.get_queue_details()
-            text = self._format_queue_text(queue)
-            keyboard = get_downloads_queue_keyboard(
-                queue["items"], page=page, paused=queue["paused"]
-            )
-
-        await query.message.edit_text(text, reply_markup=keyboard)
+        await self._refresh_current_view(query, context)
 
     async def handle_downloads_pause_item(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Handle per-item pause."""
@@ -246,6 +218,10 @@ class SabnzbdHandler:
         await query.answer()
 
         await self._refresh_current_view(query, context)
+
+    async def handle_downloads_noop(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle display-only button presses (dismiss loading spinner)."""
+        await update.callback_query.answer()
 
     # -----------------------------------------------------------------
     # Private helpers

--- a/src/bot/handlers/sabnzbd.py
+++ b/src/bot/handlers/sabnzbd.py
@@ -10,6 +10,10 @@ from telegram.ext import CommandHandler, ContextTypes, CallbackQueryHandler
 from src.utils.logger import get_logger, log_user_interaction
 from src.services.sabnzbd import SABnzbdService
 from src.bot.handlers.auth import require_auth
+from src.bot.keyboards import (
+    get_downloads_queue_keyboard,
+    get_downloads_history_keyboard,
+)
 from src.services.translation import TranslationService
 
 logger = get_logger("addarr.handlers.sabnzbd")
@@ -30,7 +34,15 @@ class SabnzbdHandler:
 
         return [
             CommandHandler("sabnzbd", self.handle_sabnzbd),
-            CallbackQueryHandler(self.handle_speed_selection, pattern="^sabnzbd_speed_")
+            CallbackQueryHandler(self.handle_speed_selection, pattern="^sabnzbd_speed_"),
+            CommandHandler("downloads", self.handle_downloads),
+            CallbackQueryHandler(self.handle_downloads_tab, pattern=r"^dl_tab_"),
+            CallbackQueryHandler(self.handle_downloads_page, pattern=r"^dl_page_"),
+            CallbackQueryHandler(self.handle_downloads_pause_item, pattern=r"^dl_pause_(?!all)"),
+            CallbackQueryHandler(self.handle_downloads_resume_item, pattern=r"^dl_resume_(?!all)"),
+            CallbackQueryHandler(self.handle_downloads_pauseall, pattern=r"^dl_pauseall$"),
+            CallbackQueryHandler(self.handle_downloads_resumeall, pattern=r"^dl_resumeall$"),
+            CallbackQueryHandler(self.handle_downloads_refresh, pattern=r"^dl_refresh$"),
         ]
 
     @require_auth
@@ -96,3 +108,214 @@ class SabnzbdHandler:
             await query.message.edit_text(
                 self.translation.get_text("Sabnzbd.Error")
             )
+
+    # -----------------------------------------------------------------
+    # /downloads dashboard
+    # -----------------------------------------------------------------
+
+    @require_auth
+    async def handle_downloads(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle /downloads command — show SABnzbd queue dashboard."""
+        if not update.effective_user:  # pragma: no cover
+            return
+
+        log_user_interaction(logger, update.effective_user, "/downloads")
+
+        if not self.sabnzbd_service.is_enabled():
+            await update.message.reply_text(
+                self.translation.get_text("DownloadsNotEnabled")
+            )
+            return
+
+        context.user_data["dl_tab"] = "queue"
+        context.user_data["dl_page"] = 0
+
+        queue = await self.sabnzbd_service.get_queue_details()
+        text = self._format_queue_text(queue)
+        keyboard = get_downloads_queue_keyboard(
+            queue["items"], page=0, paused=queue["paused"]
+        )
+
+        await update.message.reply_text(
+            text, reply_markup=keyboard
+        )
+
+    async def handle_downloads_tab(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle tab switching between queue and history."""
+        query = update.callback_query
+        await query.answer()
+
+        tab = query.data.replace("dl_tab_", "")
+        context.user_data["dl_tab"] = tab
+        context.user_data["dl_page"] = 0
+
+        if tab == "history":
+            history = await self.sabnzbd_service.get_history()
+            text = self._format_history_text(history)
+            keyboard = get_downloads_history_keyboard(
+                history["items"], page=0
+            )
+        else:
+            queue = await self.sabnzbd_service.get_queue_details()
+            text = self._format_queue_text(queue)
+            keyboard = get_downloads_queue_keyboard(
+                queue["items"], page=0, paused=queue["paused"]
+            )
+
+        await query.message.edit_text(text, reply_markup=keyboard)
+
+    async def handle_downloads_page(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle pagination."""
+        query = update.callback_query
+        await query.answer()
+
+        page = int(query.data.replace("dl_page_", ""))
+        context.user_data["dl_page"] = page
+        tab = context.user_data.get("dl_tab", "queue")
+
+        if tab == "history":
+            history = await self.sabnzbd_service.get_history()
+            text = self._format_history_text(history)
+            keyboard = get_downloads_history_keyboard(
+                history["items"], page=page
+            )
+        else:
+            queue = await self.sabnzbd_service.get_queue_details()
+            text = self._format_queue_text(queue)
+            keyboard = get_downloads_queue_keyboard(
+                queue["items"], page=page, paused=queue["paused"]
+            )
+
+        await query.message.edit_text(text, reply_markup=keyboard)
+
+    async def handle_downloads_pause_item(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle per-item pause."""
+        query = update.callback_query
+        nzo_id = query.data.replace("dl_pause_", "")
+
+        success = await self.sabnzbd_service.pause_item(nzo_id)
+        if success:
+            await query.answer(
+                text=self.translation.get_text("DownloadsItemPaused")
+            )
+            await self._refresh_current_view(query, context)
+        else:
+            await query.answer(
+                text=self.translation.get_text("DownloadsPauseError"),
+                show_alert=True,
+            )
+
+    async def handle_downloads_resume_item(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle per-item resume."""
+        query = update.callback_query
+        nzo_id = query.data.replace("dl_resume_", "")
+
+        success = await self.sabnzbd_service.resume_item(nzo_id)
+        if success:
+            await query.answer(
+                text=self.translation.get_text("DownloadsItemResumed")
+            )
+            await self._refresh_current_view(query, context)
+        else:
+            await query.answer(
+                text=self.translation.get_text("DownloadsResumeError"),
+                show_alert=True,
+            )
+
+    async def handle_downloads_pauseall(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle pause all."""
+        query = update.callback_query
+        await self.sabnzbd_service.pause_queue()
+        await query.answer(
+            text=self.translation.get_text("DownloadsPaused")
+        )
+        await self._refresh_current_view(query, context)
+
+    async def handle_downloads_resumeall(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle resume all."""
+        query = update.callback_query
+        await self.sabnzbd_service.resume_queue()
+        await query.answer(
+            text=self.translation.get_text("DownloadsItemResumed")
+        )
+        await self._refresh_current_view(query, context)
+
+    async def handle_downloads_refresh(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle refresh button."""
+        query = update.callback_query
+        await query.answer()
+
+        await self._refresh_current_view(query, context)
+
+    # -----------------------------------------------------------------
+    # Private helpers
+    # -----------------------------------------------------------------
+
+    async def _refresh_current_view(self, query, context):
+        """Re-fetch data and edit the message for the current tab/page."""
+        tab = context.user_data.get("dl_tab", "queue")
+        page = context.user_data.get("dl_page", 0)
+
+        if tab == "history":
+            history = await self.sabnzbd_service.get_history()
+            text = self._format_history_text(history)
+            keyboard = get_downloads_history_keyboard(
+                history["items"], page=page
+            )
+        else:
+            queue = await self.sabnzbd_service.get_queue_details()
+            text = self._format_queue_text(queue)
+            keyboard = get_downloads_queue_keyboard(
+                queue["items"], page=page, paused=queue["paused"]
+            )
+
+        await query.message.edit_text(text, reply_markup=keyboard)
+
+    def _format_queue_text(self, queue):
+        """Format queue data into display text."""
+        t = self.translation.get_text
+        title = t("DownloadsTitle")
+        speed = queue.get("speed", "0 KB/s")
+        size = queue.get("size_remaining", "0 MB")
+        count = queue.get("items_count", 0)
+
+        lines = [f"\U0001f4e5 {title}\n"]
+
+        if count == 0:
+            lines.append(t("DownloadsEmpty"))
+        else:
+            lines.append(
+                f"\u26a1 {t('DownloadsSpeed')}: {speed} | "
+                f"\U0001f4e6 {t('DownloadsItems')}: {count} | "
+                f"\U0001f4be {t('DownloadsRemaining')}: {size}"
+            )
+            if queue.get("paused"):
+                lines.append(f"\u23f8 {t('DownloadsPaused')}")
+
+        return "\n".join(lines)
+
+    def _format_history_text(self, history):
+        """Format history data into display text."""
+        t = self.translation.get_text
+        title = t("DownloadsHistoryTitle")
+        lines = [f"\U0001f4dc {title}\n"]
+
+        items = history.get("items", [])
+        if not items:
+            lines.append(t("DownloadsHistoryEmpty"))
+        else:
+            for i, item in enumerate(items[:10], 1):
+                name = item.get("name", "")
+                status = item.get("status", "")
+                size = item.get("size", "")
+                icon = "\u2705" if status == "Completed" else "\u274c"
+                dl_time = item.get("download_time", 0)
+                if dl_time > 0:
+                    hours = dl_time // 3600
+                    minutes = (dl_time % 3600) // 60
+                    time_str = f"{hours}h {minutes}m" if hours else f"{minutes}m"
+                    lines.append(f"{i}. {icon} {name} \u2014 {size} \u2014 {time_str}")
+                else:
+                    lines.append(f"{i}. {icon} {name} \u2014 {size}")
+
+        return "\n".join(lines)

--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -839,6 +839,179 @@ def _build_queue_filter_row(active_filter, translation):
     return row
 
 
+def get_downloads_queue_keyboard(
+    items: list, page: int, paused: bool = False, page_size: int = 5,
+) -> InlineKeyboardMarkup:
+    """Get keyboard for SABnzbd downloads queue view.
+
+    Args:
+        items: List of queue item dicts with nzo_id, title, status, progress.
+        page: Current page (0-indexed).
+        paused: Whether the entire queue is paused.
+        page_size: Number of items per page.
+    """
+    keyboard = []
+
+    total_pages = max(1, -(-len(items) // page_size))
+    start = page * page_size
+    end = start + page_size
+    page_items = items[start:end]
+
+    for item in page_items:
+        nzo_id = item.get("nzo_id", "")
+        title = item.get("title", "")
+        status = item.get("status", "")
+        progress = item.get("progress", 0)
+
+        status_icon = "\u2b07\ufe0f" if status == "Downloading" else (
+            "\u23f8" if status == "Paused" else "\u23f3"
+        )
+        label = f"{status_icon} {title} — {progress}%"
+        keyboard.append([
+            InlineKeyboardButton(label, callback_data="dl_noop")
+        ])
+
+        if status == "Paused":
+            keyboard.append([
+                InlineKeyboardButton(
+                    "\u25b6\ufe0f Resume",
+                    callback_data=f"dl_resume_{nzo_id}"
+                )
+            ])
+        else:
+            keyboard.append([
+                InlineKeyboardButton(
+                    "\u23f8 Pause",
+                    callback_data=f"dl_pause_{nzo_id}"
+                )
+            ])
+
+    # Pagination row
+    if total_pages > 1:
+        nav_row = []
+        if page > 0:
+            nav_row.append(
+                InlineKeyboardButton(
+                    "\u25c0\ufe0f Prev", callback_data=f"dl_page_{page - 1}"
+                )
+            )
+        nav_row.append(
+            InlineKeyboardButton(
+                f"{page + 1}/{total_pages}", callback_data="dl_noop"
+            )
+        )
+        if page < total_pages - 1:
+            nav_row.append(
+                InlineKeyboardButton(
+                    "Next \u25b6\ufe0f", callback_data=f"dl_page_{page + 1}"
+                )
+            )
+        keyboard.append(nav_row)
+
+    # Tab row
+    keyboard.append([
+        InlineKeyboardButton(
+            "\u2713 \U0001f4cb Queue", callback_data="dl_tab_queue"
+        ),
+        InlineKeyboardButton(
+            "\U0001f4dc History", callback_data="dl_tab_history"
+        ),
+    ])
+
+    # Action row
+    action_row = []
+    if paused:
+        action_row.append(
+            InlineKeyboardButton(
+                "\u25b6\ufe0f Resume All", callback_data="dl_resumeall"
+            )
+        )
+    else:
+        action_row.append(
+            InlineKeyboardButton(
+                "\u23f8 Pause All", callback_data="dl_pauseall"
+            )
+        )
+    action_row.append(
+        InlineKeyboardButton(
+            "\U0001f504 Refresh", callback_data="dl_refresh"
+        )
+    )
+    keyboard.append(action_row)
+
+    return InlineKeyboardMarkup(keyboard)
+
+
+def get_downloads_history_keyboard(
+    items: list, page: int, page_size: int = 5,
+) -> InlineKeyboardMarkup:
+    """Get keyboard for SABnzbd downloads history view.
+
+    Args:
+        items: List of history item dicts with name, status, size.
+        page: Current page (0-indexed).
+        page_size: Number of items per page.
+    """
+    keyboard = []
+
+    total_pages = max(1, -(-len(items) // page_size))
+    start = page * page_size
+    end = start + page_size
+    page_items = items[start:end]
+
+    for item in page_items:
+        name = item.get("name", "")
+        status = item.get("status", "")
+        size = item.get("size", "")
+
+        icon = "\u2705" if status == "Completed" else "\u274c"
+        label = f"{icon} {name} \u2014 {size}"
+        keyboard.append([
+            InlineKeyboardButton(label, callback_data="dl_noop")
+        ])
+
+    # Pagination row
+    if total_pages > 1:
+        nav_row = []
+        if page > 0:
+            nav_row.append(
+                InlineKeyboardButton(
+                    "\u25c0\ufe0f Prev", callback_data=f"dl_page_{page - 1}"
+                )
+            )
+        nav_row.append(
+            InlineKeyboardButton(
+                f"{page + 1}/{total_pages}", callback_data="dl_noop"
+            )
+        )
+        if page < total_pages - 1:
+            nav_row.append(
+                InlineKeyboardButton(
+                    "Next \u25b6\ufe0f", callback_data=f"dl_page_{page + 1}"
+                )
+            )
+        keyboard.append(nav_row)
+
+    # Tab row
+    keyboard.append([
+        InlineKeyboardButton(
+            "\U0001f4cb Queue", callback_data="dl_tab_queue"
+        ),
+        InlineKeyboardButton(
+            "\u2713 \U0001f4dc History", callback_data="dl_tab_history"
+        ),
+    ])
+
+    # Action row (refresh only — no pause/resume in history)
+    keyboard.append([
+        InlineKeyboardButton(
+            "\U0001f504 Refresh", callback_data="dl_refresh"
+        ),
+    ])
+
+    return InlineKeyboardMarkup(keyboard)
+
+
 def get_yes_no_keyboard(callback_prefix: str, yes_text: str = "Yes", no_text: str = "No") -> InlineKeyboardMarkup:
     """Create a Yes/No inline keyboard
 

--- a/src/services/sabnzbd.py
+++ b/src/services/sabnzbd.py
@@ -195,6 +195,108 @@ class SABnzbdService:
             logger.error(f"Error resuming SABnzbd queue: {e}")
             return False
 
+    async def pause_item(self, nzo_id: str) -> bool:
+        """Pause an individual queue item"""
+        try:
+            params = {
+                'mode': 'queue',
+                'name': 'pause',
+                'value': nzo_id,
+                'output': 'json',
+                'apikey': self.api_key
+            }
+
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{self.base_url}/api", params=params) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        return data.get('status', False)
+                    else:
+                        logger.error(f"SABnzbd API returned status {response.status}")
+                        return False
+
+        except Exception as e:
+            logger.error(f"Error pausing SABnzbd item {nzo_id}: {e}")
+            return False
+
+    async def resume_item(self, nzo_id: str) -> bool:
+        """Resume an individual queue item"""
+        try:
+            params = {
+                'mode': 'queue',
+                'name': 'resume',
+                'value': nzo_id,
+                'output': 'json',
+                'apikey': self.api_key
+            }
+
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{self.base_url}/api", params=params) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        return data.get('status', False)
+                    else:
+                        logger.error(f"SABnzbd API returned status {response.status}")
+                        return False
+
+        except Exception as e:
+            logger.error(f"Error resuming SABnzbd item {nzo_id}: {e}")
+            return False
+
+    async def get_queue_details(self) -> Dict[str, Any]:
+        """Get detailed SABnzbd queue data for dashboard display"""
+        empty = {
+            'paused': False,
+            'speed': '0 KB/s',
+            'size_remaining': '0 MB',
+            'items_count': 0,
+            'items': []
+        }
+        try:
+            params = {
+                'mode': 'queue',
+                'output': 'json',
+                'apikey': self.api_key
+            }
+
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{self.base_url}/api", params=params) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        queue = data.get('queue', {})
+
+                        items = []
+                        for slot in queue.get('slots', []):
+                            percentage = slot.get('percentage', '0')
+                            try:
+                                progress = int(percentage)
+                            except (ValueError, TypeError):
+                                progress = 0
+
+                            items.append({
+                                'nzo_id': slot.get('nzo_id', ''),
+                                'title': slot.get('filename', ''),
+                                'status': slot.get('status', ''),
+                                'progress': progress,
+                                'size': slot.get('size', ''),
+                                'timeleft': slot.get('timeleft', ''),
+                            })
+
+                        return {
+                            'paused': bool(queue.get('paused', False)),
+                            'speed': queue.get('speed', '0 KB/s'),
+                            'size_remaining': queue.get('size', '0 MB'),
+                            'items_count': int(queue.get('noofslots', 0)),
+                            'items': items,
+                        }
+                    else:
+                        logger.error(f"SABnzbd API returned status {response.status}")
+                        return empty
+
+        except Exception as e:
+            logger.error(f"Error getting SABnzbd queue details: {e}")
+            return empty
+
     async def get_history(self, limit: int = 10) -> Dict[str, Any]:
         """Get SABnzbd download history"""
         try:

--- a/tests/test_api/test_sabnzbd_api.py
+++ b/tests/test_api/test_sabnzbd_api.py
@@ -248,3 +248,59 @@ class TestSabnzbdGetHistory:
         aio_mock.get(url, exception=aiohttp.ClientError("connection refused"))
         result = await sabnzbd_client.get_history()
         assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# pause_item
+# ---------------------------------------------------------------------------
+
+
+class TestSabnzbdPauseItem:
+    @pytest.mark.asyncio
+    async def test_pause_item_success(self, aio_mock, sabnzbd_client, sabnzbd_url):
+        url = f"{sabnzbd_url}/api?mode=queue&name=pause&value=SABnzbd_nzo_abc123&output=json&apikey=test-sabnzbd-key"
+        aio_mock.get(url, payload={"status": True}, status=200)
+        result = await sabnzbd_client.pause_item("SABnzbd_nzo_abc123")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_pause_item_http_error(self, aio_mock, sabnzbd_client, sabnzbd_url):
+        url = f"{sabnzbd_url}/api?mode=queue&name=pause&value=SABnzbd_nzo_abc123&output=json&apikey=test-sabnzbd-key"
+        aio_mock.get(url, status=500)
+        result = await sabnzbd_client.pause_item("SABnzbd_nzo_abc123")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_pause_item_connection_error(self, aio_mock, sabnzbd_client, sabnzbd_url):
+        url = f"{sabnzbd_url}/api?mode=queue&name=pause&value=SABnzbd_nzo_abc123&output=json&apikey=test-sabnzbd-key"
+        aio_mock.get(url, exception=aiohttp.ClientError("connection refused"))
+        result = await sabnzbd_client.pause_item("SABnzbd_nzo_abc123")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# resume_item
+# ---------------------------------------------------------------------------
+
+
+class TestSabnzbdResumeItem:
+    @pytest.mark.asyncio
+    async def test_resume_item_success(self, aio_mock, sabnzbd_client, sabnzbd_url):
+        url = f"{sabnzbd_url}/api?mode=queue&name=resume&value=SABnzbd_nzo_abc123&output=json&apikey=test-sabnzbd-key"
+        aio_mock.get(url, payload={"status": True}, status=200)
+        result = await sabnzbd_client.resume_item("SABnzbd_nzo_abc123")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_resume_item_http_error(self, aio_mock, sabnzbd_client, sabnzbd_url):
+        url = f"{sabnzbd_url}/api?mode=queue&name=resume&value=SABnzbd_nzo_abc123&output=json&apikey=test-sabnzbd-key"
+        aio_mock.get(url, status=500)
+        result = await sabnzbd_client.resume_item("SABnzbd_nzo_abc123")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_resume_item_connection_error(self, aio_mock, sabnzbd_client, sabnzbd_url):
+        url = f"{sabnzbd_url}/api?mode=queue&name=resume&value=SABnzbd_nzo_abc123&output=json&apikey=test-sabnzbd-key"
+        aio_mock.get(url, exception=aiohttp.ClientError("connection refused"))
+        result = await sabnzbd_client.resume_item("SABnzbd_nzo_abc123")
+        assert result is False

--- a/tests/test_bot/test_commands.py
+++ b/tests/test_bot/test_commands.py
@@ -145,7 +145,8 @@ class TestBuildAuthenticatedCommands:
 
         names = [c.command for c in commands]
         assert "sabnzbd" in names
-        assert len(commands) == 8  # 7 base + 1
+        assert "downloads" in names
+        assert len(commands) == 9  # 7 base + sabnzbd + downloads
 
     def test_radarr_adds_upcoming_and_missing(self, mock_config):
         """Radarr enabled adds upcoming and missing commands."""
@@ -198,13 +199,14 @@ class TestBuildAuthenticatedCommands:
             from src.bot.commands import build_authenticated_commands
             commands = build_authenticated_commands()
 
-        assert len(commands) == 18
+        assert len(commands) == 19
         names = [c.command for c in commands]
         expected = [
             "start", "auth", "help", "status", "settings",
             "preferences", "delete", "movie", "allmovies",
             "series", "allseries", "music", "allmusic",
-            "upcoming", "missing", "queue", "transmission", "sabnzbd",
+            "upcoming", "missing", "queue", "transmission",
+            "sabnzbd", "downloads",
         ]
         assert names == expected
 

--- a/tests/test_bot/test_keyboards.py
+++ b/tests/test_bot/test_keyboards.py
@@ -6,6 +6,8 @@ from telegram import InlineKeyboardMarkup
 
 from src.bot.keyboards import (
     get_confirmation_keyboard,
+    get_downloads_history_keyboard,
+    get_downloads_queue_keyboard,
     get_main_menu_keyboard,
     get_settings_keyboard,
     get_system_keyboard,
@@ -1640,3 +1642,211 @@ class TestQueueItemsKeyboard:
         ]
         assert "queue_refresh" in callbacks
         assert "queue_back" in callbacks
+
+
+# ---------------------------------------------------------------------------
+# Downloads Queue Keyboard
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadsQueueKeyboard:
+    SAMPLE_ITEMS = [
+        {
+            "nzo_id": "nzo_abc",
+            "title": "Movie.2024.1080p",
+            "status": "Downloading",
+            "progress": 72,
+            "size": "4.2 GB",
+            "timeleft": "0:15:30",
+        },
+        {
+            "nzo_id": "nzo_def",
+            "title": "TV.Show.S03E05",
+            "status": "Queued",
+            "progress": 0,
+            "size": "1.1 GB",
+            "timeleft": "0:45:00",
+        },
+        {
+            "nzo_id": "nzo_ghi",
+            "title": "Another.Movie",
+            "status": "Paused",
+            "progress": 12,
+            "size": "3.5 GB",
+            "timeleft": "",
+        },
+    ]
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_returns_markup(self, mock_ts):
+        _mock_translation(mock_ts)
+        result = get_downloads_queue_keyboard(self.SAMPLE_ITEMS, page=0)
+        assert isinstance(result, InlineKeyboardMarkup)
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_tab_buttons(self, mock_ts):
+        _mock_translation(mock_ts)
+        result = get_downloads_queue_keyboard(self.SAMPLE_ITEMS, page=0)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_tab_queue" in callbacks
+        assert "dl_tab_history" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_per_item_pause_resume_buttons(self, mock_ts):
+        """Downloading/Queued items get pause button, Paused gets resume."""
+        _mock_translation(mock_ts)
+        result = get_downloads_queue_keyboard(self.SAMPLE_ITEMS, page=0)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_pause_nzo_abc" in callbacks
+        assert "dl_pause_nzo_def" in callbacks
+        assert "dl_resume_nzo_ghi" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_pause_all_when_not_paused(self, mock_ts):
+        _mock_translation(mock_ts)
+        result = get_downloads_queue_keyboard(
+            self.SAMPLE_ITEMS, page=0, paused=False
+        )
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_pauseall" in callbacks
+        assert "dl_resumeall" not in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_resume_all_when_paused(self, mock_ts):
+        _mock_translation(mock_ts)
+        result = get_downloads_queue_keyboard(
+            self.SAMPLE_ITEMS, page=0, paused=True
+        )
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_resumeall" in callbacks
+        assert "dl_pauseall" not in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_refresh_button(self, mock_ts):
+        _mock_translation(mock_ts)
+        result = get_downloads_queue_keyboard(self.SAMPLE_ITEMS, page=0)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_refresh" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_pagination_on_second_page(self, mock_ts):
+        _mock_translation(mock_ts)
+        # Create 8 items to force 2 pages (page_size=5)
+        items = self.SAMPLE_ITEMS * 3  # 9 items
+        result = get_downloads_queue_keyboard(items, page=1)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_page_0" in callbacks  # Prev button
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_empty_queue_has_tabs_and_refresh(self, mock_ts):
+        _mock_translation(mock_ts)
+        result = get_downloads_queue_keyboard([], page=0)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_tab_queue" in callbacks
+        assert "dl_tab_history" in callbacks
+        assert "dl_refresh" in callbacks
+
+
+# ---------------------------------------------------------------------------
+# Downloads History Keyboard
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadsHistoryKeyboard:
+    SAMPLE_ITEMS = [
+        {
+            "name": "Movie.2024",
+            "status": "Completed",
+            "size": "4.2 GB",
+            "download_time": 8100,
+        },
+        {
+            "name": "Failed.Download",
+            "status": "Failed",
+            "size": "0 B",
+            "download_time": 0,
+        },
+    ]
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_returns_markup(self, mock_ts):
+        _mock_translation(mock_ts)
+        result = get_downloads_history_keyboard(self.SAMPLE_ITEMS, page=0)
+        assert isinstance(result, InlineKeyboardMarkup)
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_tab_buttons(self, mock_ts):
+        _mock_translation(mock_ts)
+        result = get_downloads_history_keyboard(self.SAMPLE_ITEMS, page=0)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_tab_queue" in callbacks
+        assert "dl_tab_history" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_refresh_button(self, mock_ts):
+        _mock_translation(mock_ts)
+        result = get_downloads_history_keyboard(self.SAMPLE_ITEMS, page=0)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_refresh" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_no_pause_resume_buttons(self, mock_ts):
+        """History view should not have any pause/resume buttons."""
+        _mock_translation(mock_ts)
+        result = get_downloads_history_keyboard(self.SAMPLE_ITEMS, page=0)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert not any(cb.startswith("dl_pause") for cb in callbacks)
+        assert not any(cb.startswith("dl_resume") for cb in callbacks)
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_empty_history_has_tabs_and_refresh(self, mock_ts):
+        _mock_translation(mock_ts)
+        result = get_downloads_history_keyboard([], page=0)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_tab_queue" in callbacks
+        assert "dl_tab_history" in callbacks
+        assert "dl_refresh" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_pagination(self, mock_ts):
+        _mock_translation(mock_ts)
+        items = self.SAMPLE_ITEMS * 4  # 8 items
+        result = get_downloads_history_keyboard(items, page=0)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_page_1" in callbacks  # Next button

--- a/tests/test_bot/test_keyboards.py
+++ b/tests/test_bot/test_keyboards.py
@@ -1756,6 +1756,17 @@ class TestDownloadsQueueKeyboard:
         assert "dl_page_0" in callbacks  # Prev button
 
     @patch("src.bot.keyboards.TranslationService")
+    def test_pagination_first_page_has_next(self, mock_ts):
+        _mock_translation(mock_ts)
+        items = self.SAMPLE_ITEMS * 3  # 9 items → 2 pages
+        result = get_downloads_queue_keyboard(items, page=0)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_page_1" in callbacks  # Next button
+
+    @patch("src.bot.keyboards.TranslationService")
     def test_empty_queue_has_tabs_and_refresh(self, mock_ts):
         _mock_translation(mock_ts)
         result = get_downloads_queue_keyboard([], page=0)
@@ -1841,7 +1852,7 @@ class TestDownloadsHistoryKeyboard:
         assert "dl_refresh" in callbacks
 
     @patch("src.bot.keyboards.TranslationService")
-    def test_pagination(self, mock_ts):
+    def test_pagination_first_page_has_next(self, mock_ts):
         _mock_translation(mock_ts)
         items = self.SAMPLE_ITEMS * 4  # 8 items
         result = get_downloads_history_keyboard(items, page=0)
@@ -1850,3 +1861,14 @@ class TestDownloadsHistoryKeyboard:
             for row in result.inline_keyboard for btn in row
         ]
         assert "dl_page_1" in callbacks  # Next button
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_pagination_second_page_has_prev(self, mock_ts):
+        _mock_translation(mock_ts)
+        items = self.SAMPLE_ITEMS * 4  # 8 items → 2 pages
+        result = get_downloads_history_keyboard(items, page=1)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "dl_page_0" in callbacks  # Prev button

--- a/tests/test_handlers/test_sabnzbd_handler.py
+++ b/tests/test_handlers/test_sabnzbd_handler.py
@@ -829,3 +829,22 @@ async def test_resume_item_failure(
 
     answer_call = update.callback_query.answer.call_args
     assert answer_call[1].get("show_alert") is True
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_noop_handler_answers_query(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_noop handler dismisses loading spinner without side effects."""
+    handler, _, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_noop")
+    context = make_context()
+
+    await handler.handle_downloads_noop(update, context)
+
+    update.callback_query.answer.assert_called_once()

--- a/tests/test_handlers/test_sabnzbd_handler.py
+++ b/tests/test_handlers/test_sabnzbd_handler.py
@@ -229,3 +229,603 @@ def test_get_handler_returns_list(mock_sab_class, mock_ts_class):
 
     assert isinstance(handlers, list)
     assert len(handlers) > 0
+
+
+# ---------------------------------------------------------------------------
+# handle_downloads — /downloads command
+# ---------------------------------------------------------------------------
+
+
+def _make_handler_with_mocks(mock_sab_class, mock_ts_class, enabled=True):
+    """Helper to create a SabnzbdHandler with properly configured mocks."""
+    mock_sab = MagicMock()
+    mock_sab.is_enabled.return_value = enabled
+    mock_sab.get_queue_details = AsyncMock(return_value={
+        'paused': False,
+        'speed': '5.2 MB/s',
+        'size_remaining': '1.2 GB',
+        'items_count': 2,
+        'items': [
+            {
+                'nzo_id': 'nzo_abc',
+                'title': 'Movie.2024.1080p',
+                'status': 'Downloading',
+                'progress': 72,
+                'size': '4.2 GB',
+                'timeleft': '0:15:30',
+            },
+            {
+                'nzo_id': 'nzo_def',
+                'title': 'TV.Show.S03E05',
+                'status': 'Queued',
+                'progress': 0,
+                'size': '1.1 GB',
+                'timeleft': '0:45:00',
+            },
+        ],
+    })
+    mock_sab.get_history = AsyncMock(return_value={
+        'total': 1,
+        'items': [
+            {
+                'name': 'Completed.Movie',
+                'status': 'Completed',
+                'size': '4.2 GB',
+                'download_time': 8100,
+            },
+        ],
+    })
+    mock_sab.pause_item = AsyncMock(return_value=True)
+    mock_sab.resume_item = AsyncMock(return_value=True)
+    mock_sab.pause_queue = AsyncMock(return_value=True)
+    mock_sab.resume_queue = AsyncMock(return_value=True)
+    mock_sab_class.return_value = mock_sab
+
+    mock_ts = MagicMock()
+    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_ts_class.return_value = mock_ts
+
+    from src.bot.handlers.sabnzbd import SabnzbdHandler
+    handler = SabnzbdHandler()
+    return handler, mock_sab, mock_ts
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_handle_downloads_shows_queue(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """handle_downloads shows queue view with keyboard."""
+    from src.bot.handlers.auth import AuthHandler
+    AuthHandler._authenticated_users = {12345}
+
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(text="/downloads")
+    context = make_context()
+
+    await handler.handle_downloads(update, context)
+
+    update.message.reply_text.assert_called_once()
+    call_args = update.message.reply_text.call_args
+    assert call_args[1].get("reply_markup") is not None
+    mock_sab.get_queue_details.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_handle_downloads_not_enabled(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """handle_downloads shows error when service not enabled."""
+    from src.bot.handlers.auth import AuthHandler
+    AuthHandler._authenticated_users = {12345}
+
+    handler, _, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class, enabled=False
+    )
+
+    update = make_update(text="/downloads")
+    context = make_context()
+
+    await handler.handle_downloads(update, context)
+
+    update.message.reply_text.assert_called_once()
+    text_arg = update.message.reply_text.call_args[0][0]
+    assert "DownloadsNotEnabled" in text_arg
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_handle_downloads_no_user(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """handle_downloads returns early when no effective_user."""
+    from src.bot.handlers.auth import AuthHandler
+    AuthHandler._authenticated_users = {12345}
+
+    handler, _, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(text="/downloads")
+    update.effective_user = None
+    context = make_context()
+
+    result = await handler.handle_downloads(update, context)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# handle_downloads_tab — tab switching callbacks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_tab_switch_to_history(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_tab_history switches to history view."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_tab_history")
+    context = make_context()
+
+    await handler.handle_downloads_tab(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    update.callback_query.message.edit_text.assert_called_once()
+    mock_sab.get_history.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_tab_switch_to_queue(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_tab_queue switches to queue view."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_tab_queue")
+    context = make_context()
+
+    await handler.handle_downloads_tab(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    update.callback_query.message.edit_text.assert_called_once()
+    mock_sab.get_queue_details.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# handle_downloads_page — pagination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_pagination_updates_page(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_page_1 fetches queue and updates with page=1."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_page_1")
+    context = make_context(user_data={"dl_tab": "queue"})
+
+    await handler.handle_downloads_page(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    update.callback_query.message.edit_text.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# handle_downloads_pause_item / resume_item
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_pause_item_success(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_pause_<nzo_id> pauses item and refreshes."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_pause_nzo_abc")
+    context = make_context(user_data={"dl_tab": "queue"})
+
+    await handler.handle_downloads_pause_item(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    mock_sab.pause_item.assert_awaited_once_with("nzo_abc")
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_pause_item_failure(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_pause_<nzo_id> shows error on failure."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+    mock_sab.pause_item = AsyncMock(return_value=False)
+
+    update = make_update(callback_data="dl_pause_nzo_abc")
+    context = make_context(user_data={"dl_tab": "queue"})
+
+    await handler.handle_downloads_pause_item(update, context)
+
+    answer_call = update.callback_query.answer.call_args
+    assert answer_call[1].get("show_alert") is True
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_resume_item_success(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_resume_<nzo_id> resumes item and refreshes."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_resume_nzo_ghi")
+    context = make_context(user_data={"dl_tab": "queue"})
+
+    await handler.handle_downloads_resume_item(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    mock_sab.resume_item.assert_awaited_once_with("nzo_ghi")
+
+
+# ---------------------------------------------------------------------------
+# handle_downloads_pauseall / resumeall
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_pause_all(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_pauseall pauses entire queue and refreshes."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_pauseall")
+    context = make_context(user_data={"dl_tab": "queue"})
+
+    await handler.handle_downloads_pauseall(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    mock_sab.pause_queue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_resume_all(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_resumeall resumes entire queue and refreshes."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_resumeall")
+    context = make_context(user_data={"dl_tab": "queue"})
+
+    await handler.handle_downloads_resumeall(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    mock_sab.resume_queue.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# handle_downloads_refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_refresh_queue(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_refresh re-fetches and edits message."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_refresh")
+    context = make_context(user_data={"dl_tab": "queue"})
+
+    await handler.handle_downloads_refresh(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    update.callback_query.message.edit_text.assert_called_once()
+    mock_sab.get_queue_details.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_refresh_history(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_refresh on history tab re-fetches history."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_refresh")
+    context = make_context(user_data={"dl_tab": "history"})
+
+    await handler.handle_downloads_refresh(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    mock_sab.get_history.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# command registration
+# ---------------------------------------------------------------------------
+
+
+@patch("src.bot.commands.TranslationService")
+@patch("src.bot.commands.config")
+def test_downloads_command_registered_when_sabnzbd_enabled(
+    mock_config, mock_ts_class
+):
+    """build_authenticated_commands includes /downloads when sabnzbd enabled."""
+    mock_ts = MagicMock()
+    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_ts_class.return_value = mock_ts
+
+    mock_config.get = MagicMock(side_effect=lambda key, default=None: {
+        "radarr": {"enable": False},
+        "sonarr": {"enable": False},
+        "lidarr": {"enable": False},
+        "transmission": {"enable": False},
+        "sabnzbd": {"enable": True},
+    }.get(key, default if default is not None else {}))
+
+    from src.bot.commands import build_authenticated_commands
+    commands = build_authenticated_commands()
+    command_names = [c.command for c in commands]
+
+    assert "downloads" in command_names
+    assert "sabnzbd" in command_names
+
+
+@patch("src.bot.commands.TranslationService")
+@patch("src.bot.commands.config")
+def test_downloads_command_not_registered_when_sabnzbd_disabled(
+    mock_config, mock_ts_class
+):
+    """build_authenticated_commands excludes /downloads when sabnzbd disabled."""
+    mock_ts = MagicMock()
+    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_ts_class.return_value = mock_ts
+
+    mock_config.get = MagicMock(side_effect=lambda key, default=None: {
+        "radarr": {"enable": False},
+        "sonarr": {"enable": False},
+        "lidarr": {"enable": False},
+        "transmission": {"enable": False},
+        "sabnzbd": {"enable": False},
+    }.get(key, default if default is not None else {}))
+
+    from src.bot.commands import build_authenticated_commands
+    commands = build_authenticated_commands()
+    command_names = [c.command for c in commands]
+
+    assert "downloads" not in command_names
+
+
+# ---------------------------------------------------------------------------
+# Edge cases for coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_pagination_history_tab(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_page_0 on history tab fetches history."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_page_0")
+    context = make_context(user_data={"dl_tab": "history"})
+
+    await handler.handle_downloads_page(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    mock_sab.get_history.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_pause_item_refreshes_history_tab(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """Per-item pause on history tab refreshes with history view."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+
+    update = make_update(callback_data="dl_pause_nzo_abc")
+    context = make_context(user_data={"dl_tab": "history"})
+
+    await handler.handle_downloads_pause_item(update, context)
+
+    mock_sab.get_history.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_downloads_empty_queue(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """Empty queue shows DownloadsEmpty text."""
+    from src.bot.handlers.auth import AuthHandler
+    AuthHandler._authenticated_users = {12345}
+
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+    mock_sab.get_queue_details = AsyncMock(return_value={
+        'paused': False,
+        'speed': '0 KB/s',
+        'size_remaining': '0 MB',
+        'items_count': 0,
+        'items': [],
+    })
+
+    update = make_update(text="/downloads")
+    context = make_context()
+
+    await handler.handle_downloads(update, context)
+
+    text_arg = update.message.reply_text.call_args[0][0]
+    assert "DownloadsEmpty" in text_arg
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_downloads_paused_queue_text(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """Paused queue shows DownloadsPaused in text."""
+    from src.bot.handlers.auth import AuthHandler
+    AuthHandler._authenticated_users = {12345}
+
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+    mock_sab.get_queue_details = AsyncMock(return_value={
+        'paused': True,
+        'speed': '0 KB/s',
+        'size_remaining': '1.2 GB',
+        'items_count': 1,
+        'items': [{
+            'nzo_id': 'nzo_abc',
+            'title': 'Test',
+            'status': 'Paused',
+            'progress': 50,
+            'size': '1 GB',
+            'timeleft': '',
+        }],
+    })
+
+    update = make_update(text="/downloads")
+    context = make_context()
+
+    await handler.handle_downloads(update, context)
+
+    text_arg = update.message.reply_text.call_args[0][0]
+    assert "DownloadsPaused" in text_arg
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_tab_switch_to_empty_history(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """Switching to history with no items shows DownloadsHistoryEmpty."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+    mock_sab.get_history = AsyncMock(return_value={
+        'total': 0,
+        'items': [],
+    })
+
+    update = make_update(callback_data="dl_tab_history")
+    context = make_context()
+
+    await handler.handle_downloads_tab(update, context)
+
+    text_arg = update.callback_query.message.edit_text.call_args[0][0]
+    assert "DownloadsHistoryEmpty" in text_arg
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_history_item_no_download_time(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """History item with download_time=0 shows no time string."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+    mock_sab.get_history = AsyncMock(return_value={
+        'total': 1,
+        'items': [{
+            'name': 'Failed.Download',
+            'status': 'Failed',
+            'size': '0 B',
+            'download_time': 0,
+        }],
+    })
+
+    update = make_update(callback_data="dl_tab_history")
+    context = make_context()
+
+    await handler.handle_downloads_tab(update, context)
+
+    text_arg = update.callback_query.message.edit_text.call_args[0][0]
+    assert "Failed.Download" in text_arg
+
+
+@pytest.mark.asyncio
+@patch("src.bot.handlers.sabnzbd.TranslationService")
+@patch("src.bot.handlers.sabnzbd.SABnzbdService")
+async def test_resume_item_failure(
+    mock_sab_class, mock_ts_class, make_update, make_context
+):
+    """dl_resume_<nzo_id> shows error on failure."""
+    handler, mock_sab, _ = _make_handler_with_mocks(
+        mock_sab_class, mock_ts_class
+    )
+    mock_sab.resume_item = AsyncMock(return_value=False)
+
+    update = make_update(callback_data="dl_resume_nzo_abc")
+    context = make_context(user_data={"dl_tab": "queue"})
+
+    await handler.handle_downloads_resume_item(update, context)
+
+    answer_call = update.callback_query.answer.call_args
+    assert answer_call[1].get("show_alert") is True

--- a/tests/test_services/test_sabnzbd_service.py
+++ b/tests/test_services/test_sabnzbd_service.py
@@ -303,6 +303,195 @@ class TestResumeQueue:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# pause_item
+# ---------------------------------------------------------------------------
+
+
+class TestPauseItem:
+    @pytest.mark.asyncio
+    async def test_pause_item_success(self, sabnzbd_service):
+        with aioresponses() as m:
+            m.get(SABNZBD_API_PATTERN, payload={"status": True}, status=200)
+            result = await sabnzbd_service.pause_item("SABnzbd_nzo_abc123")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_pause_item_http_error(self, sabnzbd_service):
+        with aioresponses() as m:
+            m.get(SABNZBD_API_PATTERN, status=500)
+            result = await sabnzbd_service.pause_item("SABnzbd_nzo_abc123")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_pause_item_connection_error(self, sabnzbd_service):
+        with aioresponses() as m:
+            m.get(
+                SABNZBD_API_PATTERN,
+                exception=Exception("Connection refused"),
+            )
+            result = await sabnzbd_service.pause_item("SABnzbd_nzo_abc123")
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# resume_item
+# ---------------------------------------------------------------------------
+
+
+class TestResumeItem:
+    @pytest.mark.asyncio
+    async def test_resume_item_success(self, sabnzbd_service):
+        with aioresponses() as m:
+            m.get(SABNZBD_API_PATTERN, payload={"status": True}, status=200)
+            result = await sabnzbd_service.resume_item("SABnzbd_nzo_abc123")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_resume_item_http_error(self, sabnzbd_service):
+        with aioresponses() as m:
+            m.get(SABNZBD_API_PATTERN, status=500)
+            result = await sabnzbd_service.resume_item("SABnzbd_nzo_abc123")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_resume_item_connection_error(self, sabnzbd_service):
+        with aioresponses() as m:
+            m.get(
+                SABNZBD_API_PATTERN,
+                exception=Exception("Connection refused"),
+            )
+            result = await sabnzbd_service.resume_item("SABnzbd_nzo_abc123")
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# get_queue_details
+# ---------------------------------------------------------------------------
+
+
+SABNZBD_QUEUE_DETAILED = {
+    "queue": {
+        "status": "Downloading",
+        "paused": False,
+        "speed": "5.2 MB/s",
+        "size": "1.2 GB",
+        "noofslots": 3,
+        "slots": [
+            {
+                "nzo_id": "SABnzbd_nzo_abc",
+                "filename": "Movie.Name.2024.1080p",
+                "status": "Downloading",
+                "percentage": "72",
+                "size": "4.2 GB",
+                "timeleft": "0:15:30",
+            },
+            {
+                "nzo_id": "SABnzbd_nzo_def",
+                "filename": "TV.Show.S03E05",
+                "status": "Queued",
+                "percentage": "0",
+                "size": "1.1 GB",
+                "timeleft": "0:45:00",
+            },
+            {
+                "nzo_id": "SABnzbd_nzo_ghi",
+                "filename": "Another.Movie",
+                "status": "Paused",
+                "percentage": "12",
+                "size": "3.5 GB",
+                "timeleft": "",
+            },
+        ],
+    }
+}
+
+
+class TestGetQueueDetails:
+    @pytest.mark.asyncio
+    async def test_get_queue_details_success(self, sabnzbd_service):
+        with aioresponses() as m:
+            m.get(
+                SABNZBD_API_PATTERN,
+                payload=SABNZBD_QUEUE_DETAILED,
+                status=200,
+            )
+            result = await sabnzbd_service.get_queue_details()
+
+        assert result["paused"] is False
+        assert result["speed"] == "5.2 MB/s"
+        assert result["size_remaining"] == "1.2 GB"
+        assert result["items_count"] == 3
+        assert len(result["items"]) == 3
+
+        item = result["items"][0]
+        assert item["nzo_id"] == "SABnzbd_nzo_abc"
+        assert item["title"] == "Movie.Name.2024.1080p"
+        assert item["status"] == "Downloading"
+        assert item["progress"] == 72
+        assert item["size"] == "4.2 GB"
+        assert item["timeleft"] == "0:15:30"
+
+        paused_item = result["items"][2]
+        assert paused_item["status"] == "Paused"
+        assert paused_item["progress"] == 12
+
+    @pytest.mark.asyncio
+    async def test_get_queue_details_empty(self, sabnzbd_service):
+        empty_queue = {
+            "queue": {
+                "slots": [],
+                "noofslots": 0,
+                "speed": "0 KB/s",
+                "size": "0 MB",
+                "paused": False,
+            }
+        }
+        with aioresponses() as m:
+            m.get(
+                SABNZBD_API_PATTERN,
+                payload=empty_queue,
+                status=200,
+            )
+            result = await sabnzbd_service.get_queue_details()
+
+        assert result["items_count"] == 0
+        assert result["items"] == []
+        assert result["paused"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_queue_details_http_error(self, sabnzbd_service):
+        with aioresponses() as m:
+            m.get(SABNZBD_API_PATTERN, status=500)
+            result = await sabnzbd_service.get_queue_details()
+
+        assert result["items_count"] == 0
+        assert result["items"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_queue_details_connection_error(self, sabnzbd_service):
+        with aioresponses() as m:
+            m.get(
+                SABNZBD_API_PATTERN,
+                exception=Exception("Connection refused"),
+            )
+            result = await sabnzbd_service.get_queue_details()
+
+        assert result["items_count"] == 0
+        assert result["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# get_history
+# ---------------------------------------------------------------------------
+
+
 SABNZBD_HISTORY_RESPONSE = {
     "history": {
         "noofslots": 2,

--- a/tests/test_services/test_sabnzbd_service.py
+++ b/tests/test_services/test_sabnzbd_service.py
@@ -466,6 +466,30 @@ class TestGetQueueDetails:
         assert result["paused"] is False
 
     @pytest.mark.asyncio
+    async def test_get_queue_details_invalid_percentage(self, sabnzbd_service):
+        bad_queue = {
+            "queue": {
+                "paused": False,
+                "speed": "1 MB/s",
+                "size": "500 MB",
+                "noofslots": 1,
+                "slots": [{
+                    "nzo_id": "nzo_bad",
+                    "filename": "Bad.Percentage",
+                    "status": "Downloading",
+                    "percentage": "not-a-number",
+                    "size": "1 GB",
+                    "timeleft": "1:00:00",
+                }],
+            }
+        }
+        with aioresponses() as m:
+            m.get(SABNZBD_API_PATTERN, payload=bad_queue, status=200)
+            result = await sabnzbd_service.get_queue_details()
+
+        assert result["items"][0]["progress"] == 0
+
+    @pytest.mark.asyncio
     async def test_get_queue_details_http_error(self, sabnzbd_service):
         with aioresponses() as m:
             m.get(SABNZBD_API_PATTERN, status=500)

--- a/translations/addarr.en-us.yml
+++ b/translations/addarr.en-us.yml
@@ -219,6 +219,22 @@ en-us:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+  CommandDownloads: "SABnzbd download queue"
+
+  # Downloads dashboard
+  DownloadsTitle: "SABnzbd Downloads"
+  DownloadsEmpty: "No items in the download queue."
+  DownloadsHistoryTitle: "SABnzbd History"
+  DownloadsHistoryEmpty: "No download history available."
+  DownloadsSpeed: "Speed"
+  DownloadsRemaining: "Remaining"
+  DownloadsItems: "Items"
+  DownloadsPaused: "Queue paused"
+  DownloadsItemPaused: "Item paused."
+  DownloadsItemResumed: "Item resumed."
+  DownloadsPauseError: "Failed to pause item."
+  DownloadsResumeError: "Failed to resume item."
+  DownloadsNotEnabled: "SABnzbd is not enabled or configured."
 
   # Rate limiting
   RateLimitExceeded: "Slow down! Please wait %(seconds)s seconds before trying again."

--- a/translations/addarr.template.yml
+++ b/translations/addarr.template.yml
@@ -223,6 +223,22 @@ template:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+  CommandDownloads: "SABnzbd download queue"
+
+  # Downloads dashboard
+  DownloadsTitle: "SABnzbd Downloads"
+  DownloadsEmpty: "No items in the download queue."
+  DownloadsHistoryTitle: "SABnzbd History"
+  DownloadsHistoryEmpty: "No download history available."
+  DownloadsSpeed: "Speed"
+  DownloadsRemaining: "Remaining"
+  DownloadsItems: "Items"
+  DownloadsPaused: "Queue paused"
+  DownloadsItemPaused: "Item paused."
+  DownloadsItemResumed: "Item resumed."
+  DownloadsPauseError: "Failed to pause item."
+  DownloadsResumeError: "Failed to resume item."
+  DownloadsNotEnabled: "SABnzbd is not enabled or configured."
 
   # Bot command descriptions (for Telegram /menu)
   CommandStart: "Start the bot"
@@ -240,6 +256,7 @@ template:
   CommandAllMusic: "List all music"
   CommandTransmission: "Manage Transmission"
   CommandSabnzbd: "Manage SABnzbd"
+  CommandDownloads: "SABnzbd download queue"
 
   # Rate limiting
   RateLimitExceeded: "Slow down! Please wait %(seconds)s seconds before trying again."


### PR DESCRIPTION
## Summary

Adds a `/downloads` command that displays a SABnzbd queue dashboard with:

- **Queue view**: Active downloads with progress, speed, remaining size, per-item pause/resume buttons
- **History view**: Completed/failed downloads with size and download time
- **Tab switching**: Toggle between Queue and History views
- **Pagination**: Navigate through items (5 per page)
- **Pause/Resume All**: Control entire queue from the dashboard
- **Refresh**: Re-fetch current data on demand

Closes #101

## Changes

### API Client (`src/api/sabnzbd.py`)
- Added `pause_item(nzo_id)` and `resume_item(nzo_id)` methods with URL-encoded parameters

### Service Layer (`src/services/sabnzbd.py`)
- Added `pause_item()`, `resume_item()`, `get_queue_details()`, `get_history()` methods
- `get_queue_details()` returns normalized dict with parsed progress values

### Handler (`src/bot/handlers/sabnzbd.py`)
- Added `/downloads` command with `@require_auth`
- 8 callback handlers: tab switching, pagination, per-item pause/resume, pause/resume all, refresh, noop
- Text formatters for queue and history views
- Uses `context.user_data` for tab/page state (no ConversationHandler needed)

### Keyboards (`src/bot/keyboards.py`)
- `get_downloads_queue_keyboard()` — per-item controls, pagination, tab row, action row
- `get_downloads_history_keyboard()` — item display, pagination, tab row, refresh

### Command Registration (`src/bot/commands.py`)
- `/downloads` registered under sabnzbd enable conditional

### Translations
- 16 new keys in `en-us` and `template` files

## Test Plan

- [x] 1692 tests pass (`pytest --tb=short -q`)
- [x] flake8 clean
- [x] 100% coverage on all changed modules (API, service, handler, keyboards, commands)
- [x] i18n validation passes for en-us (other locale warnings expected for new keys)
- [x] Bug review: added noop handler for display-only buttons, URL-encoded nzo_id in API client
- [x] Code review: deduplicated fetch-and-format logic in handler callbacks

Generated with [Claude Code](https://claude.com/claude-code)
