### PR TITLE
feat: add integration test harness (#136)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Validate translation files
         run: python run.py --validate-i18n
 
-  test:
-    name: Test
+  unit-test:
+    name: Unit Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -64,8 +64,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-test.txt
-      - name: Run tests with 100% coverage enforcement
-        run: pytest --cov=src --cov-report=term-missing --cov-report=html:coverage-html --cov-fail-under=100 --tb=short
+      - name: Run unit tests with 100% coverage enforcement
+        run: pytest tests/ --ignore=tests/integration --ignore=tests/test_architecture --cov=src --cov-report=term-missing --cov-report=html:coverage-html --cov-fail-under=100 --tb=short
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         if: always()
@@ -73,6 +73,40 @@ jobs:
           name: coverage-report
           path: coverage-html/
           retention-days: 14
+
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-test.txt
+      - name: Run integration tests
+        run: pytest tests/integration --tb=short -v
+
+  architecture-test:
+    name: Architecture Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-test.txt
+      - name: Run architecture tests
+        run: pytest tests/test_architecture --tb=short -v
 
   security:
     name: Dependency Audit
@@ -96,7 +130,7 @@ jobs:
 
   docker-build:
     name: Docker Build
-    needs: [test]
+    needs: [unit-test, integration-test, architecture-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/docs/issues/issue-136/TASKS.md
+++ b/docs/issues/issue-136/TASKS.md
@@ -205,7 +205,7 @@
 
 **Goal:** Test the `/downloads` unified dashboard with Transmission and SABnzbd.
 
-- [ ] **5.1** Downloads dashboard integration tests
+- [x] **5.1** Downloads dashboard integration tests
     - **Context:** `DownloadsHandler` (`src/bot/handlers/downloads.py`) uses `CommandHandler` + multiple `CallbackQueryHandler`s (not a ConversationHandler). It checks `is_enabled()` on both Transmission and SABnzbd services. Callbacks: `dl_client_*` (tab switch), `dl_tab_*` (queue/history), `dl_page_*` (pagination), `dl_pause_*`/`dl_resume_*` (item control), `dl_pauseall`/`dl_resumeall`, `dl_refresh`. Transmission uses sync `requests.post` (not aiohttp). SABnzbd uses aiohttp via `BaseApiClient`.
     - **Watch out:**
         - Transmission uses `requests.post` (sync) — mock with `unittest.mock.patch("requests.post")`, not aioresponses
@@ -224,3 +224,12 @@
         - [GREEN] Mock SABnzbd aiohttp responses (queue, history)
         - [GREEN] Build harness variant that re-registers handlers with download-enabled config
     - **Success:** Downloads dashboard works with both clients, tab switching and refresh verified
+    - **Completed:** 2026-03-06
+    - **Learnings:**
+        - `DownloadsHandler.__init__` calls `is_enabled()` at construction time — must patch before `_build_application()`, not during test
+        - Created `downloads_harness` fixture that patches both services' `is_enabled` before handler registration
+        - Downloads handler is NOT a ConversationHandler — uses standalone CommandHandler + CallbackQueryHandlers
+    - **Key Changes:**
+        - Created `tests/integration/test_downloads_flow.py` with 4 tests (queue, sabnzbd switch, client toggle, refresh)
+        - Added `downloads_harness` fixture to `tests/integration/conftest.py`
+    - **Notes:** `_multi_client` mode tested (both clients enabled) which activates client switch buttons

--- a/docs/issues/issue-136/TASKS.md
+++ b/docs/issues/issue-136/TASKS.md
@@ -138,7 +138,7 @@
         - Created `tests/integration/test_media_flow.py` with 5 tests (happy path, no results, cancel at search/selection/quality)
     - **Notes:** `patch.object(MediaService, ...)` pattern is the correct approach for all integration tests that need to mock service methods
 
-- [ ] **3.2** Series and music flows with type-specific steps
+- [x] **3.2** Series and music flows with type-specific steps
     - **Context:** Series flow adds a SEASON_SELECT state after QUALITY_SELECT (`handler.py:529-566`). Season keyboard has "Monitor All", "All Seasons", "Future Seasons", "Future Episodes", plus individual season buttons. User selects seasons then taps `season_confirm`. Music flow adds ALBUM_SELECT state for artist searches — shows album monitor mode keyboard (`get_album_monitor_mode_keyboard()` in `keyboards.py`). Album/song searches skip album selection and add directly.
     - **Watch out:**
         - Series `quality_data` must include `"seasons"` key for season picker to appear
@@ -155,6 +155,14 @@
         - [GREEN] Add Sonarr and Lidarr mock data with correct field shapes (seasons, music_type, artist_id)
         - [GREEN] Fix any state transition issues discovered
     - **Success:** Series season picker and music album picker work end-to-end in integration tests
+    - **Completed:** 2026-03-06
+    - **Learnings:**
+        - `season_monitor_all` auto-calls `handle_season_confirm` — one tap completes the flow
+        - Music artist flow routes to ALBUM_SELECT with album monitor mode keyboard; album/song flow skips album picker and adds directly
+        - `select_album:b1ae2a0f` callback data works — handler strips `album:` prefix for API calls
+    - **Key Changes:**
+        - Added 4 tests to `tests/integration/test_media_flow.py`: series happy path, series monitor all, music artist happy path, music album direct add
+    - **Notes:** All media types (movie, series, music-artist, music-album) now have integration test coverage
 
 ---
 

--- a/docs/issues/issue-136/TASKS.md
+++ b/docs/issues/issue-136/TASKS.md
@@ -170,7 +170,7 @@
 
 **Goal:** Test the authentication conversation flow and systematic cancel-at-every-stage coverage.
 
-- [ ] **4.1** Auth flow and comprehensive cancel tests
+- [x] **4.1** Auth flow and comprehensive cancel tests
     - **Context:** Auth flow: `AuthHandler` (`src/bot/handlers/auth.py:54`) uses ConversationHandler with PASSWORD state. Entry via `/auth` command. User types password, checked against `config["telegram"]["password"]` (mock: "test-pass"). On success, user ID added to `_authenticated_users` and persisted to config.yaml (mocked via MockConfig.save()). Cancel tests: every ConversationHandler state should handle `menu_cancel` callback or `/cancel` command gracefully.
     - **Watch out:**
         - Auth handler writes to `config.yaml` via `yaml.dump` — must mock file I/O or the `CONFIG_PATH` constant
@@ -188,6 +188,16 @@
         - [GREEN] Mock `register_commands_for_chat` to prevent bot API calls during auth
         - [GREEN] Implement any missing harness helpers discovered during these tests
     - **Success:** Full auth round-trip works, cancel is tested at every conversation stage
+    - **Completed:** 2026-03-06
+    - **Learnings:**
+        - `_save_authenticated_users` must be patched to avoid config.yaml file I/O during tests
+        - `check_password` calls `message.delete()` first (deleteMessage endpoint), then `chat.send_message` — both handled by fake transport
+        - `register_commands_for_chat` calls `bot.set_my_commands` which goes through fake transport returning True for unknown endpoints
+        - Parametrized cancel test cleanly covers all 3 media conversation stages
+    - **Key Changes:**
+        - Created `tests/integration/test_auth_flow.py` — 3 tests (correct password, wrong password, auth-then-movie)
+        - Created `tests/integration/test_cancel_flow.py` — parametrized cancel at every stage + /cancel command fallback
+    - **Notes:** Auth flow tests require discarding pre-seeded user (12345) and re-adding after password check
 
 ---
 

--- a/docs/issues/issue-136/TASKS.md
+++ b/docs/issues/issue-136/TASKS.md
@@ -73,7 +73,7 @@
 
 **Goal:** Friendly `aioresponses` wrappers for Radarr, Sonarr, and Lidarr APIs that make test setup concise and readable.
 
-- [ ] **2.1** Build API mock helpers for Radarr, Sonarr, Lidarr
+- [x] **2.1** Build API mock helpers for Radarr, Sonarr, Lidarr
     - **Context:** See plan.md section 4. API clients use `BaseApiClient._make_request()` (`src/api/base.py:131`) which calls `session.request(method, url)` via `aiohttp`. URL pattern: `http://localhost:{port}/api/v3/{endpoint}` with `X-Api-Key` header. Each mock helper wraps `aioresponses` to register URL patterns for search, quality profiles, root folders, and add endpoints. Radarr port 7878, Sonarr 8989, Lidarr 8686 (from `conftest.py` mock config).
     - **Watch out:**
         - `aioresponses` must be installed as test dependency — check if it's already in requirements or test deps
@@ -94,6 +94,16 @@
         - [GREEN] Implement `SonarrMockHelper` and `LidarrMockHelper` following same pattern
         - [GREEN] Add `mock_radarr`, `mock_sonarr`, `mock_lidarr` fixtures to integration conftest
     - **Success:** API mock helpers correctly intercept aiohttp calls, tests pass without network access
+    - **Completed:** 2026-03-06
+    - **Learnings:**
+        - Search endpoints use URL pattern matching (regex) because query params vary — `_url_pattern()` wraps base URL with optional `?` suffix
+        - Radarr/Sonarr use `qualityProfile` (camelCase) but Lidarr uses `qualityprofile` (lowercase) — mock helpers must match per-service
+        - `aioresponses` fixture added directly to integration conftest since test_api conftest is directory-scoped
+    - **Key Changes:**
+        - Created `tests/integration/api_mocks.py` with `BaseMockHelper`, `RadarrMockHelper`, `SonarrMockHelper`, `LidarrMockHelper`
+        - Created `tests/integration/test_api_mocks.py` with 3 tests
+        - Added `aio_mock` fixture to `tests/integration/conftest.py`
+    - **Notes:** `add_returns()` method at 98% coverage — will be exercised by Phase 3 media flow tests
 
 ---
 

--- a/docs/issues/issue-136/TASKS.md
+++ b/docs/issues/issue-136/TASKS.md
@@ -111,7 +111,7 @@
 
 **Goal:** Full conversation flow tests for all three media types, including the happy path and edge cases.
 
-- [ ] **3.1** Movie flow: search → select → quality → added
+- [x] **3.1** Movie flow: search → select → quality → added
     - **Context:** Movie flow uses `MediaHandler` (`src/bot/handlers/media/handler.py`). States: `/movie` → SEARCHING → user types query → `handle_search` calls `MediaService.search_movies()` → SELECTING → user taps `select_{id}` → `handle_selection` calls `MediaService.add_movie()` → if quality selection needed, returns dict with `type: "quality_selection"` → QUALITY_SELECT → user taps `quality_{id}` → `handle_quality_selection` calls `add_movie_with_profile()` → END. The `@require_auth` and `@rate_limit` decorators wrap entry points.
     - **Watch out:**
         - `handle_selection` (`handler.py:386`) matches result by `r["id"] == selection` where selection is the string after `select_` — mock search results must have an `id` field matching
@@ -129,6 +129,14 @@
         - [GREEN] Wire up API mocks for Radarr search, quality profiles, root folders, and add endpoints in each test
         - [GREEN] Fix any harness issues discovered during first real conversation flow test
     - **Success:** All movie flow tests pass, conversation states transition correctly, responses contain expected text
+    - **Completed:** 2026-03-06
+    - **Learnings:**
+        - Cannot patch `MediaService` constructor on handler module — handler instance is created during fixture setup. Must use `patch.object(MediaService, "method")` to patch methods on the singleton class directly
+        - `send_response` in formatters.py checks `message.photo` to decide between `edit_text` and `edit_caption` — the harness fake results handle both
+        - `PreferencesService().get_view_mode()` defaults to "card" view, which uses `show_result()` (single result display)
+    - **Key Changes:**
+        - Created `tests/integration/test_media_flow.py` with 5 tests (happy path, no results, cancel at search/selection/quality)
+    - **Notes:** `patch.object(MediaService, ...)` pattern is the correct approach for all integration tests that need to mock service methods
 
 - [ ] **3.2** Series and music flows with type-specific steps
     - **Context:** Series flow adds a SEASON_SELECT state after QUALITY_SELECT (`handler.py:529-566`). Season keyboard has "Monitor All", "All Seasons", "Future Seasons", "Future Episodes", plus individual season buttons. User selects seasons then taps `season_confirm`. Music flow adds ALBUM_SELECT state for artist searches — shows album monitor mode keyboard (`get_album_monitor_mode_keyboard()` in `keyboards.py`). Album/song searches skip album selection and add directly.

--- a/docs/issues/issue-136/TASKS.md
+++ b/docs/issues/issue-136/TASKS.md
@@ -1,0 +1,190 @@
+# TASKS — Issue #136: Integration Test Harness
+
+> **Issue:** [#136](https://github.com/Krypt0nBull3t/Addarr/issues/136)
+> **Branch:** `feature/136-integration-test-harness`
+> **Plan:** [plan.md](plan.md)
+
+---
+
+### Phase 1: Core Harness Infrastructure (2 tasks)
+
+**Goal:** Build the `BotHarness` class that can construct a real PTB `Application`, process `Update` objects through the handler chain, and capture bot responses — validated with a `/start` smoke test.
+
+- [x] **1.1** Build BotHarness with response capture and Update factories
+    - **Context:** See plan.md "Design Decisions" sections 1–3. The harness builds a real `Application` via `Application.builder().token("test").build()`, registers handlers using the same logic as `AddarrBot._add_handlers()` (`src/main.py:106-188`), and intercepts outgoing API calls by patching `Bot._do_post`. Update objects are constructed via `Update.de_json(data, bot)` with dicts matching Telegram's wire format.
+    - **Watch out:**
+        - `Application.builder().token("test")` — PTB validates token format, may need `"0:test"` or similar dummy that passes the regex
+        - `Bot._do_post` is the low-level hook — confirm this is the right interception point in PTB v20+ (may be `Bot._post` or `Bot.do_api_request`)
+        - Callback updates need a `message` field (the message the inline keyboard was on) — handlers call `query.message.edit_text()`
+        - The existing `conftest.py` mock config injection must work with the real `Application` (it should — handlers import config at module level, already intercepted)
+        - `AuthHandler._authenticated_users` must be pre-seeded for non-auth tests
+    - **Scope:** `tests/integration/__init__.py`, `tests/integration/conftest.py` (BotHarness, BotResponse dataclass, update factories, application builder fixture)
+    - **Touches:** `tests/integration/conftest.py` (new), `tests/integration/__init__.py` (new)
+    - **Action items:**
+        - [RED] Write smoke test: `test_start_command_returns_response` — sends `/start` to a fully wired Application, asserts bot sent a `sendMessage` response containing menu text
+        - [RED] Write test: `test_unknown_command_no_crash` — sends `/nonexistent`, asserts no error raised
+        - [RED] Write test: `test_harness_captures_multiple_responses` — verifies `harness.responses` collects all API calls from a single update
+        - [GREEN] Implement `BotResponse` dataclass with `method`, `text`, `chat_id`, `reply_markup`, `photo` fields
+        - [GREEN] Implement update factory functions: `make_text_update()`, `make_command_update()`, `make_callback_update()` using `Update.de_json()`
+        - [GREEN] Implement `BotHarness` class: builds Application, registers handlers, patches Bot transport, exposes `send_command()`, `send_text()`, `tap_button()`, `responses`, `last_response`
+        - [GREEN] Implement `harness` pytest fixture that builds and initializes the Application
+    - **Success:** Smoke tests pass — `/start` returns a recognizable response, harness captures it, no real network calls made
+    - **Completed:** 2026-03-06
+    - **Learnings:**
+        - PTB v22 `TelegramObject` is frozen — can't patch `Bot._do_post` directly. Must intercept at `HTTPXRequest.do_request` level instead
+        - `do_request` returns `(status_code, bytes)` — response must be wrapped as `{"ok": true, "result": ...}` JSON
+        - `Application.initialize()` calls `getMe` — transport patch must be in place before init
+        - Token format `"0:TEST"` passes PTB's builder validation
+        - `_FAKE_RESULTS` dict needs a `getMe` entry returning bot info for initialize to work
+    - **Key Changes:**
+        - Created `tests/integration/__init__.py`
+        - Created `tests/integration/conftest.py` — BotHarness class, BotResponse dataclass, update factories, harness fixture
+        - Created `tests/integration/test_smoke.py` — 3 smoke tests (start command, unknown command, multiple response capture)
+    - **Notes:** PTB warnings about `per_message=False` on ConversationHandlers are pre-existing and benign
+
+- [x] **1.2** Add conversation state inspection and auth pre-seeding
+    - **Context:** See plan.md sections 5–6. Most integration tests need an authenticated user. `AuthHandler._authenticated_users` (class-level `set` in `src/bot/handlers/auth.py:58`) must be pre-seeded. Conversation state is tracked in `ConversationHandler._conversations` dict, keyed by `(chat_id, user_id)` tuple.
+    - **Watch out:**
+        - `@require_auth` decorator (`auth.py:37-51`) checks `AuthHandler.is_authenticated()` — if user not in set, it replies with "Not Authorized" and returns `None` (skips handler), which may not be `ConversationHandler.END`
+        - Singleton reset in `conftest.py` already clears `AuthHandler._authenticated_users` between tests
+        - Conversation state key format may vary — check PTB v20 docs for `ConversationHandler._conversations` key structure
+    - **Scope:** Auth fixture, state inspection helper on BotHarness
+    - **Touches:** `tests/integration/conftest.py`
+    - **Action items:**
+        - [RED] Write test: `test_unauthenticated_user_blocked` — sends `/movie` without auth, asserts "authenticate" in response
+        - [RED] Write test: `test_authenticated_user_proceeds` — sends `/movie` with pre-seeded auth, asserts "Title" prompt in response (entering SEARCHING state)
+        - [RED] Write test: `test_conversation_state_after_command` — sends `/movie`, checks harness reports conversation is in SEARCHING state
+        - [GREEN] Add `authenticated_user_id` parameter to harness fixture that pre-seeds `AuthHandler._authenticated_users`
+        - [GREEN] Add `get_conversation_state(handler_name, chat_id, user_id)` method to BotHarness
+    - **Success:** Auth gating works in integration tests, conversation state is inspectable
+    - **Completed:** 2026-03-06
+    - **Learnings:**
+        - Auth pre-seeding was already implemented in task 1.1 (harness fixture adds user 12345 to `AuthHandler._authenticated_users`) — test for unauthenticated just discards that user
+        - PTB `ConversationHandler._conversations` uses `(chat_id, user_id)` tuple as key, stores state as plain int (not tuple) in PTB v22
+        - `require_auth` returns `None` when user not authenticated, which prevents ConversationHandler from entering any state
+    - **Key Changes:**
+        - Added `get_conversation_state(handler_name, chat_id, user_id)` method to `BotHarness` in `tests/integration/conftest.py`
+        - Created `tests/integration/test_auth_gating.py` with 3 tests (unauth blocked, auth proceeds, state inspection)
+    - **Notes:** ConversationHandler state is stored as plain int, but code handles tuple case defensively for PTB version compatibility
+
+---
+
+### Phase 2: API Mock Helpers (1 task)
+
+**Goal:** Friendly `aioresponses` wrappers for Radarr, Sonarr, and Lidarr APIs that make test setup concise and readable.
+
+- [ ] **2.1** Build API mock helpers for Radarr, Sonarr, Lidarr
+    - **Context:** See plan.md section 4. API clients use `BaseApiClient._make_request()` (`src/api/base.py:131`) which calls `session.request(method, url)` via `aiohttp`. URL pattern: `http://localhost:{port}/api/v3/{endpoint}` with `X-Api-Key` header. Each mock helper wraps `aioresponses` to register URL patterns for search, quality profiles, root folders, and add endpoints. Radarr port 7878, Sonarr 8989, Lidarr 8686 (from `conftest.py` mock config).
+    - **Watch out:**
+        - `aioresponses` must be installed as test dependency — check if it's already in requirements or test deps
+        - URL construction: `base.py:145` builds `{base_url}/api/v3/{endpoint}` — mock URLs must match exactly
+        - Radarr search endpoint: `movie/lookup?term=...` (`radarr.py:47`), Sonarr: `series/lookup?term=...`, Lidarr: `artist/lookup?term=...`
+        - Quality profile endpoints: `qualityprofile` for all three
+        - Root folder endpoints: `rootfolder` for all three
+        - Add endpoints: `movie` (POST) for Radarr, `series` (POST) for Sonarr, `artist` (POST) for Lidarr
+        - Each service's `_make_request` does retries — mock should return 200 on first call
+    - **Scope:** `tests/integration/api_mocks.py` — `RadarrMockHelper`, `SonarrMockHelper`, `LidarrMockHelper` classes + fixtures
+    - **Touches:** `tests/integration/api_mocks.py` (new), `tests/integration/conftest.py` (add fixtures)
+    - **Action items:**
+        - [RED] Write test: `test_radarr_mock_search_returns_results` — uses mock helper, calls `RadarrClient().search("inception")`, asserts results returned
+        - [RED] Write test: `test_sonarr_mock_quality_profiles` — uses mock helper, calls quality profile endpoint, asserts profiles returned
+        - [RED] Write test: `test_mock_helper_defaults_return_empty_search` — verifies `set_defaults()` returns empty search results
+        - [GREEN] Implement `BaseMockHelper` with `set_defaults()`, URL builder from mock config
+        - [GREEN] Implement `RadarrMockHelper` with `search_returns()`, `quality_profiles()`, `root_folders()`, `add_returns()`
+        - [GREEN] Implement `SonarrMockHelper` and `LidarrMockHelper` following same pattern
+        - [GREEN] Add `mock_radarr`, `mock_sonarr`, `mock_lidarr` fixtures to integration conftest
+    - **Success:** API mock helpers correctly intercept aiohttp calls, tests pass without network access
+
+---
+
+### Phase 3: Media Flow Tests (2 tasks)
+
+**Goal:** Full conversation flow tests for all three media types, including the happy path and edge cases.
+
+- [ ] **3.1** Movie flow: search → select → quality → added
+    - **Context:** Movie flow uses `MediaHandler` (`src/bot/handlers/media/handler.py`). States: `/movie` → SEARCHING → user types query → `handle_search` calls `MediaService.search_movies()` → SELECTING → user taps `select_{id}` → `handle_selection` calls `MediaService.add_movie()` → if quality selection needed, returns dict with `type: "quality_selection"` → QUALITY_SELECT → user taps `quality_{id}` → `handle_quality_selection` calls `add_movie_with_profile()` → END. The `@require_auth` and `@rate_limit` decorators wrap entry points.
+    - **Watch out:**
+        - `handle_selection` (`handler.py:386`) matches result by `r["id"] == selection` where selection is the string after `select_` — mock search results must have an `id` field matching
+        - `add_movie()` returns either `(success, message)` tuple or `dict(type="quality_selection", profiles=[...], root_folder=...)` — the flow branches on this
+        - `show_result()` in `formatters.py` sends a `reply_photo` if the result has a poster URL, otherwise `reply_text` — mock results should include/exclude `remotePoster` to test both paths
+        - `rate_limit` decorator may interfere — may need to disable or mock `RateLimitService`
+    - **Scope:** `tests/integration/test_media_flow.py` — movie happy path, no results, cancel at each stage
+    - **Touches:** `tests/integration/test_media_flow.py` (new)
+    - **Action items:**
+        - [RED] Write test: `test_movie_happy_path` — `/movie` → type "inception" → tap `select_{id}` → tap `quality_{id}` → assert "added" in response
+        - [RED] Write test: `test_movie_no_results` — `/movie` → type "xyznonexistent" → assert "No movie found" in response, conversation ends
+        - [RED] Write test: `test_movie_cancel_at_search` — `/movie` → tap `menu_cancel` → assert cancelled message
+        - [RED] Write test: `test_movie_cancel_at_selection` — search → results shown → tap `select_cancel` → assert cancelled
+        - [RED] Write test: `test_movie_cancel_at_quality` — select result → quality shown → tap `quality_cancel` → assert cancelled
+        - [GREEN] Wire up API mocks for Radarr search, quality profiles, root folders, and add endpoints in each test
+        - [GREEN] Fix any harness issues discovered during first real conversation flow test
+    - **Success:** All movie flow tests pass, conversation states transition correctly, responses contain expected text
+
+- [ ] **3.2** Series and music flows with type-specific steps
+    - **Context:** Series flow adds a SEASON_SELECT state after QUALITY_SELECT (`handler.py:529-566`). Season keyboard has "Monitor All", "All Seasons", "Future Seasons", "Future Episodes", plus individual season buttons. User selects seasons then taps `season_confirm`. Music flow adds ALBUM_SELECT state for artist searches — shows album monitor mode keyboard (`get_album_monitor_mode_keyboard()` in `keyboards.py`). Album/song searches skip album selection and add directly.
+    - **Watch out:**
+        - Series `quality_data` must include `"seasons"` key for season picker to appear
+        - Season selection uses `SeasonPickerMixin` (`season_picker.py`) — `handle_season_selection` toggles seasons in `context.user_data["selected_seasons"]` set
+        - Music `selected` result must have `music_type` field ("artist", "album", or "song") to route correctly
+        - Lidarr add uses `artist_id`, not the result `id` directly — mock data must include both
+    - **Scope:** `tests/integration/test_media_flow.py` — series and music happy paths
+    - **Touches:** `tests/integration/test_media_flow.py`
+    - **Action items:**
+        - [RED] Write test: `test_series_happy_path` — `/series` → search → select → quality → season select → confirm → added
+        - [RED] Write test: `test_series_monitor_all` — select "Monitor All" then confirm, assert correct add call
+        - [RED] Write test: `test_music_artist_happy_path` — `/music` → search → select artist → quality → album monitor mode → added
+        - [RED] Write test: `test_music_album_direct_add` — `/music` → search → select album result → quality → added (no album picker)
+        - [GREEN] Add Sonarr and Lidarr mock data with correct field shapes (seasons, music_type, artist_id)
+        - [GREEN] Fix any state transition issues discovered
+    - **Success:** Series season picker and music album picker work end-to-end in integration tests
+
+---
+
+### Phase 4: Auth and Cancel Flow Tests (1 task)
+
+**Goal:** Test the authentication conversation flow and systematic cancel-at-every-stage coverage.
+
+- [ ] **4.1** Auth flow and comprehensive cancel tests
+    - **Context:** Auth flow: `AuthHandler` (`src/bot/handlers/auth.py:54`) uses ConversationHandler with PASSWORD state. Entry via `/auth` command. User types password, checked against `config["telegram"]["password"]` (mock: "test-pass"). On success, user ID added to `_authenticated_users` and persisted to config.yaml (mocked via MockConfig.save()). Cancel tests: every ConversationHandler state should handle `menu_cancel` callback or `/cancel` command gracefully.
+    - **Watch out:**
+        - Auth handler writes to `config.yaml` via `yaml.dump` — must mock file I/O or the `CONFIG_PATH` constant
+        - `register_commands_for_chat` is called after successful auth — needs `application.bot.set_my_commands` to not fail
+        - The `/start` handler checks auth and shows different menus for authenticated vs unauthenticated users
+    - **Scope:** `tests/integration/test_auth_flow.py`, `tests/integration/test_cancel_flow.py`
+    - **Touches:** `tests/integration/test_auth_flow.py` (new), `tests/integration/test_cancel_flow.py` (new)
+    - **Action items:**
+        - [RED] Write test: `test_auth_correct_password` — unauthenticated user sends `/auth` → types "test-pass" → assert authenticated
+        - [RED] Write test: `test_auth_wrong_password` — sends wrong password → assert not authenticated, appropriate message
+        - [RED] Write test: `test_auth_then_movie` — authenticate → then `/movie` → assert enters SEARCHING (not blocked)
+        - [RED] Write test: `test_cancel_movie_at_every_state` — parametrized test cancelling at SEARCHING, SELECTING, QUALITY_SELECT stages
+        - [RED] Write test: `test_cancel_command_fallback` — send `/cancel` during conversation, assert conversation ends
+        - [GREEN] Mock config.yaml file writes in auth handler
+        - [GREEN] Mock `register_commands_for_chat` to prevent bot API calls during auth
+        - [GREEN] Implement any missing harness helpers discovered during these tests
+    - **Success:** Full auth round-trip works, cancel is tested at every conversation stage
+
+---
+
+### Phase 5: Downloads Flow Tests (1 task)
+
+**Goal:** Test the `/downloads` unified dashboard with Transmission and SABnzbd.
+
+- [ ] **5.1** Downloads dashboard integration tests
+    - **Context:** `DownloadsHandler` (`src/bot/handlers/downloads.py`) uses `CommandHandler` + multiple `CallbackQueryHandler`s (not a ConversationHandler). It checks `is_enabled()` on both Transmission and SABnzbd services. Callbacks: `dl_client_*` (tab switch), `dl_tab_*` (queue/history), `dl_page_*` (pagination), `dl_pause_*`/`dl_resume_*` (item control), `dl_pauseall`/`dl_resumeall`, `dl_refresh`. Transmission uses sync `requests.post` (not aiohttp). SABnzbd uses aiohttp via `BaseApiClient`.
+    - **Watch out:**
+        - Transmission uses `requests.post` (sync) — mock with `unittest.mock.patch("requests.post")`, not aioresponses
+        - Config must enable transmission/sabnzbd (`enable: True`) for handlers to register — need to override mock config
+        - `DownloadsHandler.__init__` checks `is_enabled()` at construction time — config override must happen before handler init
+        - Downloads handler is NOT a ConversationHandler — no state machine, just standalone handlers matched by callback pattern
+    - **Scope:** `tests/integration/test_downloads_flow.py`
+    - **Touches:** `tests/integration/test_downloads_flow.py` (new)
+    - **Action items:**
+        - [RED] Write test: `test_downloads_command_shows_queue` — `/downloads` with Transmission enabled, assert queue displayed
+        - [RED] Write test: `test_downloads_sabnzbd_queue` — `/downloads` with SABnzbd enabled, assert SABnzbd queue displayed
+        - [RED] Write test: `test_downloads_client_switch` — both clients enabled, tap `dl_client_transmission` then `dl_client_sabnzbd`, verify tab switch
+        - [RED] Write test: `test_downloads_refresh` — tap `dl_refresh`, assert queue re-fetched
+        - [GREEN] Create config override fixture that enables Transmission and/or SABnzbd
+        - [GREEN] Mock Transmission `requests.post` responses (queue, torrent list)
+        - [GREEN] Mock SABnzbd aiohttp responses (queue, history)
+        - [GREEN] Build harness variant that re-registers handlers with download-enabled config
+    - **Success:** Downloads dashboard works with both clients, tab switching and refresh verified

--- a/docs/issues/issue-136/plan.md
+++ b/docs/issues/issue-136/plan.md
@@ -1,0 +1,141 @@
+# Issue #136: Integration Test Harness for End-to-End Conversation Flow Testing
+
+## Context
+
+Addarr has comprehensive unit tests that call individual handler methods directly with mock objects. However, there's no way to verify that the full conversation wiring works — state transitions, callback pattern matching, handler registration order, and data flow between steps — without deploying the bot to a live environment.
+
+This plan adds an integration test layer that processes real `Update` objects through the actual `python-telegram-bot` handler chain, catching wiring bugs that unit tests can't.
+
+## Target Structure
+
+```
+tests/
+├── conftest.py                        # existing (unchanged)
+├── integration/
+│   ├── __init__.py
+│   ├── conftest.py                    # BotHarness, response capture, API mock fixtures
+│   ├── test_media_flow.py             # movie/series/music: search → select → quality → add
+│   ├── test_auth_flow.py              # unauthenticated → password → authenticated → command
+│   ├── test_downloads_flow.py         # /downloads with Transmission/SABnzbd tabs
+│   └── test_cancel_flow.py            # cancel at every conversation stage
+```
+
+## Design Decisions
+
+### 1. Real Application, Fake Transport
+
+Build a real `Application` via `Application.builder().token("test").build()` with all handlers registered via `AddarrBot._add_handlers()` logic. The key is `Application.process_update(update)` — this feeds an Update through PTB's actual dispatcher (pattern matching, conversation state tracking, handler groups) without polling Telegram.
+
+We intercept outgoing bot responses by patching `Bot._do_post` (the low-level HTTP method PTB uses for all API calls). This captures every `reply_text`, `edit_message_text`, `send_photo`, etc. as raw request data.
+
+**Why not mock individual response methods?** Because we want real `Update` objects, which means real `Message` objects on callback queries. Mocking at the transport layer lets PTB's internal plumbing work naturally while preventing any network calls.
+
+### 2. Real Update Objects via de_json
+
+Construct `Update` objects using `Update.de_json(data, bot)` with dictionaries matching Telegram's API format. This ensures callback_data patterns, message types, and user IDs are all realistic.
+
+A factory module provides helpers:
+- `make_text_update(text, user_id, chat_id)` → Update with a text message
+- `make_command_update(command, user_id, chat_id)` → Update with a /command
+- `make_callback_update(callback_data, user_id, chat_id, message)` → Update with a callback query
+
+The `message` parameter on callback updates is important — PTB's `CallbackQuery.message` carries the original message that the inline keyboard was attached to, and handlers use `query.message.edit_text()` etc.
+
+### 3. Response Capture
+
+The `BotHarness` captures all outgoing API calls made by the bot. Each captured response includes:
+- Method name (`sendMessage`, `editMessageText`, `sendPhoto`, etc.)
+- Parameters (text, chat_id, reply_markup, parse_mode, etc.)
+
+A `BotResponse` dataclass provides convenient access:
+```python
+@dataclass
+class BotResponse:
+    method: str       # "sendMessage", "editMessageText", etc.
+    text: str         # message text or caption
+    chat_id: int
+    reply_markup: dict | None  # inline keyboard if present
+    photo: str | None
+```
+
+The harness exposes `last_response` and `responses` (full list) after each `process_update` call.
+
+### 4. API Mock Fixtures
+
+Wrap `aioresponses` in friendly fixtures that set up canned responses for each service:
+
+```python
+@pytest.fixture
+def mock_radarr(aioresponses):
+    """Pre-configure Radarr API responses."""
+    helper = RadarrMockHelper(aioresponses)
+    # Default: search returns empty, profiles return one profile, root folders return one
+    helper.set_defaults()
+    return helper
+```
+
+Each helper provides methods like:
+- `helper.search_returns(results)` — mock the search endpoint
+- `helper.quality_profiles(profiles)` — mock quality profile lookup
+- `helper.root_folders(folders)` — mock root folder lookup
+- `helper.add_returns(success=True)` — mock the add endpoint
+
+This keeps test bodies clean and focused on the conversation flow.
+
+### 5. Auth Handling
+
+The `@require_auth` decorator checks `AuthHandler._authenticated_users`. For most integration tests, we pre-seed the authenticated user set in the fixture. The auth flow test specifically does NOT pre-seed, testing the full password → authenticate → access flow.
+
+### 6. Conversation State Verification
+
+After each step, the harness can optionally check which conversation state PTB's `ConversationHandler` is in for a given user. This helps debug "conversation got stuck" issues. Access via PTB's internal `ConversationHandler._conversations` dict.
+
+## Phased Approach
+
+### Phase 1: Core Harness Infrastructure
+- `BotHarness` class with `process_update()` wrapper and response capture
+- Update factory functions (text, command, callback)
+- Basic smoke test: send `/start`, verify bot responds
+
+### Phase 2: API Mock Helpers
+- `RadarrMockHelper`, `SonarrMockHelper`, `LidarrMockHelper` wrapping aioresponses
+- Transmission and SABnzbd mock helpers
+- Verify mocks work with a simple search call
+
+### Phase 3: Media Flow Tests
+- Movie flow: `/movie` → search → select → quality → added
+- Series flow: `/series` → search → select → quality → season select → added
+- Music flow: `/music` → search → select → quality → album monitor mode → added
+- No results flow: search returns empty → appropriate message
+- Navigation: paging through multiple results
+
+### Phase 4: Auth & Cancel Flow Tests
+- Auth flow: unauthenticated → `/start` → password prompt → correct password → authenticated
+- Cancel at each conversation state (SEARCHING, SELECTING, QUALITY_SELECT, SEASON_SELECT)
+- `/cancel` command as fallback
+
+### Phase 5: Downloads Flow Tests
+- `/downloads` with Transmission enabled
+- `/downloads` with SABnzbd enabled
+- Tab switching between clients
+
+## Bot Response Methods to Intercept
+
+From the codebase analysis, these are all the Telegram Bot API methods the handlers call:
+
+| PTB Method | Telegram API Method | Used By |
+|---|---|---|
+| `message.reply_text()` | `sendMessage` | All handlers — initial responses |
+| `message.reply_photo()` | `sendPhoto` | Media formatters — result cards with posters |
+| `query.message.edit_text()` | `editMessageText` | Handlers + formatters — update message content |
+| `query.message.edit_caption()` | `editMessageCaption` | Formatters — update photo caption |
+| `query.message.edit_reply_markup()` | `editMessageReplyMarkup` | Season/album pickers — keyboard-only updates |
+| `query.message.delete()` | `deleteMessage` | Formatters — cleanup before sending new message |
+| `query.answer()` | `answerCallbackQuery` | All callback handlers — acknowledge tap |
+
+## Verification
+
+- `pytest tests/integration/ -v` passes with no external services
+- Integration tests run in CI alongside existing unit tests
+- No modifications to existing unit tests or production code
+- Coverage: at minimum one happy-path test per media type + auth flow + cancel flow

--- a/tests/integration/api_mocks.py
+++ b/tests/integration/api_mocks.py
@@ -1,0 +1,86 @@
+"""
+API mock helpers for integration tests.
+
+Friendly wrappers around aioresponses that register URL patterns matching
+the real Radarr, Sonarr, and Lidarr API clients.
+"""
+
+import re
+
+
+class BaseMockHelper:
+    """Base class for API mock helpers."""
+
+    SERVICE = ""
+    PORT = 0
+    SEARCH_ENDPOINT = ""
+    QUALITY_ENDPOINT = "qualityProfile"
+    ROOT_FOLDER_ENDPOINT = "rootfolder"
+    ADD_ENDPOINT = ""
+
+    def __init__(self, aio_mock):
+        self._m = aio_mock
+        self.base_url = f"http://localhost:{self.PORT}"
+
+    def _url(self, endpoint):
+        return f"{self.base_url}/api/v3/{endpoint}"
+
+    def _url_pattern(self, endpoint):
+        """Build a regex pattern matching the endpoint (with optional query string)."""
+        return re.compile(re.escape(self._url(endpoint)) + r"(\?.*)?$")
+
+    def set_defaults(self):
+        """Register default responses: empty search, empty profiles, empty root folders."""
+        self.search_returns([])
+        self.quality_profiles([])
+        self.root_folders([])
+
+    def search_returns(self, results):
+        """Mock the search endpoint to return given results."""
+        self._m.get(self._url_pattern(self.SEARCH_ENDPOINT), payload=results)
+
+    def quality_profiles(self, profiles=None):
+        """Mock the quality profiles endpoint."""
+        self._m.get(
+            self._url(self.QUALITY_ENDPOINT),
+            payload=profiles or [],
+        )
+
+    def root_folders(self, folders=None):
+        """Mock the root folders endpoint."""
+        self._m.get(
+            self._url(self.ROOT_FOLDER_ENDPOINT),
+            payload=folders or [{"path": "/media", "freeSpace": 1000000000000}],
+        )
+
+    def add_returns(self, result=None, status=201):
+        """Mock the add (POST) endpoint."""
+        self._m.post(
+            self._url(self.ADD_ENDPOINT),
+            payload=result or {"id": 1},
+            status=status,
+        )
+
+
+class RadarrMockHelper(BaseMockHelper):
+    SERVICE = "radarr"
+    PORT = 7878
+    SEARCH_ENDPOINT = "movie/lookup"
+    QUALITY_ENDPOINT = "qualityProfile"
+    ADD_ENDPOINT = "movie"
+
+
+class SonarrMockHelper(BaseMockHelper):
+    SERVICE = "sonarr"
+    PORT = 8989
+    SEARCH_ENDPOINT = "series/lookup"
+    QUALITY_ENDPOINT = "qualityProfile"
+    ADD_ENDPOINT = "series"
+
+
+class LidarrMockHelper(BaseMockHelper):
+    SERVICE = "lidarr"
+    PORT = 8686
+    SEARCH_ENDPOINT = "artist/lookup"
+    QUALITY_ENDPOINT = "qualityprofile"
+    ADD_ENDPOINT = "artist"

--- a/tests/integration/api_mocks.py
+++ b/tests/integration/api_mocks.py
@@ -13,6 +13,7 @@ class BaseMockHelper:
 
     SERVICE = ""
     PORT = 0
+    API_VERSION = "v3"
     SEARCH_ENDPOINT = ""
     QUALITY_ENDPOINT = "qualityProfile"
     ROOT_FOLDER_ENDPOINT = "rootfolder"
@@ -23,7 +24,7 @@ class BaseMockHelper:
         self.base_url = f"http://localhost:{self.PORT}"
 
     def _url(self, endpoint):
-        return f"{self.base_url}/api/v3/{endpoint}"
+        return f"{self.base_url}/api/{self.API_VERSION}/{endpoint}"
 
     def _url_pattern(self, endpoint):
         """Build a regex pattern matching the endpoint (with optional query string)."""
@@ -81,6 +82,7 @@ class SonarrMockHelper(BaseMockHelper):
 class LidarrMockHelper(BaseMockHelper):
     SERVICE = "lidarr"
     PORT = 8686
+    API_VERSION = "v1"
     SEARCH_ENDPOINT = "artist/lookup"
     QUALITY_ENDPOINT = "qualityprofile"
     ADD_ENDPOINT = "artist"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,7 @@ Integration test infrastructure.
 
 BotHarness builds a real PTB Application with all handlers registered,
 processes Update objects through the handler chain, and captures bot
-responses by intercepting Bot._do_post — no Telegram connection needed.
+responses by intercepting HTTPXRequest.do_request — no Telegram connection needed.
 """
 
 import json as json_mod
@@ -201,8 +201,8 @@ def make_callback_update(
 class BotHarness:
     """Drives a real PTB Application with all handlers, no Telegram connection.
 
-    Intercepts Bot._do_post to capture outgoing API calls and return
-    plausible fake results so PTB's internals don't break.
+    Intercepts HTTPXRequest.do_request to capture outgoing API calls and
+    return plausible fake results so PTB's internals don't break.
     """
 
     def __init__(self, app: Application):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ from typing import Optional
 from unittest.mock import patch
 
 import pytest
+from aioresponses import aioresponses
 from telegram import Update
 from telegram.ext import Application, ConversationHandler
 
@@ -345,6 +346,13 @@ def _build_application() -> Application:
 
 
 # ---- Fixtures ----------------------------------------------------------------
+
+@pytest.fixture
+def aio_mock():
+    """Provide aioresponses mock for async HTTP requests."""
+    with aioresponses() as m:
+        yield m
+
 
 @pytest.fixture
 async def harness():

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,6 +30,8 @@ from src.bot.handlers.queue import QueueHandler
 from src.bot.handlers.downloads import DownloadsHandler
 from src.bot.handlers.preferences import PreferencesHandler
 from src.config.settings import config
+from src.services.transmission import TransmissionService
+from src.services.sabnzbd import SABnzbdService
 
 
 # ---- Response capture -------------------------------------------------------
@@ -371,5 +373,32 @@ async def harness():
     ):
         await app.initialize()
         yield h
+
+    await app.shutdown()
+
+
+@pytest.fixture
+async def downloads_harness():
+    """Provide a BotHarness with downloads handlers enabled.
+
+    Patches TransmissionService.is_enabled and SABnzbdService.is_enabled
+    to return True *before* handler registration so DownloadsHandler
+    registers its handlers.
+    """
+    AuthHandler._authenticated_users.add(12345)
+
+    with (
+        patch.object(TransmissionService, "is_enabled", return_value=True),
+        patch.object(SABnzbdService, "is_enabled", return_value=True),
+    ):
+        app = _build_application()
+        h = BotHarness(app)
+
+        with patch(
+            "telegram.request.HTTPXRequest.do_request",
+            side_effect=h._fake_do_request,
+        ):
+            await app.initialize()
+            yield h
 
     await app.shutdown()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -109,6 +109,11 @@ _FAKE_RESULTS = {
 _update_counter = 0
 
 
+def _reset_update_counter():
+    global _update_counter
+    _update_counter = 0
+
+
 def _next_update_id():
     global _update_counter
     _update_counter += 1
@@ -356,35 +361,32 @@ def aio_mock():
         yield m
 
 
-@pytest.fixture
-async def harness():
-    """Provide a BotHarness with a fully wired Application."""
-    # Pre-seed authenticated user so most tests pass auth checks
-    AuthHandler._authenticated_users.add(12345)
-
-    app = _build_application()
+async def _make_harness(app):
+    """Shared helper: patch transport, initialize, yield, shutdown."""
+    _reset_update_counter()
     h = BotHarness(app)
 
-    # Patch do_request on BOTH HTTPXRequest instances (regular + getUpdates)
-    # This must happen BEFORE initialize() so getMe doesn't hit the network
     with patch(
         "telegram.request.HTTPXRequest.do_request",
         side_effect=h._fake_do_request,
     ):
         await app.initialize()
         yield h
+        await app.shutdown()
 
-    await app.shutdown()
+
+@pytest.fixture
+async def harness():
+    """Provide a BotHarness with a fully wired Application."""
+    AuthHandler._authenticated_users.add(12345)
+    app = _build_application()
+    async for h in _make_harness(app):
+        yield h
 
 
 @pytest.fixture
 async def downloads_harness():
-    """Provide a BotHarness with downloads handlers enabled.
-
-    Patches TransmissionService.is_enabled and SABnzbdService.is_enabled
-    to return True *before* handler registration so DownloadsHandler
-    registers its handlers.
-    """
+    """Provide a BotHarness with downloads handlers enabled."""
     AuthHandler._authenticated_users.add(12345)
 
     with (
@@ -392,13 +394,5 @@ async def downloads_harness():
         patch.object(SABnzbdService, "is_enabled", return_value=True),
     ):
         app = _build_application()
-        h = BotHarness(app)
-
-        with patch(
-            "telegram.request.HTTPXRequest.do_request",
-            side_effect=h._fake_do_request,
-        ):
-            await app.initialize()
+        async for h in _make_harness(app):
             yield h
-
-    await app.shutdown()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,367 @@
+"""
+Integration test infrastructure.
+
+BotHarness builds a real PTB Application with all handlers registered,
+processes Update objects through the handler chain, and captures bot
+responses by intercepting Bot._do_post — no Telegram connection needed.
+"""
+
+import json as json_mod
+from dataclasses import dataclass, field
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+from telegram import Update
+from telegram.ext import Application, ConversationHandler
+
+from src.bot.handlers.auth import AuthHandler
+from src.bot.handlers.start import StartHandler
+from src.bot.handlers.media import MediaHandler
+from src.bot.handlers.help import HelpHandler
+from src.bot.handlers.system import SystemHandler
+from src.bot.handlers.settings import SettingsHandler
+from src.bot.handlers.delete import DeleteHandler
+from src.bot.handlers.library import LibraryHandler
+from src.bot.handlers.calendar import CalendarHandler
+from src.bot.handlers.missing import MissingHandler
+from src.bot.handlers.queue import QueueHandler
+from src.bot.handlers.downloads import DownloadsHandler
+from src.bot.handlers.preferences import PreferencesHandler
+from src.config.settings import config
+
+
+# ---- Response capture -------------------------------------------------------
+
+@dataclass
+class BotResponse:
+    """A captured outgoing bot API call."""
+    method: str
+    text: str = ""
+    chat_id: int = 0
+    reply_markup: Optional[dict] = None
+    photo: Optional[str] = None
+    raw: dict = field(default_factory=dict)
+
+
+def _extract_response(endpoint: str, data: dict) -> BotResponse:
+    """Convert a raw _do_post call into a BotResponse."""
+    text = data.get("text", "") or data.get("caption", "")
+    chat_id = data.get("chat_id", 0)
+    reply_markup = data.get("reply_markup")
+    photo = data.get("photo")
+    return BotResponse(
+        method=endpoint,
+        text=str(text),
+        chat_id=int(chat_id) if chat_id else 0,
+        reply_markup=reply_markup,
+        photo=photo,
+        raw=data,
+    )
+
+
+# Minimal fake API results keyed by endpoint.
+# _do_post must return dicts that PTB can parse into objects.
+_FAKE_RESULTS = {
+    "getMe": {
+        "id": 999,
+        "is_bot": True,
+        "first_name": "AddarrTestBot",
+        "username": "addarr_test_bot",
+    },
+    "sendMessage": {
+        "message_id": 100,
+        "date": 0,
+        "chat": {"id": 12345, "type": "private"},
+        "text": "",
+    },
+    "editMessageText": {
+        "message_id": 100,
+        "date": 0,
+        "chat": {"id": 12345, "type": "private"},
+        "text": "",
+    },
+    "editMessageCaption": {
+        "message_id": 100,
+        "date": 0,
+        "chat": {"id": 12345, "type": "private"},
+    },
+    "editMessageReplyMarkup": {
+        "message_id": 100,
+        "date": 0,
+        "chat": {"id": 12345, "type": "private"},
+    },
+    "sendPhoto": {
+        "message_id": 100,
+        "date": 0,
+        "chat": {"id": 12345, "type": "private"},
+    },
+    "deleteMessage": True,
+    "answerCallbackQuery": True,
+}
+
+
+# ---- Update factories -------------------------------------------------------
+
+_update_counter = 0
+
+
+def _next_update_id():
+    global _update_counter
+    _update_counter += 1
+    return _update_counter
+
+
+def make_command_update(command: str, user_id: int = 12345, chat_id: int = 12345):
+    """Build a real Update for a /command message."""
+    text = command if command.startswith("/") else f"/{command}"
+    return {
+        "update_id": _next_update_id(),
+        "message": {
+            "message_id": _next_update_id(),
+            "date": 0,
+            "chat": {"id": chat_id, "type": "private"},
+            "from": {
+                "id": user_id,
+                "is_bot": False,
+                "first_name": "Test",
+                "username": "testuser",
+            },
+            "text": text,
+            "entities": [
+                {"type": "bot_command", "offset": 0, "length": len(text.split()[0])}
+            ],
+        },
+    }
+
+
+def make_text_update(text: str, user_id: int = 12345, chat_id: int = 12345):
+    """Build a real Update for a plain text message."""
+    return {
+        "update_id": _next_update_id(),
+        "message": {
+            "message_id": _next_update_id(),
+            "date": 0,
+            "chat": {"id": chat_id, "type": "private"},
+            "from": {
+                "id": user_id,
+                "is_bot": False,
+                "first_name": "Test",
+                "username": "testuser",
+            },
+            "text": text,
+        },
+    }
+
+
+def make_callback_update(
+    callback_data: str,
+    user_id: int = 12345,
+    chat_id: int = 12345,
+    message_id: int = 100,
+):
+    """Build a real Update for a callback query (inline button tap)."""
+    return {
+        "update_id": _next_update_id(),
+        "callback_query": {
+            "id": str(_next_update_id()),
+            "chat_instance": "test",
+            "from": {
+                "id": user_id,
+                "is_bot": False,
+                "first_name": "Test",
+                "username": "testuser",
+            },
+            "data": callback_data,
+            "message": {
+                "message_id": message_id,
+                "date": 0,
+                "chat": {"id": chat_id, "type": "private"},
+                "from": {
+                    "id": 0,
+                    "is_bot": True,
+                    "first_name": "AddarrBot",
+                },
+                "text": "previous message",
+            },
+        },
+    }
+
+
+# ---- BotHarness -------------------------------------------------------------
+
+class BotHarness:
+    """Drives a real PTB Application with all handlers, no Telegram connection.
+
+    Intercepts Bot._do_post to capture outgoing API calls and return
+    plausible fake results so PTB's internals don't break.
+    """
+
+    def __init__(self, app: Application):
+        self.app = app
+        self.responses: list[BotResponse] = []
+        self._last_message_id = 100
+
+    @property
+    def last_response(self) -> Optional[BotResponse]:
+        return self.responses[-1] if self.responses else None
+
+    def _next_message_id(self) -> int:
+        self._last_message_id += 1
+        return self._last_message_id
+
+    async def _fake_do_request(self, url, method, request_data=None, **kwargs):
+        """Intercept HTTPXRequest.do_request — the lowest network layer.
+
+        Returns (status_code, response_bytes) in Telegram Bot API format:
+        {"ok": true, "result": <payload>}
+        """
+        # Extract endpoint name from URL (e.g., ".../bot0:TEST/sendMessage")
+        endpoint = url.rsplit("/", 1)[-1] if "/" in url else url
+
+        # Extract parameters from request_data
+        data = {}
+        if request_data and request_data.json_parameters:
+            data = dict(request_data.json_parameters)
+
+        # Don't capture internal calls like getMe
+        if endpoint not in ("getMe",):
+            self.responses.append(_extract_response(endpoint, data))
+
+        # Build a plausible result
+        result = _FAKE_RESULTS.get(endpoint)
+        if isinstance(result, dict):
+            result = dict(result)
+            result["message_id"] = self._next_message_id()
+            if "text" in data:
+                result["text"] = data["text"]
+            if "caption" in data:
+                result["caption"] = data["caption"]
+        elif result is None:
+            result = True
+
+        payload = json_mod.dumps({"ok": True, "result": result}).encode()
+        return 200, payload
+
+    def _clear(self):
+        """Clear captured responses for the next interaction step."""
+        self.responses.clear()
+
+    async def send_command(self, command: str, user_id: int = 12345) -> Optional[BotResponse]:
+        """Simulate user sending a /command."""
+        self._clear()
+        update_data = make_command_update(command, user_id=user_id)
+        update = Update.de_json(update_data, self.app.bot)
+        await self.app.process_update(update)
+        return self.last_response
+
+    async def send_text(self, text: str, user_id: int = 12345) -> Optional[BotResponse]:
+        """Simulate user typing a plain text message."""
+        self._clear()
+        update_data = make_text_update(text, user_id=user_id)
+        update = Update.de_json(update_data, self.app.bot)
+        await self.app.process_update(update)
+        return self.last_response
+
+    def get_conversation_state(
+        self, handler_name: str, chat_id: int = 12345, user_id: int = 12345
+    ) -> Optional[int]:
+        """Get the current state of a named ConversationHandler.
+
+        Returns the state integer (e.g. SEARCHING=1) or None if not in conversation.
+        """
+        for group_handlers in self.app.handlers.values():
+            for handler in group_handlers:
+                if (
+                    isinstance(handler, ConversationHandler)
+                    and handler.name == handler_name
+                ):
+                    key = (chat_id, user_id)
+                    conversations = handler._conversations
+                    if key in conversations:
+                        # PTB stores state as a tuple: (state,) or just state
+                        state = conversations[key]
+                        if isinstance(state, tuple):
+                            return state[0]
+                        return state
+                    return None
+        return None
+
+    async def tap_button(
+        self, callback_data: str, user_id: int = 12345, message_id: int = 100
+    ) -> Optional[BotResponse]:
+        """Simulate user tapping an inline keyboard button."""
+        self._clear()
+        update_data = make_callback_update(
+            callback_data, user_id=user_id, message_id=message_id
+        )
+        update = Update.de_json(update_data, self.app.bot)
+        await self.app.process_update(update)
+        return self.last_response
+
+
+# ---- Application builder ----------------------------------------------------
+
+def _register_handlers(app: Application):
+    """Register handlers in the same order as AddarrBot._add_handlers()."""
+    handler_classes = [
+        StartHandler,
+        AuthHandler,
+        MediaHandler,
+        SettingsHandler,
+        DeleteHandler,
+        LibraryHandler,
+        CalendarHandler,
+        MissingHandler,
+        QueueHandler,
+        HelpHandler,
+        PreferencesHandler,
+        SystemHandler,
+    ]
+
+    # Conditionally add download handlers
+    if config.get("transmission", {}).get("enable", False):
+        from src.bot.handlers.transmission import TransmissionHandler
+        handler_classes.append(TransmissionHandler)
+
+    if config.get("sabnzbd", {}).get("enable", False):
+        from src.bot.handlers.sabnzbd import SabnzbdHandler
+        handler_classes.append(SabnzbdHandler)
+
+    # Downloads handler checks is_enabled internally
+    handler_classes.append(DownloadsHandler)
+
+    for cls in handler_classes:
+        instance = cls()
+        for handler in instance.get_handler():
+            app.add_handler(handler)
+
+
+def _build_application() -> Application:
+    """Build a real Application with handlers (not yet initialized)."""
+    app = Application.builder().token("0:TEST").build()
+    _register_handlers(app)
+    return app
+
+
+# ---- Fixtures ----------------------------------------------------------------
+
+@pytest.fixture
+async def harness():
+    """Provide a BotHarness with a fully wired Application."""
+    # Pre-seed authenticated user so most tests pass auth checks
+    AuthHandler._authenticated_users.add(12345)
+
+    app = _build_application()
+    h = BotHarness(app)
+
+    # Patch do_request on BOTH HTTPXRequest instances (regular + getUpdates)
+    # This must happen BEFORE initialize() so getMe doesn't hit the network
+    with patch(
+        "telegram.request.HTTPXRequest.do_request",
+        side_effect=h._fake_do_request,
+    ):
+        await app.initialize()
+        yield h
+
+    await app.shutdown()

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -1,0 +1,143 @@
+"""
+Shared test data for integration tests.
+
+Provides reusable search results, quality selection results, and queue data
+used across multiple test files.
+"""
+
+MOVIE_SEARCH_RESULTS = [
+    {
+        "id": "550",
+        "title": "Fight Club (1999)",
+        "overview": "An insomniac office worker...",
+        "year": 1999,
+        "poster": None,
+        "ratings": {"imdb": 8.8, "rottenTomatoes": 79},
+        "studio": "Fox 2000 Pictures",
+        "status": "released",
+        "runtime": 139,
+        "genres": ["Drama", "Thriller"],
+        "data": {"tmdbId": 550, "title": "Fight Club"},
+    },
+]
+
+MOVIE_QUALITY_RESULT = {
+    "type": "quality_selection",
+    "profiles": [
+        {"id": 1, "name": "HD-1080p"},
+        {"id": 2, "name": "Ultra-HD"},
+    ],
+    "root_folder": "/movies",
+    "movie": {"tmdbId": 550, "title": "Fight Club"},
+}
+
+SERIES_SEARCH_RESULTS = [
+    {
+        "id": "81189",
+        "title": "Breaking Bad (2008)",
+        "overview": "A high school chemistry teacher...",
+        "year": 2008,
+        "poster": None,
+        "ratings": {"tmdb": 8.9, "votes": 1000},
+        "network": "AMC",
+        "studio": "N/A",
+        "status": "ended",
+        "seasons": 2,
+        "runtime": 45,
+        "genres": ["Drama", "Thriller"],
+        "data": {"tvdbId": 81189, "title": "Breaking Bad"},
+    },
+]
+
+SERIES_QUALITY_RESULT = {
+    "type": "quality_selection",
+    "profiles": [
+        {"id": 1, "name": "HD-1080p"},
+    ],
+    "root_folder": "/tv",
+    "series": {"tvdbId": 81189, "title": "Breaking Bad"},
+    "seasons": [
+        {"seasonNumber": 1, "monitored": True},
+        {"seasonNumber": 2, "monitored": True},
+    ],
+}
+
+MUSIC_ARTIST_RESULTS = [
+    {
+        "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+        "title": "Linkin Park",
+        "overview": "Linkin Park is an American rock band...",
+        "year": 1996,
+        "poster": None,
+        "rating": 8.5,
+        "genres": "Rock, Nu Metal",
+        "type": "Group",
+        "status": "active",
+        "music_type": "artist",
+        "data": {
+            "foreignArtistId": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+            "artistName": "Linkin Park",
+        },
+    },
+]
+
+MUSIC_QUALITY_RESULT = {
+    "type": "quality_selection",
+    "profiles": [
+        {"id": 1, "name": "Lossless"},
+    ],
+    "root_folder": "/music",
+}
+
+MUSIC_ALBUM_RESULTS = [
+    {
+        "id": "album:b1ae2a0f",
+        "title": "Hybrid Theory",
+        "overview": "Debut studio album",
+        "year": 2000,
+        "poster": None,
+        "rating": 8.5,
+        "genres": "Rock",
+        "type": "Album",
+        "status": "released",
+        "music_type": "album",
+        "artist_name": "Linkin Park",
+        "artist_id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+        "album_id": "b1ae2a0f",
+        "data": {},
+    },
+]
+
+MUSIC_ALBUM_QUALITY_RESULT = {
+    "type": "quality_selection",
+    "profiles": [
+        {"id": 1, "name": "Lossless"},
+    ],
+    "root_folder": "/music",
+}
+
+DOWNLOADS_QUEUE = {
+    "paused": False,
+    "speed": "5.2 MB/s",
+    "size_remaining": "1.5 GB",
+    "items_count": 1,
+    "items": [
+        {
+            "id": "abc123",
+            "name": "Ubuntu.22.04.nzb",
+            "status": "Downloading",
+            "progress": 45.0,
+            "size": "2.1 GB",
+            "speed": "5.2 MB/s",
+            "timeleft": "00:04:30",
+        },
+    ],
+}
+
+DOWNLOADS_EMPTY_QUEUE = {
+    "paused": False,
+    "speed": "0 B/s",
+    "size_remaining": "0 MB",
+    "items_count": 0,
+    "items": [],
+}

--- a/tests/integration/test_api_mocks.py
+++ b/tests/integration/test_api_mocks.py
@@ -1,0 +1,63 @@
+"""
+Tests for API mock helpers.
+
+Validates that mock helpers correctly intercept aiohttp calls
+for Radarr, Sonarr, and Lidarr API clients.
+"""
+
+import pytest
+
+from tests.integration.api_mocks import RadarrMockHelper, SonarrMockHelper, LidarrMockHelper
+
+
+@pytest.mark.asyncio
+async def test_radarr_mock_search_returns_results(aio_mock):
+    """Radarr mock helper intercepts search and returns configured results."""
+    helper = RadarrMockHelper(aio_mock)
+    helper.search_returns([
+        {"tmdbId": 550, "title": "Fight Club", "year": 1999},
+    ])
+
+    from src.api.radarr import RadarrClient
+    client = RadarrClient()
+    try:
+        results = await client.search("fight club")
+        assert len(results) == 1
+        assert results[0]["title"] == "Fight Club"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_sonarr_mock_quality_profiles(aio_mock):
+    """Sonarr mock helper intercepts quality profile endpoint."""
+    helper = SonarrMockHelper(aio_mock)
+    profiles = [
+        {"id": 1, "name": "HD-1080p"},
+        {"id": 2, "name": "Ultra-HD"},
+    ]
+    helper.quality_profiles(profiles)
+
+    from src.api.sonarr import SonarrClient
+    client = SonarrClient()
+    try:
+        result = await client.get_quality_profiles()
+        assert len(result) == 2
+        assert result[0]["name"] == "HD-1080p"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_mock_helper_defaults_return_empty_search(aio_mock):
+    """set_defaults() configures empty search results by default."""
+    helper = RadarrMockHelper(aio_mock)
+    helper.set_defaults()
+
+    from src.api.radarr import RadarrClient
+    client = RadarrClient()
+    try:
+        results = await client.search("nonexistent")
+        assert results == []
+    finally:
+        await client.close()

--- a/tests/integration/test_api_mocks.py
+++ b/tests/integration/test_api_mocks.py
@@ -7,7 +7,7 @@ for Radarr, Sonarr, and Lidarr API clients.
 
 import pytest
 
-from tests.integration.api_mocks import RadarrMockHelper, SonarrMockHelper, LidarrMockHelper
+from tests.integration.api_mocks import RadarrMockHelper, SonarrMockHelper
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_auth_flow.py
+++ b/tests/integration/test_auth_flow.py
@@ -1,0 +1,61 @@
+"""
+Integration tests for the authentication conversation flow.
+
+Tests the full /auth -> password -> authenticated/rejected cycle.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from src.bot.handlers.auth import AuthHandler
+
+
+@pytest.mark.asyncio
+async def test_auth_correct_password(harness):
+    """Unauthenticated user sends /auth, types correct password, becomes authenticated."""
+    # Remove pre-seeded auth
+    AuthHandler._authenticated_users.discard(12345)
+
+    with patch.object(AuthHandler, "_save_authenticated_users"):
+        resp = await harness.send_command("/auth")
+        assert resp is not None
+        # Should ask for password ("Authorize" translation key)
+        assert resp.text
+
+        # Type correct password
+        resp = await harness.send_text("test-pass")
+        # check_password deletes the message, then sends success
+        assert len(harness.responses) >= 1
+        # User should now be authenticated
+        assert AuthHandler.is_authenticated(12345)
+
+
+@pytest.mark.asyncio
+async def test_auth_wrong_password(harness):
+    """Unauthenticated user sends wrong password, stays unauthenticated."""
+    AuthHandler._authenticated_users.discard(12345)
+
+    with patch.object(AuthHandler, "_save_authenticated_users"):
+        await harness.send_command("/auth")
+        resp = await harness.send_text("wrong-password")
+        assert len(harness.responses) >= 1
+        # User should NOT be authenticated
+        assert not AuthHandler.is_authenticated(12345)
+
+
+@pytest.mark.asyncio
+async def test_auth_then_movie(harness):
+    """Authenticate first, then /movie should enter SEARCHING state."""
+    AuthHandler._authenticated_users.discard(12345)
+
+    with patch.object(AuthHandler, "_save_authenticated_users"):
+        await harness.send_command("/auth")
+        await harness.send_text("test-pass")
+        assert AuthHandler.is_authenticated(12345)
+
+    # Now send /movie — should proceed since authenticated
+    resp = await harness.send_command("/movie")
+    assert resp is not None
+    assert "Title" in resp.text
+    state = harness.get_conversation_state("media_conversation", 12345, 12345)
+    assert state == 1  # SEARCHING

--- a/tests/integration/test_auth_flow.py
+++ b/tests/integration/test_auth_flow.py
@@ -8,6 +8,7 @@ import pytest
 from unittest.mock import patch
 
 from src.bot.handlers.auth import AuthHandler
+from src.bot.handlers.media.dispatch import SEARCHING
 
 
 @pytest.mark.asyncio
@@ -58,4 +59,4 @@ async def test_auth_then_movie(harness):
     assert resp is not None
     assert "Title" in resp.text
     state = harness.get_conversation_state("media_conversation", 12345, 12345)
-    assert state == 1  # SEARCHING
+    assert state == SEARCHING

--- a/tests/integration/test_auth_flow.py
+++ b/tests/integration/test_auth_flow.py
@@ -23,7 +23,7 @@ async def test_auth_correct_password(harness):
         assert resp.text
 
         # Type correct password
-        resp = await harness.send_text("test-pass")
+        await harness.send_text("test-pass")
         # check_password deletes the message, then sends success
         assert len(harness.responses) >= 1
         # User should now be authenticated
@@ -37,7 +37,7 @@ async def test_auth_wrong_password(harness):
 
     with patch.object(AuthHandler, "_save_authenticated_users"):
         await harness.send_command("/auth")
-        resp = await harness.send_text("wrong-password")
+        await harness.send_text("wrong-password")
         assert len(harness.responses) >= 1
         # User should NOT be authenticated
         assert not AuthHandler.is_authenticated(12345)

--- a/tests/integration/test_auth_gating.py
+++ b/tests/integration/test_auth_gating.py
@@ -1,0 +1,42 @@
+"""
+Tests for auth pre-seeding and conversation state inspection.
+
+Validates that:
+1. Unauthenticated users are blocked from protected commands
+2. Authenticated users proceed into conversation flows
+3. Conversation state is inspectable via BotHarness
+"""
+
+import pytest
+
+from src.bot.handlers.auth import AuthHandler
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_user_blocked(harness):
+    """Unauthenticated user sending /movie gets auth-required message."""
+    # Remove the default pre-seeded user
+    AuthHandler._authenticated_users.discard(12345)
+
+    resp = await harness.send_command("/movie")
+    assert resp is not None
+    assert "authenticate" in resp.text.lower() or "auth" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_authenticated_user_proceeds(harness):
+    """Authenticated user sending /movie gets the search prompt."""
+    # User 12345 is pre-seeded by the harness fixture
+    resp = await harness.send_command("/movie")
+    assert resp is not None
+    # TranslationService mock returns the key, so we expect "Title"
+    assert "Title" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_conversation_state_after_command(harness):
+    """After /movie, harness reports conversation is in SEARCHING state."""
+    await harness.send_command("/movie")
+    state = harness.get_conversation_state("media_conversation", 12345, 12345)
+    # SEARCHING = 1 (from dispatch.py)
+    assert state == 1

--- a/tests/integration/test_auth_gating.py
+++ b/tests/integration/test_auth_gating.py
@@ -10,6 +10,7 @@ Validates that:
 import pytest
 
 from src.bot.handlers.auth import AuthHandler
+from src.bot.handlers.media.dispatch import SEARCHING
 
 
 @pytest.mark.asyncio
@@ -38,5 +39,4 @@ async def test_conversation_state_after_command(harness):
     """After /movie, harness reports conversation is in SEARCHING state."""
     await harness.send_command("/movie")
     state = harness.get_conversation_state("media_conversation", 12345, 12345)
-    # SEARCHING = 1 (from dispatch.py)
-    assert state == 1
+    assert state == SEARCHING

--- a/tests/integration/test_cancel_flow.py
+++ b/tests/integration/test_cancel_flow.py
@@ -10,29 +10,9 @@ from unittest.mock import AsyncMock, patch
 
 from src.services.media import MediaService
 
+from tests.integration.fixtures import MOVIE_SEARCH_RESULTS, MOVIE_QUALITY_RESULT
 
-SEARCH_RESULTS = [
-    {
-        "id": "550",
-        "title": "Fight Club (1999)",
-        "overview": "An insomniac office worker...",
-        "year": 1999,
-        "poster": None,
-        "ratings": {"imdb": 8.8, "rottenTomatoes": 79},
-        "studio": "Fox 2000 Pictures",
-        "status": "released",
-        "runtime": 139,
-        "genres": ["Drama", "Thriller"],
-        "data": {"tmdbId": 550, "title": "Fight Club"},
-    },
-]
-
-QUALITY_RESULT = {
-    "type": "quality_selection",
-    "profiles": [{"id": 1, "name": "HD-1080p"}],
-    "root_folder": "/movies",
-    "movie": {"tmdbId": 550, "title": "Fight Club"},
-}
+MEDIA_CONVERSATION = "media_conversation"
 
 
 @pytest.mark.asyncio
@@ -40,8 +20,8 @@ QUALITY_RESULT = {
 async def test_cancel_movie_at_every_state(harness, cancel_at):
     """Cancel at each conversation stage returns cancel message."""
     with (
-        patch.object(MediaService, "search_movies", new_callable=AsyncMock, return_value=SEARCH_RESULTS),
-        patch.object(MediaService, "add_movie", new_callable=AsyncMock, return_value=QUALITY_RESULT),
+        patch.object(MediaService, "search_movies", new_callable=AsyncMock, return_value=MOVIE_SEARCH_RESULTS),
+        patch.object(MediaService, "add_movie", new_callable=AsyncMock, return_value=MOVIE_QUALITY_RESULT),
     ):
         await harness.send_command("/movie")
 
@@ -59,7 +39,7 @@ async def test_cancel_movie_at_every_state(harness, cancel_at):
         assert "cancel" in resp.text.lower()
 
         # Conversation should have ended
-        state = harness.get_conversation_state("media_conversation", 12345, 12345)
+        state = harness.get_conversation_state(MEDIA_CONVERSATION, 12345, 12345)
         assert state is None
 
 
@@ -71,5 +51,5 @@ async def test_cancel_command_fallback(harness):
     assert resp is not None
     assert "cancel" in resp.text.lower()
 
-    state = harness.get_conversation_state("media_conversation", 12345, 12345)
+    state = harness.get_conversation_state(MEDIA_CONVERSATION, 12345, 12345)
     assert state is None

--- a/tests/integration/test_cancel_flow.py
+++ b/tests/integration/test_cancel_flow.py
@@ -1,0 +1,75 @@
+"""
+Integration tests for cancel at every conversation stage.
+
+Parametrized tests ensuring cancel works at SEARCHING, SELECTING,
+QUALITY_SELECT stages and /cancel command fallback.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.media import MediaService
+
+
+SEARCH_RESULTS = [
+    {
+        "id": "550",
+        "title": "Fight Club (1999)",
+        "overview": "An insomniac office worker...",
+        "year": 1999,
+        "poster": None,
+        "ratings": {"imdb": 8.8, "rottenTomatoes": 79},
+        "studio": "Fox 2000 Pictures",
+        "status": "released",
+        "runtime": 139,
+        "genres": ["Drama", "Thriller"],
+        "data": {"tmdbId": 550, "title": "Fight Club"},
+    },
+]
+
+QUALITY_RESULT = {
+    "type": "quality_selection",
+    "profiles": [{"id": 1, "name": "HD-1080p"}],
+    "root_folder": "/movies",
+    "movie": {"tmdbId": 550, "title": "Fight Club"},
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_at", ["searching", "selecting", "quality"])
+async def test_cancel_movie_at_every_state(harness, cancel_at):
+    """Cancel at each conversation stage returns cancel message."""
+    with (
+        patch.object(MediaService, "search_movies", new_callable=AsyncMock, return_value=SEARCH_RESULTS),
+        patch.object(MediaService, "add_movie", new_callable=AsyncMock, return_value=QUALITY_RESULT),
+    ):
+        await harness.send_command("/movie")
+
+        if cancel_at == "searching":
+            resp = await harness.tap_button("menu_cancel")
+        elif cancel_at == "selecting":
+            await harness.send_text("fight club")
+            resp = await harness.tap_button("select_cancel")
+        elif cancel_at == "quality":
+            await harness.send_text("fight club")
+            await harness.tap_button("select_550")
+            resp = await harness.tap_button("quality_cancel")
+
+        assert resp is not None
+        assert "cancel" in resp.text.lower()
+
+        # Conversation should have ended
+        state = harness.get_conversation_state("media_conversation", 12345, 12345)
+        assert state is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_command_fallback(harness):
+    """Send /cancel during conversation, assert conversation ends."""
+    await harness.send_command("/movie")
+    resp = await harness.send_command("/cancel")
+    assert resp is not None
+    assert "cancel" in resp.text.lower()
+
+    state = harness.get_conversation_state("media_conversation", 12345, 12345)
+    assert state is None

--- a/tests/integration/test_downloads_flow.py
+++ b/tests/integration/test_downloads_flow.py
@@ -1,0 +1,108 @@
+"""
+Integration tests for the /downloads dashboard.
+
+Uses downloads_harness fixture which enables both Transmission and SABnzbd
+services so DownloadsHandler registers its handlers.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.transmission import TransmissionService
+from src.services.sabnzbd import SABnzbdService
+
+
+MOCK_QUEUE = {
+    "paused": False,
+    "speed": "5.2 MB/s",
+    "size_remaining": "1.5 GB",
+    "items_count": 1,
+    "items": [
+        {
+            "id": "abc123",
+            "name": "Ubuntu.22.04.nzb",
+            "status": "Downloading",
+            "progress": 45.0,
+            "size": "2.1 GB",
+            "speed": "5.2 MB/s",
+            "timeleft": "00:04:30",
+        },
+    ],
+}
+
+EMPTY_QUEUE = {
+    "paused": False,
+    "speed": "0 B/s",
+    "size_remaining": "0 MB",
+    "items_count": 0,
+    "items": [],
+}
+
+
+@pytest.mark.asyncio
+async def test_downloads_command_shows_queue(downloads_harness):
+    """/downloads with Transmission enabled shows queue."""
+    with patch.object(
+        TransmissionService, "get_queue_details",
+        new_callable=AsyncMock, return_value=MOCK_QUEUE,
+    ):
+        resp = await downloads_harness.send_command("/downloads")
+        assert resp is not None
+        assert resp.method == "sendMessage"
+        assert resp.text  # Should have queue text
+
+
+@pytest.mark.asyncio
+async def test_downloads_sabnzbd_queue(downloads_harness):
+    """/downloads then switch to SABnzbd shows its queue."""
+    with (
+        patch.object(
+            TransmissionService, "get_queue_details",
+            new_callable=AsyncMock, return_value=EMPTY_QUEUE,
+        ),
+        patch.object(
+            SABnzbdService, "get_queue_details",
+            new_callable=AsyncMock, return_value=MOCK_QUEUE,
+        ),
+    ):
+        await downloads_harness.send_command("/downloads")
+        resp = await downloads_harness.tap_button("dl_client_sab")
+        assert resp is not None
+        assert resp.text
+
+
+@pytest.mark.asyncio
+async def test_downloads_client_switch(downloads_harness):
+    """Switch between Transmission and SABnzbd clients."""
+    with (
+        patch.object(
+            TransmissionService, "get_queue_details",
+            new_callable=AsyncMock, return_value=EMPTY_QUEUE,
+        ),
+        patch.object(
+            SABnzbdService, "get_queue_details",
+            new_callable=AsyncMock, return_value=MOCK_QUEUE,
+        ),
+    ):
+        await downloads_harness.send_command("/downloads")
+
+        # Switch to SABnzbd
+        resp = await downloads_harness.tap_button("dl_client_sab")
+        assert resp is not None
+
+        # Switch back to Transmission
+        resp = await downloads_harness.tap_button("dl_client_tx")
+        assert resp is not None
+
+
+@pytest.mark.asyncio
+async def test_downloads_refresh(downloads_harness):
+    """Tap refresh, assert queue re-fetched."""
+    with patch.object(
+        TransmissionService, "get_queue_details",
+        new_callable=AsyncMock, return_value=MOCK_QUEUE,
+    ):
+        await downloads_harness.send_command("/downloads")
+        resp = await downloads_harness.tap_button("dl_refresh")
+        assert resp is not None
+        assert resp.text

--- a/tests/integration/test_downloads_flow.py
+++ b/tests/integration/test_downloads_flow.py
@@ -11,32 +11,7 @@ from unittest.mock import AsyncMock, patch
 from src.services.transmission import TransmissionService
 from src.services.sabnzbd import SABnzbdService
 
-
-MOCK_QUEUE = {
-    "paused": False,
-    "speed": "5.2 MB/s",
-    "size_remaining": "1.5 GB",
-    "items_count": 1,
-    "items": [
-        {
-            "id": "abc123",
-            "name": "Ubuntu.22.04.nzb",
-            "status": "Downloading",
-            "progress": 45.0,
-            "size": "2.1 GB",
-            "speed": "5.2 MB/s",
-            "timeleft": "00:04:30",
-        },
-    ],
-}
-
-EMPTY_QUEUE = {
-    "paused": False,
-    "speed": "0 B/s",
-    "size_remaining": "0 MB",
-    "items_count": 0,
-    "items": [],
-}
+from tests.integration.fixtures import DOWNLOADS_QUEUE, DOWNLOADS_EMPTY_QUEUE
 
 
 @pytest.mark.asyncio
@@ -44,12 +19,12 @@ async def test_downloads_command_shows_queue(downloads_harness):
     """/downloads with Transmission enabled shows queue."""
     with patch.object(
         TransmissionService, "get_queue_details",
-        new_callable=AsyncMock, return_value=MOCK_QUEUE,
+        new_callable=AsyncMock, return_value=DOWNLOADS_QUEUE,
     ):
         resp = await downloads_harness.send_command("/downloads")
         assert resp is not None
         assert resp.method == "sendMessage"
-        assert resp.text  # Should have queue text
+        assert resp.text
 
 
 @pytest.mark.asyncio
@@ -58,11 +33,11 @@ async def test_downloads_sabnzbd_queue(downloads_harness):
     with (
         patch.object(
             TransmissionService, "get_queue_details",
-            new_callable=AsyncMock, return_value=EMPTY_QUEUE,
+            new_callable=AsyncMock, return_value=DOWNLOADS_EMPTY_QUEUE,
         ),
         patch.object(
             SABnzbdService, "get_queue_details",
-            new_callable=AsyncMock, return_value=MOCK_QUEUE,
+            new_callable=AsyncMock, return_value=DOWNLOADS_QUEUE,
         ),
     ):
         await downloads_harness.send_command("/downloads")
@@ -77,11 +52,11 @@ async def test_downloads_client_switch(downloads_harness):
     with (
         patch.object(
             TransmissionService, "get_queue_details",
-            new_callable=AsyncMock, return_value=EMPTY_QUEUE,
+            new_callable=AsyncMock, return_value=DOWNLOADS_EMPTY_QUEUE,
         ),
         patch.object(
             SABnzbdService, "get_queue_details",
-            new_callable=AsyncMock, return_value=MOCK_QUEUE,
+            new_callable=AsyncMock, return_value=DOWNLOADS_QUEUE,
         ),
     ):
         await downloads_harness.send_command("/downloads")
@@ -100,7 +75,7 @@ async def test_downloads_refresh(downloads_harness):
     """Tap refresh, assert queue re-fetched."""
     with patch.object(
         TransmissionService, "get_queue_details",
-        new_callable=AsyncMock, return_value=MOCK_QUEUE,
+        new_callable=AsyncMock, return_value=DOWNLOADS_QUEUE,
     ):
         await downloads_harness.send_command("/downloads")
         resp = await downloads_harness.tap_button("dl_refresh")

--- a/tests/integration/test_media_flow.py
+++ b/tests/integration/test_media_flow.py
@@ -1,0 +1,117 @@
+"""
+Integration tests for the movie search -> select -> quality -> added flow.
+
+Tests the full conversation lifecycle through real PTB handlers,
+mocking MediaService methods on the singleton instance since the
+handler holds a reference obtained at construction time.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.media import MediaService
+
+
+MOVIE_SEARCH_RESULTS = [
+    {
+        "id": "550",
+        "title": "Fight Club (1999)",
+        "overview": "An insomniac office worker...",
+        "year": 1999,
+        "poster": None,
+        "ratings": {"imdb": 8.8, "rottenTomatoes": 79},
+        "studio": "Fox 2000 Pictures",
+        "status": "released",
+        "runtime": 139,
+        "genres": ["Drama", "Thriller"],
+        "data": {"tmdbId": 550, "title": "Fight Club"},
+    },
+]
+
+QUALITY_SELECTION_RESULT = {
+    "type": "quality_selection",
+    "profiles": [
+        {"id": 1, "name": "HD-1080p"},
+        {"id": 2, "name": "Ultra-HD"},
+    ],
+    "root_folder": "/movies",
+    "movie": {"tmdbId": 550, "title": "Fight Club"},
+}
+
+
+@pytest.mark.asyncio
+async def test_movie_happy_path(harness):
+    """/movie -> search -> select -> quality -> added."""
+    with (
+        patch.object(MediaService, "search_movies", new_callable=AsyncMock, return_value=MOVIE_SEARCH_RESULTS),
+        patch.object(MediaService, "add_movie", new_callable=AsyncMock, return_value=QUALITY_SELECTION_RESULT),
+        patch.object(MediaService, "add_movie_with_profile", new_callable=AsyncMock, return_value=(True, "Fight Club added successfully")),
+    ):
+        # Step 1: /movie -> SEARCHING
+        resp = await harness.send_command("/movie")
+        assert resp is not None
+        assert "Title" in resp.text
+
+        # Step 2: Type search query -> SELECTING
+        resp = await harness.send_text("fight club")
+        assert resp is not None
+        assert len(harness.responses) >= 1
+
+        # Step 3: Select the result -> QUALITY_SELECT
+        resp = await harness.tap_button("select_550")
+        assert resp is not None
+        assert "quality" in resp.text.lower() or "HD-1080p" in resp.text
+
+        # Step 4: Select quality profile -> END
+        resp = await harness.tap_button("quality_1")
+        assert resp is not None
+        assert "added" in resp.text.lower() or "Fight Club" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_movie_no_results(harness):
+    """/movie -> search with no results -> conversation ends."""
+    with patch.object(MediaService, "search_movies", new_callable=AsyncMock, return_value=[]):
+        await harness.send_command("/movie")
+        resp = await harness.send_text("xyznonexistent")
+        assert resp is not None
+        assert "no" in resp.text.lower() or "not found" in resp.text.lower()
+
+        # Conversation should have ended
+        state = harness.get_conversation_state("media_conversation", 12345, 12345)
+        assert state is None
+
+
+@pytest.mark.asyncio
+async def test_movie_cancel_at_search(harness):
+    """/movie -> cancel at SEARCHING state."""
+    await harness.send_command("/movie")
+    resp = await harness.tap_button("menu_cancel")
+    assert resp is not None
+    assert "cancel" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_movie_cancel_at_selection(harness):
+    """Search -> results shown -> cancel at SELECTING state."""
+    with patch.object(MediaService, "search_movies", new_callable=AsyncMock, return_value=MOVIE_SEARCH_RESULTS):
+        await harness.send_command("/movie")
+        await harness.send_text("fight club")
+        resp = await harness.tap_button("select_cancel")
+        assert resp is not None
+        assert "cancel" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_movie_cancel_at_quality(harness):
+    """Select result -> quality shown -> cancel at QUALITY_SELECT state."""
+    with (
+        patch.object(MediaService, "search_movies", new_callable=AsyncMock, return_value=MOVIE_SEARCH_RESULTS),
+        patch.object(MediaService, "add_movie", new_callable=AsyncMock, return_value=QUALITY_SELECTION_RESULT),
+    ):
+        await harness.send_command("/movie")
+        await harness.send_text("fight club")
+        await harness.tap_button("select_550")
+        resp = await harness.tap_button("quality_cancel")
+        assert resp is not None
+        assert "cancel" in resp.text.lower()

--- a/tests/integration/test_media_flow.py
+++ b/tests/integration/test_media_flow.py
@@ -1,5 +1,5 @@
 """
-Integration tests for the movie search -> select -> quality -> added flow.
+Integration tests for media conversation flows (movie, series, music).
 
 Tests the full conversation lifecycle through real PTB handlers,
 mocking MediaService methods on the singleton instance since the
@@ -11,6 +11,8 @@ from unittest.mock import AsyncMock, patch
 
 from src.services.media import MediaService
 
+
+# --- Movie test data ---
 
 MOVIE_SEARCH_RESULTS = [
     {
@@ -115,3 +117,198 @@ async def test_movie_cancel_at_quality(harness):
         resp = await harness.tap_button("quality_cancel")
         assert resp is not None
         assert "cancel" in resp.text.lower()
+
+
+# --- Series test data ---
+
+SERIES_SEARCH_RESULTS = [
+    {
+        "id": "81189",
+        "title": "Breaking Bad (2008)",
+        "overview": "A high school chemistry teacher...",
+        "year": 2008,
+        "poster": None,
+        "ratings": {"tmdb": 8.9, "votes": 1000},
+        "network": "AMC",
+        "studio": "N/A",
+        "status": "ended",
+        "seasons": 2,
+        "runtime": 45,
+        "genres": ["Drama", "Thriller"],
+        "data": {"tvdbId": 81189, "title": "Breaking Bad"},
+    },
+]
+
+SERIES_QUALITY_RESULT = {
+    "type": "quality_selection",
+    "profiles": [
+        {"id": 1, "name": "HD-1080p"},
+    ],
+    "root_folder": "/tv",
+    "series": {"tvdbId": 81189, "title": "Breaking Bad"},
+    "seasons": [
+        {"seasonNumber": 1, "monitored": True},
+        {"seasonNumber": 2, "monitored": True},
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_series_happy_path(harness):
+    """/series -> search -> select -> quality -> season select -> confirm -> added."""
+    with (
+        patch.object(MediaService, "search_series", new_callable=AsyncMock, return_value=SERIES_SEARCH_RESULTS),
+        patch.object(MediaService, "add_series", new_callable=AsyncMock, return_value=SERIES_QUALITY_RESULT),
+        patch.object(MediaService, "add_series_with_profile", new_callable=AsyncMock, return_value=(True, "Breaking Bad added successfully")),
+    ):
+        resp = await harness.send_command("/series")
+        assert "Title" in resp.text
+
+        resp = await harness.send_text("breaking bad")
+        assert len(harness.responses) >= 1
+
+        resp = await harness.tap_button("select_81189")
+        assert resp is not None
+        assert "quality" in resp.text.lower() or "HD-1080p" in resp.text
+
+        # Select quality -> should show season picker
+        resp = await harness.tap_button("quality_1")
+        assert resp is not None
+        assert "season" in resp.text.lower()
+
+        # Select individual season, then confirm
+        await harness.tap_button("season_1")
+        resp = await harness.tap_button("season_confirm")
+        assert resp is not None
+        assert "added" in resp.text.lower() or "Breaking Bad" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_series_monitor_all(harness):
+    """Select 'Monitor All' auto-confirms with all seasons."""
+    with (
+        patch.object(MediaService, "search_series", new_callable=AsyncMock, return_value=SERIES_SEARCH_RESULTS),
+        patch.object(MediaService, "add_series", new_callable=AsyncMock, return_value=SERIES_QUALITY_RESULT),
+        patch.object(MediaService, "add_series_with_profile", new_callable=AsyncMock, return_value=(True, "Breaking Bad added")),
+    ):
+        await harness.send_command("/series")
+        await harness.send_text("breaking bad")
+        await harness.tap_button("select_81189")
+        await harness.tap_button("quality_1")
+
+        # Monitor All auto-confirms
+        resp = await harness.tap_button("season_monitor_all")
+        assert resp is not None
+        assert "added" in resp.text.lower() or "Breaking Bad" in resp.text
+
+
+# --- Music test data ---
+
+MUSIC_ARTIST_RESULTS = [
+    {
+        "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+        "title": "Linkin Park",
+        "overview": "Linkin Park is an American rock band...",
+        "year": 1996,
+        "poster": None,
+        "rating": 8.5,
+        "genres": "Rock, Nu Metal",
+        "type": "Group",
+        "status": "active",
+        "music_type": "artist",
+        "data": {
+            "foreignArtistId": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+            "artistName": "Linkin Park",
+        },
+    },
+]
+
+MUSIC_QUALITY_RESULT = {
+    "type": "quality_selection",
+    "profiles": [
+        {"id": 1, "name": "Lossless"},
+    ],
+    "root_folder": "/music",
+}
+
+MUSIC_ALBUM_RESULTS = [
+    {
+        "id": "album:b1ae2a0f",
+        "title": "Hybrid Theory",
+        "overview": "Debut studio album",
+        "year": 2000,
+        "poster": None,
+        "rating": 8.5,
+        "genres": "Rock",
+        "type": "Album",
+        "status": "released",
+        "music_type": "album",
+        "artist_name": "Linkin Park",
+        "artist_id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+        "album_id": "b1ae2a0f",
+        "data": {},
+    },
+]
+
+MUSIC_ALBUM_QUALITY_RESULT = {
+    "type": "quality_selection",
+    "profiles": [
+        {"id": 1, "name": "Lossless"},
+    ],
+    "root_folder": "/music",
+}
+
+
+@pytest.mark.asyncio
+async def test_music_artist_happy_path(harness):
+    """/music -> search -> select artist -> quality -> album monitor mode -> added."""
+    with (
+        patch.object(MediaService, "search_music", new_callable=AsyncMock, return_value=MUSIC_ARTIST_RESULTS),
+        patch.object(MediaService, "add_music", new_callable=AsyncMock, return_value=MUSIC_QUALITY_RESULT),
+        patch.object(MediaService, "add_music_with_profile", new_callable=AsyncMock, return_value=(True, "Linkin Park added successfully")),
+    ):
+        resp = await harness.send_command("/music")
+        assert "Title" in resp.text
+
+        resp = await harness.send_text("linkin park")
+        assert len(harness.responses) >= 1
+
+        # Select artist
+        resp = await harness.tap_button("select_f59c5520-5f46-4d2c-b2c4-822eabf53419")
+        assert resp is not None
+        assert "quality" in resp.text.lower() or "Lossless" in resp.text
+
+        # Select quality -> album monitor mode for artists
+        resp = await harness.tap_button("quality_1")
+        assert resp is not None
+        assert "monitor" in resp.text.lower() or "album" in resp.text.lower()
+
+        # Choose "Monitor All Albums"
+        resp = await harness.tap_button("album_monitor_mode_all")
+        assert resp is not None
+        assert "added" in resp.text.lower() or "Linkin Park" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_music_album_direct_add(harness):
+    """/music -> search -> select album -> quality -> added (no album picker)."""
+    with (
+        patch.object(MediaService, "search_music", new_callable=AsyncMock, return_value=MUSIC_ALBUM_RESULTS),
+        patch.object(MediaService, "add_music", new_callable=AsyncMock, return_value=MUSIC_ALBUM_QUALITY_RESULT),
+        patch.object(MediaService, "add_music_with_profile", new_callable=AsyncMock, return_value=(True, "Hybrid Theory added")),
+    ):
+        resp = await harness.send_command("/music")
+        assert "Title" in resp.text
+
+        resp = await harness.send_text("hybrid theory")
+        assert len(harness.responses) >= 1
+
+        # Select album result
+        resp = await harness.tap_button("select_album:b1ae2a0f")
+        assert resp is not None
+        assert "quality" in resp.text.lower() or "Lossless" in resp.text
+
+        # Select quality -> direct add (album, no album picker)
+        resp = await harness.tap_button("quality_1")
+        assert resp is not None
+        assert "added" in resp.text.lower() or "Hybrid Theory" in resp.text

--- a/tests/integration/test_media_flow.py
+++ b/tests/integration/test_media_flow.py
@@ -11,34 +11,18 @@ from unittest.mock import AsyncMock, patch
 
 from src.services.media import MediaService
 
+from tests.integration.fixtures import (
+    MOVIE_SEARCH_RESULTS,
+    MOVIE_QUALITY_RESULT,
+    SERIES_SEARCH_RESULTS,
+    SERIES_QUALITY_RESULT,
+    MUSIC_ARTIST_RESULTS,
+    MUSIC_QUALITY_RESULT,
+    MUSIC_ALBUM_RESULTS,
+    MUSIC_ALBUM_QUALITY_RESULT,
+)
 
-# --- Movie test data ---
-
-MOVIE_SEARCH_RESULTS = [
-    {
-        "id": "550",
-        "title": "Fight Club (1999)",
-        "overview": "An insomniac office worker...",
-        "year": 1999,
-        "poster": None,
-        "ratings": {"imdb": 8.8, "rottenTomatoes": 79},
-        "studio": "Fox 2000 Pictures",
-        "status": "released",
-        "runtime": 139,
-        "genres": ["Drama", "Thriller"],
-        "data": {"tmdbId": 550, "title": "Fight Club"},
-    },
-]
-
-QUALITY_SELECTION_RESULT = {
-    "type": "quality_selection",
-    "profiles": [
-        {"id": 1, "name": "HD-1080p"},
-        {"id": 2, "name": "Ultra-HD"},
-    ],
-    "root_folder": "/movies",
-    "movie": {"tmdbId": 550, "title": "Fight Club"},
-}
+MEDIA_CONVERSATION = "media_conversation"
 
 
 @pytest.mark.asyncio
@@ -46,7 +30,7 @@ async def test_movie_happy_path(harness):
     """/movie -> search -> select -> quality -> added."""
     with (
         patch.object(MediaService, "search_movies", new_callable=AsyncMock, return_value=MOVIE_SEARCH_RESULTS),
-        patch.object(MediaService, "add_movie", new_callable=AsyncMock, return_value=QUALITY_SELECTION_RESULT),
+        patch.object(MediaService, "add_movie", new_callable=AsyncMock, return_value=MOVIE_QUALITY_RESULT),
         patch.object(MediaService, "add_movie_with_profile", new_callable=AsyncMock, return_value=(True, "Fight Club added successfully")),
     ):
         # Step 1: /movie -> SEARCHING
@@ -80,7 +64,7 @@ async def test_movie_no_results(harness):
         assert "no" in resp.text.lower() or "not found" in resp.text.lower()
 
         # Conversation should have ended
-        state = harness.get_conversation_state("media_conversation", 12345, 12345)
+        state = harness.get_conversation_state(MEDIA_CONVERSATION, 12345, 12345)
         assert state is None
 
 
@@ -109,7 +93,7 @@ async def test_movie_cancel_at_quality(harness):
     """Select result -> quality shown -> cancel at QUALITY_SELECT state."""
     with (
         patch.object(MediaService, "search_movies", new_callable=AsyncMock, return_value=MOVIE_SEARCH_RESULTS),
-        patch.object(MediaService, "add_movie", new_callable=AsyncMock, return_value=QUALITY_SELECTION_RESULT),
+        patch.object(MediaService, "add_movie", new_callable=AsyncMock, return_value=MOVIE_QUALITY_RESULT),
     ):
         await harness.send_command("/movie")
         await harness.send_text("fight club")
@@ -119,38 +103,7 @@ async def test_movie_cancel_at_quality(harness):
         assert "cancel" in resp.text.lower()
 
 
-# --- Series test data ---
-
-SERIES_SEARCH_RESULTS = [
-    {
-        "id": "81189",
-        "title": "Breaking Bad (2008)",
-        "overview": "A high school chemistry teacher...",
-        "year": 2008,
-        "poster": None,
-        "ratings": {"tmdb": 8.9, "votes": 1000},
-        "network": "AMC",
-        "studio": "N/A",
-        "status": "ended",
-        "seasons": 2,
-        "runtime": 45,
-        "genres": ["Drama", "Thriller"],
-        "data": {"tvdbId": 81189, "title": "Breaking Bad"},
-    },
-]
-
-SERIES_QUALITY_RESULT = {
-    "type": "quality_selection",
-    "profiles": [
-        {"id": 1, "name": "HD-1080p"},
-    ],
-    "root_folder": "/tv",
-    "series": {"tvdbId": 81189, "title": "Breaking Bad"},
-    "seasons": [
-        {"seasonNumber": 1, "monitored": True},
-        {"seasonNumber": 2, "monitored": True},
-    ],
-}
+# --- Series tests ---
 
 
 @pytest.mark.asyncio
@@ -202,61 +155,7 @@ async def test_series_monitor_all(harness):
         assert "added" in resp.text.lower() or "Breaking Bad" in resp.text
 
 
-# --- Music test data ---
-
-MUSIC_ARTIST_RESULTS = [
-    {
-        "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-        "title": "Linkin Park",
-        "overview": "Linkin Park is an American rock band...",
-        "year": 1996,
-        "poster": None,
-        "rating": 8.5,
-        "genres": "Rock, Nu Metal",
-        "type": "Group",
-        "status": "active",
-        "music_type": "artist",
-        "data": {
-            "foreignArtistId": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-            "artistName": "Linkin Park",
-        },
-    },
-]
-
-MUSIC_QUALITY_RESULT = {
-    "type": "quality_selection",
-    "profiles": [
-        {"id": 1, "name": "Lossless"},
-    ],
-    "root_folder": "/music",
-}
-
-MUSIC_ALBUM_RESULTS = [
-    {
-        "id": "album:b1ae2a0f",
-        "title": "Hybrid Theory",
-        "overview": "Debut studio album",
-        "year": 2000,
-        "poster": None,
-        "rating": 8.5,
-        "genres": "Rock",
-        "type": "Album",
-        "status": "released",
-        "music_type": "album",
-        "artist_name": "Linkin Park",
-        "artist_id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-        "album_id": "b1ae2a0f",
-        "data": {},
-    },
-]
-
-MUSIC_ALBUM_QUALITY_RESULT = {
-    "type": "quality_selection",
-    "profiles": [
-        {"id": 1, "name": "Lossless"},
-    ],
-    "root_folder": "/music",
-}
+# --- Music tests ---
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -1,0 +1,38 @@
+"""
+Smoke tests for the integration test harness.
+
+These tests validate that BotHarness can:
+1. Build a real Application with all handlers
+2. Process Update objects through the handler chain
+3. Capture bot responses without hitting Telegram's API
+"""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_start_command_returns_response(harness):
+    """Send /start to a fully wired Application, assert bot responds."""
+    resp = await harness.send_command("/start")
+    assert resp is not None
+    assert resp.method == "sendMessage"
+    assert resp.text  # bot should send some text
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_no_crash(harness):
+    """Send an unknown command, assert no error raised."""
+    # Should not raise — PTB just ignores unmatched commands
+    await harness.send_command("/nonexistent")
+    # No response expected for unmatched command
+
+
+@pytest.mark.asyncio
+async def test_harness_captures_multiple_responses(harness):
+    """Verify harness.responses collects all API calls from a single update."""
+    await harness.send_command("/start")
+    # /start sends at least one message; responses list should be non-empty
+    assert len(harness.responses) >= 1
+    # All captured responses should have a method name
+    for resp in harness.responses:
+        assert resp.method


### PR DESCRIPTION
## Summary

Adds a complete integration test harness that drives a real PTB `Application` with all handlers registered, processes `Update` objects through the handler chain, and captures bot responses — no Telegram network connection needed.

- **BotHarness** intercepts `HTTPXRequest.do_request` (PTB v22's lowest network layer) to capture outgoing API calls and return plausible fake results
- **29 integration tests** covering: smoke tests, auth gating, auth conversation flow, full media flows (movie/series/music with happy paths, cancellation, no-results), downloads dashboard, and API mock helpers
- **Shared fixtures**: `harness` (pre-authenticated), `downloads_harness` (Transmission + SABnzbd enabled), reusable test data in `fixtures.py`, and API mock helpers in `api_mocks.py`

### Key design decisions

- Intercept at `HTTPXRequest.do_request` rather than `Bot._do_post` because PTB v22 freezes `TelegramObject` instances
- Use `patch.object(MediaService, "method")` to mock service methods on the singleton class (handlers hold references obtained at construction time)
- Separate `downloads_harness` fixture patches `is_enabled()` before `_build_application()` since `DownloadsHandler.__init__` checks at construction time
- `LidarrMockHelper` uses `API_VERSION = "v1"` (not v3 like Radarr/Sonarr)

### New files

| File | Purpose |
|------|---------|
| `tests/integration/__init__.py` | Package marker |
| `tests/integration/conftest.py` | BotHarness, update factories, fixtures |
| `tests/integration/fixtures.py` | Shared test data (search results, quality profiles) |
| `tests/integration/api_mocks.py` | aioresponses helpers for Radarr/Sonarr/Lidarr |
| `tests/integration/test_smoke.py` | 3 smoke tests |
| `tests/integration/test_auth_gating.py` | 3 auth gating tests |
| `tests/integration/test_auth_flow.py` | 3 auth conversation tests |
| `tests/integration/test_media_flow.py` | 9 media flow tests |
| `tests/integration/test_cancel_flow.py` | 4 cancel flow tests |
| `tests/integration/test_downloads_flow.py` | 4 downloads dashboard tests |
| `tests/integration/test_api_mocks.py` | 3 API mock helper tests |

## Test plan

- [x] `pytest --tb=short -q` — 1765 passed, 0 failed
- [x] `flake8 .` — clean
- [x] `python run.py --validate-i18n` — all translations valid
- [x] All 29 integration tests pass independently
- [x] No regressions in existing unit tests

Closes #136

Generated with [Claude Code](https://claude.com/claude-code)
