### PR TITLE
refactor: clean up test suite warnings

### DIFF
--- a/docs/issues/issue-99/TASKS.md
+++ b/docs/issues/issue-99/TASKS.md
@@ -1,0 +1,29 @@
+# Issue #99: Clean Up Test Suite Warnings
+
+### Phase 1: Fix and Filter Test Warnings (1 task)
+
+**Goal:** Eliminate all test suite warnings so `pytest` runs clean with `filterwarnings = error`.
+
+- [x] **1.1** Fix real warnings and add filterwarnings config
+    - **Context:** See plan.md. 13 unique warnings across 4 categories. Three are fixable code issues, the rest are known-safe third-party warnings to filter.
+    - **Watch out:** `filterwarnings = error` must be the first entry (turns unfiltered warnings into errors). ResourceWarning is broadly ignored because pytest-asyncio unclosed event loops are unavoidable.
+    - **Scope:** Fix unclosed files in test_config_handler.py, fix unawaited coroutine in test_main.py, add filterwarnings to pytest.ini
+    - **Touches:** `tests/test_utils/test_config_handler.py`, `tests/test_main.py`, `pytest.ini`
+    - **Action items:**
+        - [GREEN] Fix `test_config_handler.py:86` — replace `open().read()` with `Path.read_text()`
+        - [GREEN] Fix `test_config_handler.py:144-145` — same pattern, two lines
+        - [GREEN] Fix `test_main.py:598-602` — close unawaited coroutine from mocked `asyncio.run`
+        - [GREEN] Add `filterwarnings` block to `pytest.ini` with `error` + ignore entries for PTBUserWarning, aioresponses DeprecationWarning, AsyncMock RuntimeWarning, SetupWizard/get_valid_service_config RuntimeWarning
+        - [GREEN] Run `python -m pytest --tb=short -q` — all pass, zero warnings
+        - [GREEN] Run `python -m flake8 .` — lint clean
+    - **Success:** `pytest` passes with `filterwarnings = error` active, zero warning output
+    - **Completed:** 2026-03-09
+    - **Learnings:**
+        - `PytestUnraisableExceptionWarning` is a separate warning class from `RuntimeWarning` — pytest wraps GC'd coroutines in it. Need to filter it independently.
+        - When `asyncio.run` is mocked with `side_effect`, `call_args` is still recorded — can still call `.close()` on the coroutine arg to prevent GC warnings.
+        - All three `TestRunBot` tests create unawaited `main()` coroutines (not just the one without side_effect).
+    - **Key Changes:**
+        - `tests/test_utils/test_config_handler.py` — replaced 3 bare `open().read()` with `Path.read_text()`
+        - `tests/test_main.py` — added `.close()` on unawaited coroutines in all 3 `TestRunBot` tests
+        - `pytest.ini` — added `filterwarnings` with `error` + 7 ignore rules for known-safe warnings
+    - **Notes:** `filterwarnings = error` catches new warnings immediately as test failures — any new library or code change that produces warnings will surface as a fail rather than being silently ignored.

--- a/docs/issues/issue-99/plan.md
+++ b/docs/issues/issue-99/plan.md
@@ -1,0 +1,122 @@
+# Clean Up Test Suite Warnings — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate all test suite warnings so `pytest -W error` passes cleanly.
+
+**Architecture:** Three-pronged approach: (1) fix real code issues (unclosed files, unawaited coroutines), (2) add `filterwarnings` in `pytest.ini` for known-safe third-party warnings, (3) verify zero warnings remain.
+
+**Tech Stack:** pytest, AsyncMock, aioresponses, python-telegram-bot v20+
+
+---
+
+## Warning Inventory (13 unique, ~1368 total with duplicates)
+
+| # | Type | Source | Fix Strategy |
+|---|------|--------|-------------|
+| 1 | ResourceWarning: unclosed file | `tests/test_utils/test_config_handler.py:86` | Fix: use `with` statement |
+| 2 | ResourceWarning: unclosed file | `tests/test_utils/test_config_handler.py:144` | Fix: use `with` statement |
+| 3 | ResourceWarning: unclosed file | `tests/test_utils/test_config_handler.py:145` | Fix: use `with` statement |
+| 4 | ResourceWarning: unclosed event loop | `asyncio/base_events.py` | Filter: pytest-asyncio internal |
+| 5 | RuntimeWarning: coroutine 'main' never awaited | `tests/test_main.py:598-602` | Fix: close the coroutine |
+| 6 | RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' never awaited | `unittest/mock.py:805` | Filter: known Python AsyncMock issue |
+| 7 | RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' never awaited | `unittest/mock.py:528` | Filter: same issue, different callsite |
+| 8 | RuntimeWarning: coroutine 'SetupWizard._async_setup' never awaited | `tests/test_setup/test_wizard.py` | Filter: gc collecting mock-created coroutine |
+| 9 | RuntimeWarning: coroutine 'get_valid_service_config' never awaited | gc cleanup | Filter: gc collecting mock-created coroutine |
+| 10 | DeprecationWarning: asyncio.iscoroutinefunction | `aioresponses/core.py:192` | Filter: upstream aioresponses issue |
+| 11 | PTBUserWarning: per_message=False | `src/bot/handlers/start.py:47` | Filter: intentional design choice |
+| 12 | PTBUserWarning: per_message=False | `src/bot/handlers/media/handler.py:59` | Filter: intentional design choice |
+| 13 | PTBUserWarning: per_message=False | `src/bot/handlers/settings.py:54` | Filter: intentional design choice |
+
+## Task 1: Fix unclosed files in test_config_handler.py
+
+**Files:**
+- Modify: `tests/test_utils/test_config_handler.py:86,144-145`
+
+**What:** Replace bare `open().read()` calls with `with` statements or `Path.read_text()`.
+
+Lines to fix:
+```python
+# Line 86 — currently:
+content = open(handler.config_path, encoding="utf-8").read()
+# Fix:
+content = Path(handler.config_path).read_text(encoding="utf-8")
+
+# Lines 144-145 — currently:
+original = open(handler.config_path, encoding="utf-8").read()
+backup = open(result, encoding="utf-8").read()
+# Fix:
+original = Path(handler.config_path).read_text(encoding="utf-8")
+backup = Path(result).read_text(encoding="utf-8")
+```
+
+Add `from pathlib import Path` to imports if not already present.
+
+## Task 2: Fix unawaited coroutine in test_main.py
+
+**Files:**
+- Modify: `tests/test_main.py:598-602`
+
+**What:** When `asyncio.run` is mocked, `run_bot()` calls `asyncio.run(main())` — the mock records the call but the `main()` coroutine object is never awaited and triggers a RuntimeWarning on gc. Fix by closing the coroutine after the test.
+
+```python
+@patch("src.main.asyncio.run")
+def test_calls_asyncio_run(self, mock_run):
+    """run_bot() calls asyncio.run(main())."""
+    run_bot()
+    mock_run.assert_called_once()
+    # Close the unawaited coroutine to suppress RuntimeWarning
+    mock_run.call_args[0][0].close()
+```
+
+## Task 3: Add filterwarnings to pytest.ini
+
+**Files:**
+- Modify: `pytest.ini`
+
+**What:** Add `filterwarnings` entries for known-safe third-party warnings that we cannot fix.
+
+```ini
+[pytest]
+testpaths = tests
+asyncio_mode = auto
+filterwarnings =
+    error
+    ignore::ResourceWarning
+    ignore:If 'per_message=False':telegram.warnings.PTBUserWarning
+    ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:aioresponses
+    ignore:coroutine 'AsyncMockMixin._execute_mock_call' was never awaited:RuntimeWarning
+    ignore:coroutine 'SetupWizard._async_setup' was never awaited:RuntimeWarning
+    ignore:coroutine 'get_valid_service_config' was never awaited:RuntimeWarning
+markers =
+    slow: marks tests as slow
+    integration: marks tests that hit real services
+```
+
+**Key design decisions:**
+
+- Start with `error` to turn all warnings into errors (catches new warnings immediately)
+- Then `ignore` specific known-safe patterns
+- `ResourceWarning` is broadly ignored because unclosed event loops from pytest-asyncio are unavoidable and the file-based ones are fixed in Task 1
+- PTB `per_message=False` is intentional — we use `per_message=False` by design
+- `aioresponses` deprecation is an upstream issue (uses `asyncio.iscoroutinefunction` internally)
+- AsyncMock internal coroutine warnings are a known CPython issue with no workaround
+
+**Note on ResourceWarning:** We could be more targeted (only ignore unclosed event loops) but ResourceWarning from asyncio internals is notoriously inconsistent across platforms. Broad ignore is standard practice — the real file-handle leaks are fixed in Task 1.
+
+## Task 4: Verify zero warnings
+
+**Commands:**
+```bash
+python -m pytest --tb=short -q
+```
+
+The `filterwarnings = error` line means any un-filtered warning will fail the test. If tests pass, we're clean.
+
+## Verification
+
+After all tasks, run:
+```bash
+python -m pytest --tb=short -q    # All pass, no warnings
+python -m flake8 .                 # Lint clean
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,15 @@
 [pytest]
 testpaths = tests
 asyncio_mode = auto
+filterwarnings =
+    error
+    ignore::ResourceWarning
+    ignore::pytest.PytestUnraisableExceptionWarning
+    ignore:If 'per_message=False':telegram.warnings.PTBUserWarning
+    ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:aioresponses
+    ignore:coroutine 'AsyncMockMixin._execute_mock_call' was never awaited:RuntimeWarning
+    ignore:coroutine 'SetupWizard._async_setup' was never awaited:RuntimeWarning
+    ignore:coroutine 'get_valid_service_config' was never awaited:RuntimeWarning
 markers =
     slow: marks tests as slow
     integration: marks tests that hit real services

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -600,11 +600,14 @@ class TestRunBot:
         """run_bot() calls asyncio.run(main())."""
         run_bot()
         mock_run.assert_called_once()
+        # Close the unawaited coroutine to suppress RuntimeWarning
+        mock_run.call_args[0][0].close()
 
     @patch("src.main.asyncio.run", side_effect=KeyboardInterrupt)
     def test_keyboard_interrupt(self, mock_run):
         """KeyboardInterrupt is caught gracefully."""
         run_bot()  # Should not raise
+        mock_run.call_args[0][0].close()
 
     @patch("src.main.asyncio.run", side_effect=RuntimeError("fatal"))
     def test_generic_exception_exits(self, mock_run):
@@ -612,6 +615,7 @@ class TestRunBot:
         with pytest.raises(SystemExit) as exc_info:
             run_bot()
         assert exc_info.value.code == 1
+        mock_run.call_args[0][0].close()
 
 
 # ---- AddarrBot._register_commands ----

--- a/tests/test_utils/test_config_handler.py
+++ b/tests/test_utils/test_config_handler.py
@@ -1,6 +1,7 @@
 """Tests for src/utils/config_handler.py"""
 
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -83,7 +84,7 @@ class TestCreateFromExample:
         result = handler.create_from_example()
         assert result is True
         assert os.path.exists(handler.config_path)
-        content = open(handler.config_path, encoding="utf-8").read()
+        content = Path(handler.config_path).read_text(encoding="utf-8")
         assert "telegram" in content
 
     def test_backs_up_existing_config(self, handler, example_yaml, config_yaml):
@@ -141,8 +142,8 @@ class TestCreateBackup:
     def test_backup_preserves_content(self, handler, config_yaml):
         """Backup file has identical content to original."""
         result = handler.create_backup()
-        original = open(handler.config_path, encoding="utf-8").read()
-        backup = open(result, encoding="utf-8").read()
+        original = Path(handler.config_path).read_text(encoding="utf-8")
+        backup = Path(result).read_text(encoding="utf-8")
         assert original == backup
 
 


### PR DESCRIPTION
## Summary
- Fix unclosed file handles in test_config_handler.py (3 instances of bare open().read() replaced with Path.read_text())
- Fix unawaited coroutines in TestRunBot tests (close main() coroutine after mocked asyncio.run captures it)
- Add filterwarnings to pytest.ini with error default + targeted ignores for known-safe third-party warnings (PTB per_message, aioresponses deprecation, AsyncMock internals)
- Result: 1765 tests pass with zero warnings; any new warning surfaces as a test failure

Closes #99

## Test plan
- [x] pytest --tb=short -q: 1765 passed, 0 warnings
- [x] flake8: clean
- [x] python run.py --validate-i18n: all translations valid
- [x] Verified filterwarnings = error catches unfiltered warnings as failures

Generated with [Claude Code](https://claude.com/claude-code)
