### PR TITLE
refactor: remove built-in packages from requirements.txt

### DIFF
--- a/docs/issues/issue-100/TASKS.md
+++ b/docs/issues/issue-100/TASKS.md
@@ -1,0 +1,13 @@
+# TASKS — Issue #100: Remove built-in packages from requirements.txt
+
+## Phase 1: Remove unnecessary dependencies
+
+- [x] **1.1** Remove `asyncio>=3.4.3` and `dataclasses>=0.6` from `requirements.txt`
+    - Remove the `asyncio>=3.4.3` line from the "Async support" section
+    - Remove the `dataclasses>=0.6` line and the "Data handling" section header (move `typing-extensions` under a better heading)
+    - Run full test suite to verify no breakage
+    - Run flake8 and i18n validation
+    - **Completed:** 2026-03-09
+    - **Learnings:** `typing-extensions` is required by `transmission-rpc` so must stay despite being stdlib-adjacent
+    - **Key Changes:** Removed `asyncio>=3.4.3` and `dataclasses>=0.6` from `requirements.txt`, reorganized section headers
+    - **Notes:** No runtime impact — both packages are no-op shims on Python 3.11+

--- a/docs/issues/issue-100/plan.md
+++ b/docs/issues/issue-100/plan.md
@@ -1,0 +1,22 @@
+# Issue #100: Remove built-in packages from requirements.txt
+
+## Context
+
+`requirements.txt` includes `asyncio>=3.4.3` and `dataclasses>=0.6`, which are stdlib modules in Python 3.11 (our target runtime per Dockerfile). These are unnecessary dependency declarations.
+
+## Analysis
+
+- `asyncio` — stdlib since Python 3.4. The PyPI package is a no-op shim.
+- `dataclasses` — stdlib since Python 3.7. The PyPI package is a backport.
+- `typing-extensions` — investigated but **keep**: required by `transmission-rpc` (a transitive dependency).
+
+## Changes
+
+1. Remove `asyncio>=3.4.3` line from `requirements.txt`
+2. Remove `dataclasses>=0.6` line from `requirements.txt`
+3. Clean up the "Async support" and "Data handling" section comments if they become empty or misleading
+4. Verify: pytest passes, flake8 passes, i18n validation passes
+
+## Risk
+
+None — these packages are no-op shims on Python 3.11+. Removing them changes nothing at runtime.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,8 @@ colorama>=0.4.6
 # Async support
 aiohttp>=3.8.5
 aiocron>=1.8
-asyncio>=3.4.3
 
-# Data handling
-dataclasses>=0.6
+# Type hints (required by transmission-rpc)
 typing-extensions>=4.7.1
 
 # Interactive CLI


### PR DESCRIPTION
## Summary

- Remove asyncio>=3.4.3 from requirements.txt (stdlib since Python 3.4)
- Remove dataclasses>=0.6 from requirements.txt (stdlib since Python 3.7)
- Both are no-op shims on Python 3.11+ (our target runtime per Dockerfile)
- Investigated typing-extensions -- kept because transmission-rpc depends on it

Closes #100

## Test plan

- [x] Full test suite passes (1765 tests)
- [x] flake8 clean
- [x] i18n validation passes
- [ ] CI pipeline passes
- [ ] Docker build succeeds

Generated with Claude Code
