### PR TITLE
feat: add /history command for download history (#107)

### DIFF
--- a/docs/issues/issue-107/TASKS.md
+++ b/docs/issues/issue-107/TASKS.md
@@ -62,7 +62,7 @@
     - **Key Changes:** Added 8 keys (History, CommandHistory, HistoryTitle, HistoryEmpty, HistoryGrabbed, HistoryImported, HistoryFailed, HistoryAll) to all 10 locale files + template.
     - **Notes:** Keys placed after Queue section, before handler error messages section.
 
-- [ ] **2.2** Add history keyboard functions to `keyboards.py`
+- [x] **2.2** Add history keyboard functions to `keyboards.py`
     - **Context:** See plan.md Phase 4. Key refs: `src/bot/keyboards.py` (follow `get_calendar_items_keyboard` pattern). Callback data prefix: `hist_`. Filter tabs row + item rows + pagination + action row.
     - **Watch out:** `_HISTORY_EVENT_EMOJI` dict for event type icons. Title truncation at 30 chars. Filter tab bullet prefix for active filter.
     - **Scope:** `get_history_items_keyboard()` and `get_history_empty_keyboard()` + event emoji mapping
@@ -71,6 +71,10 @@
         - [RED] Write tests: items keyboard with items (pagination present), empty items, active filter highlight, empty keyboard buttons
         - [GREEN] Implement `_HISTORY_EVENT_EMOJI`, `get_history_items_keyboard()`, `get_history_empty_keyboard()`
     - **Success:** `pytest tests/test_bot/test_keyboards.py -v` passes, new functions have 100% coverage
+    - **Completed:** 2026-03-09
+    - **Learnings:** Need separate tests for title truncation (>30 chars) and Previous button (page > 0) to hit 100% coverage.
+    - **Key Changes:** Added `_HISTORY_EVENT_EMOJI`, `get_history_items_keyboard()`, `get_history_empty_keyboard()` to keyboards.py. Added 6 tests.
+    - **Notes:** Filter tabs use `\u2022` bullet prefix for active filter. Items use `hist_noop` callback since they're display-only.
 
 - [ ] **2.3** Create HistoryHandler and register in main.py
     - **Context:** See plan.md Phase 5+6. Key refs: `src/bot/handlers/calendar.py` (exact pattern to follow), `src/main.py:149` (registration after QueueHandler). Handler uses `context.user_data` for `hist_items`, `hist_page`, `hist_filter`.

--- a/docs/issues/issue-107/TASKS.md
+++ b/docs/issues/issue-107/TASKS.md
@@ -76,7 +76,7 @@
     - **Key Changes:** Added `_HISTORY_EVENT_EMOJI`, `get_history_items_keyboard()`, `get_history_empty_keyboard()` to keyboards.py. Added 6 tests.
     - **Notes:** Filter tabs use `\u2022` bullet prefix for active filter. Items use `hist_noop` callback since they're display-only.
 
-- [ ] **2.3** Create HistoryHandler and register in main.py
+- [x] **2.3** Create HistoryHandler and register in main.py
     - **Context:** See plan.md Phase 5+6. Key refs: `src/bot/handlers/calendar.py` (exact pattern to follow), `src/main.py:149` (registration after QueueHandler). Handler uses `context.user_data` for `hist_items`, `hist_page`, `hist_filter`.
     - **Watch out:** `@require_auth` on both `show_history` and `handle_history_action`. Add `history_handler` fixture to `tests/test_handlers/conftest.py`. Add `("history", "CommandHistory")` to `src/bot/commands.py`. Add `HistoryHandler` to `src/bot/handlers/__init__.py`.
     - **Scope:** Full handler class + registration + fixture + tests
@@ -89,3 +89,7 @@
         - [GREEN] Add command to `src/bot/commands.py`
         - [GREEN] Add to `src/bot/handlers/__init__.py`
     - **Success:** `pytest tests/test_handlers/test_history_handler.py -v` passes, full test suite green, `flake8` clean
+    - **Completed:** 2026-03-09
+    - **Learnings:** Must update `_make_handler_patches()` in test_main.py when adding new handlers. Each mock handler returns [MagicMock()] (1 handler), so count increments by 1 per new handler class, not by the real handler count. Also need to update command count assertions in test_commands.py.
+    - **Key Changes:** Created `src/bot/handlers/history.py` with HistoryHandler. Registered in main.py after QueueHandler. Added `history` command to commands.py. Added to `__init__.py`. Added fixture + 12 tests. Updated test_main.py handler counts and test_commands.py command counts.
+    - **Notes:** History command is gated behind radarr or sonarr being enabled, same as upcoming/missing.

--- a/docs/issues/issue-107/TASKS.md
+++ b/docs/issues/issue-107/TASKS.md
@@ -47,7 +47,7 @@
 
 **Goal:** Add translation keys, keyboard functions, and the handler.
 
-- [ ] **2.1** Add history translation keys to all locales
+- [x] **2.1** Add history translation keys to all locales
     - **Context:** See plan.md Phase 3. Key refs: `translations/addarr.en-us.yml:273` (Queue section — add after it). Flat top-level keys only (no nesting). Must add to all 10 locale files + template.
     - **Watch out:** Use `PYTHONIOENCODING=utf-8` when validating. Keep emoji prefixes consistent across locales.
     - **Scope:** 8 new keys: `History`, `CommandHistory`, `HistoryTitle`, `HistoryEmpty`, `HistoryGrabbed`, `HistoryImported`, `HistoryFailed`, `HistoryAll`
@@ -57,6 +57,10 @@
         - [GREEN] Add translated keys to all other locale files
         - [GREEN] Add keys to `addarr.template.yml`
     - **Success:** `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` passes
+    - **Completed:** 2026-03-09
+    - **Learnings:** All locale files have a consistent structure — QueueEmpty is always followed by a blank line then handler error section.
+    - **Key Changes:** Added 8 keys (History, CommandHistory, HistoryTitle, HistoryEmpty, HistoryGrabbed, HistoryImported, HistoryFailed, HistoryAll) to all 10 locale files + template.
+    - **Notes:** Keys placed after Queue section, before handler error messages section.
 
 - [ ] **2.2** Add history keyboard functions to `keyboards.py`
     - **Context:** See plan.md Phase 4. Key refs: `src/bot/keyboards.py` (follow `get_calendar_items_keyboard` pattern). Callback data prefix: `hist_`. Filter tabs row + item rows + pagination + action row.

--- a/docs/issues/issue-107/TASKS.md
+++ b/docs/issues/issue-107/TASKS.md
@@ -1,0 +1,79 @@
+# Issue #107: Download History Command (`/history`)
+
+**Goal:** Add a `/history` command showing recent grab/import/fail activity from Radarr and Sonarr with event type filtering and pagination.
+
+**Plan:** See `plan.md` for full design, API schemas, and code templates.
+
+---
+
+### Phase 1: API + Service Layer (2 tasks)
+
+**Goal:** Add `get_history()` to API clients and MediaService with normalization.
+
+- [x] **1.1** Add `get_history()` to RadarrClient and SonarrClient
+    - **Context:** See plan.md Phase 1. Key refs: `src/api/radarr.py:196` (`get_missing` as pattern template), `src/api/sonarr.py:202` (same pattern). Both use paginated `?sortKey=date&sortDirection=descending` endpoints returning `{"records": [...]}`.
+    - **Watch out:** Event type filter is optional query param `&eventType=grabbed`. Response shape matches missing/queue (paginated dict with `records` key).
+    - **Scope:** `get_history(page, page_size, event_type)` on both clients + sample data fixtures
+    - **Touches:** `src/api/radarr.py`, `src/api/sonarr.py`, `tests/fixtures/sample_data.py`, `tests/test_api/test_radarr.py`, `tests/test_api/test_sonarr.py`
+    - **Action items:**
+        - [RED] Add `RADARR_HISTORY` and `SONARR_HISTORY` sample data to `tests/fixtures/sample_data.py`
+        - [RED] Write tests for Radarr `get_history` (success, with filter, empty, error, non-dict response)
+        - [RED] Write tests for Sonarr `get_history` (mirror Radarr tests)
+        - [GREEN] Implement `get_history()` on RadarrClient
+        - [GREEN] Implement `get_history()` on SonarrClient
+    - **Success:** `pytest tests/test_api/test_radarr.py tests/test_api/test_sonarr.py -v` passes, new methods have 100% coverage
+    - **Completed:** 2026-03-09
+    - **Learnings:** History endpoint follows exact same pattern as get_missing/get_queue — paginated dict with `records` key. Optional `eventType` query param appended when provided.
+    - **Key Changes:** Added `get_history(page, page_size, event_type)` to `RadarrClient` and `SonarrClient`, added `RADARR_HISTORY` and `SONARR_HISTORY` sample data, added 10 tests (5 per client).
+    - **Notes:** Both clients have identical method signatures and logic, differing only in log messages.
+
+- [ ] **1.2** Add `get_history()` to MediaService with normalizers
+    - **Context:** See plan.md Phase 2. Key refs: `src/services/media.py:532` (`get_upcoming` as pattern — gather, normalize, sort). Normalized schema includes `type`, `title`, `episode_title`, `season`, `episode`, `date`, `event_type`, `quality`, `source_title`, `service`.
+    - **Watch out:** Sort by date descending (newest first), unlike `get_upcoming` which sorts ascending. Exception from one service should not block the other.
+    - **Scope:** `get_history()` method + `_normalize_radarr_history` and `_normalize_sonarr_history` statics
+    - **Touches:** `src/services/media.py`, `tests/test_services/test_media_service.py`
+    - **Action items:**
+        - [RED] Write tests: both services return items (merged + sorted desc), radarr-only, sonarr-only, no services, one exception, event_type passthrough, normalizer unit tests
+        - [GREEN] Implement `get_history()` and both normalizer statics
+    - **Success:** `pytest tests/test_services/test_media_service.py -v` passes, new methods have 100% coverage
+
+---
+
+### Phase 2: UI Layer (3 tasks)
+
+**Goal:** Add translation keys, keyboard functions, and the handler.
+
+- [ ] **2.1** Add history translation keys to all locales
+    - **Context:** See plan.md Phase 3. Key refs: `translations/addarr.en-us.yml:273` (Queue section — add after it). Flat top-level keys only (no nesting). Must add to all 10 locale files + template.
+    - **Watch out:** Use `PYTHONIOENCODING=utf-8` when validating. Keep emoji prefixes consistent across locales.
+    - **Scope:** 8 new keys: `History`, `CommandHistory`, `HistoryTitle`, `HistoryEmpty`, `HistoryGrabbed`, `HistoryImported`, `HistoryFailed`, `HistoryAll`
+    - **Touches:** All files in `translations/` (10 locales + template)
+    - **Action items:**
+        - [GREEN] Add English keys to `addarr.en-us.yml`
+        - [GREEN] Add translated keys to all other locale files
+        - [GREEN] Add keys to `addarr.template.yml`
+    - **Success:** `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` passes
+
+- [ ] **2.2** Add history keyboard functions to `keyboards.py`
+    - **Context:** See plan.md Phase 4. Key refs: `src/bot/keyboards.py` (follow `get_calendar_items_keyboard` pattern). Callback data prefix: `hist_`. Filter tabs row + item rows + pagination + action row.
+    - **Watch out:** `_HISTORY_EVENT_EMOJI` dict for event type icons. Title truncation at 30 chars. Filter tab bullet prefix for active filter.
+    - **Scope:** `get_history_items_keyboard()` and `get_history_empty_keyboard()` + event emoji mapping
+    - **Touches:** `src/bot/keyboards.py`, `tests/test_bot/test_keyboards.py`
+    - **Action items:**
+        - [RED] Write tests: items keyboard with items (pagination present), empty items, active filter highlight, empty keyboard buttons
+        - [GREEN] Implement `_HISTORY_EVENT_EMOJI`, `get_history_items_keyboard()`, `get_history_empty_keyboard()`
+    - **Success:** `pytest tests/test_bot/test_keyboards.py -v` passes, new functions have 100% coverage
+
+- [ ] **2.3** Create HistoryHandler and register in main.py
+    - **Context:** See plan.md Phase 5+6. Key refs: `src/bot/handlers/calendar.py` (exact pattern to follow), `src/main.py:149` (registration after QueueHandler). Handler uses `context.user_data` for `hist_items`, `hist_page`, `hist_filter`.
+    - **Watch out:** `@require_auth` on both `show_history` and `handle_history_action`. Add `history_handler` fixture to `tests/test_handlers/conftest.py`. Add `("history", "CommandHistory")` to `src/bot/commands.py`. Add `HistoryHandler` to `src/bot/handlers/__init__.py`.
+    - **Scope:** Full handler class + registration + fixture + tests
+    - **Touches:** `src/bot/handlers/history.py` (create), `src/main.py`, `src/bot/commands.py`, `src/bot/handlers/__init__.py`, `tests/test_handlers/conftest.py`, `tests/test_handlers/test_history_handler.py` (create)
+    - **Action items:**
+        - [RED] Add `history_handler` fixture to conftest
+        - [RED] Write handler tests: show with results, show empty, show via callback, no user, filter grabbed, filter all, page navigation, refresh, back, noop
+        - [GREEN] Create `src/bot/handlers/history.py` with HistoryHandler
+        - [GREEN] Register handler in `main.py` after QueueHandler
+        - [GREEN] Add command to `src/bot/commands.py`
+        - [GREEN] Add to `src/bot/handlers/__init__.py`
+    - **Success:** `pytest tests/test_handlers/test_history_handler.py -v` passes, full test suite green, `flake8` clean

--- a/docs/issues/issue-107/TASKS.md
+++ b/docs/issues/issue-107/TASKS.md
@@ -27,7 +27,7 @@
     - **Key Changes:** Added `get_history(page, page_size, event_type)` to `RadarrClient` and `SonarrClient`, added `RADARR_HISTORY` and `SONARR_HISTORY` sample data, added 10 tests (5 per client).
     - **Notes:** Both clients have identical method signatures and logic, differing only in log messages.
 
-- [ ] **1.2** Add `get_history()` to MediaService with normalizers
+- [x] **1.2** Add `get_history()` to MediaService with normalizers
     - **Context:** See plan.md Phase 2. Key refs: `src/services/media.py:532` (`get_upcoming` as pattern — gather, normalize, sort). Normalized schema includes `type`, `title`, `episode_title`, `season`, `episode`, `date`, `event_type`, `quality`, `source_title`, `service`.
     - **Watch out:** Sort by date descending (newest first), unlike `get_upcoming` which sorts ascending. Exception from one service should not block the other.
     - **Scope:** `get_history()` method + `_normalize_radarr_history` and `_normalize_sonarr_history` statics
@@ -36,6 +36,10 @@
         - [RED] Write tests: both services return items (merged + sorted desc), radarr-only, sonarr-only, no services, one exception, event_type passthrough, normalizer unit tests
         - [GREEN] Implement `get_history()` and both normalizer statics
     - **Success:** `pytest tests/test_services/test_media_service.py -v` passes, new methods have 100% coverage
+    - **Completed:** 2026-03-09
+    - **Learnings:** Follows get_upcoming pattern exactly — gather, normalize, sort. Only difference is descending sort and no date computation.
+    - **Key Changes:** Added `get_history()`, `_normalize_radarr_history()`, `_normalize_sonarr_history()` to MediaService. Added `get_history` to mock client fixtures. Added 8 tests.
+    - **Notes:** Also added `get_history = AsyncMock(return_value=[])` to both `mock_radarr_client` and `mock_sonarr_client` fixtures in conftest.
 
 ---
 

--- a/docs/issues/issue-107/plan.md
+++ b/docs/issues/issue-107/plan.md
@@ -1,0 +1,697 @@
+# Download History Command (`/history`) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `/history` command that shows recent grab/import/fail activity from Radarr and Sonarr, with event type filtering and pagination.
+
+**Architecture:** Follows the existing three-layer pattern: API clients get raw history, MediaService normalizes and aggregates, HistoryHandler presents via Telegram with inline keyboards. Mirrors the calendar/missing/queue handler pattern closely.
+
+**Tech Stack:** python-telegram-bot v20+, aiohttp, asyncio.gather for parallel fetches.
+
+---
+
+## Phase 1: API Layer — Add `get_history()` to Radarr and Sonarr clients
+
+### Task 1.1: Add `get_history()` to RadarrClient
+
+**Files:**
+- Modify: `src/api/radarr.py` (add method after `get_calendar`)
+- Test: `tests/test_api/test_radarr.py`
+- Modify: `tests/fixtures/sample_data.py` (add `RADARR_HISTORY` sample data)
+
+**Context:**
+- Radarr history endpoint: `GET /api/v3/history?page=1&pageSize=20&sortKey=date&sortDirection=descending`
+- Optional filter: `&eventType=grabbed` (values: `grabbed`, `downloadFolderImported`, `downloadFailed`, `movieFileDeleted`, `movieFileRenamed`)
+- Response is paginated: `{"page": 1, "pageSize": 20, "totalRecords": 100, "records": [...]}`
+- Each record has: `id`, `movieId`, `date`, `eventType`, `sourceTitle`, `quality`, `data` (contains indexer info), plus a `movie` object with `title`, `year`, `tmdbId`
+- Follow the `get_missing()` pattern: call `_request()`, check for dict response, extract `records`
+
+**Sample data to add to `tests/fixtures/sample_data.py`:**
+
+```python
+RADARR_HISTORY = {
+    "page": 1,
+    "pageSize": 20,
+    "totalRecords": 3,
+    "records": [
+        {
+            "id": 1, "movieId": 10,
+            "sourceTitle": "Fight.Club.1999.1080p.BluRay",
+            "quality": {"quality": {"name": "Bluray-1080p"}},
+            "date": "2026-03-09T14:30:00Z",
+            "eventType": "grabbed",
+            "data": {"indexer": "NZBgeek"},
+            "movie": {"title": "Fight Club", "year": 1999, "tmdbId": 550},
+        },
+        {
+            "id": 2, "movieId": 10,
+            "sourceTitle": "Fight.Club.1999.1080p.BluRay",
+            "quality": {"quality": {"name": "Bluray-1080p"}},
+            "date": "2026-03-09T15:00:00Z",
+            "eventType": "downloadFolderImported",
+            "data": {},
+            "movie": {"title": "Fight Club", "year": 1999, "tmdbId": 550},
+        },
+        {
+            "id": 3, "movieId": 20,
+            "sourceTitle": "Pulp.Fiction.1994.720p",
+            "quality": {"quality": {"name": "Bluray-720p"}},
+            "date": "2026-03-08T10:00:00Z",
+            "eventType": "downloadFailed",
+            "data": {"indexer": "Drunken Slug"},
+            "movie": {"title": "Pulp Fiction", "year": 1994, "tmdbId": 680},
+        },
+    ],
+}
+```
+
+**Implementation:**
+
+```python
+async def get_history(self, page: int = 1, page_size: int = 20,
+                      event_type: str = None) -> List[Dict]:
+    """Get recent history from Radarr."""
+    try:
+        logger.info(Fore.BLUE + "📜 Getting history from Radarr")
+        endpoint = (
+            f"history?sortKey=date&sortDirection=descending"
+            f"&page={page}&pageSize={page_size}"
+        )
+        if event_type:
+            endpoint += f"&eventType={event_type}"
+
+        result = await self._request(endpoint)
+
+        if not result or not isinstance(result, dict):
+            logger.warning(Fore.YELLOW + "⚠️ No history found in Radarr")
+            return []
+
+        records = result.get("records", [])
+        logger.info(Fore.GREEN + f"✅ Found {len(records)} history items in Radarr")
+        return records
+
+    except Exception as e:
+        logger.error(Fore.RED + f"❌ Failed to get Radarr history: {str(e)}")
+        return []
+```
+
+**Tests:**
+1. `test_get_history_success` — mock `history?sortKey=date&sortDirection=descending&page=1&pageSize=20` returning `RADARR_HISTORY`, assert returns 3 records
+2. `test_get_history_with_event_type` — pass `event_type="grabbed"`, assert URL includes `&eventType=grabbed`
+3. `test_get_history_empty` — mock returning `{"records": []}`, assert returns `[]`
+4. `test_get_history_error` — mock exception, assert returns `[]`
+5. `test_get_history_non_dict_response` — mock returning `None`, assert returns `[]`
+
+### Task 1.2: Add `get_history()` to SonarrClient
+
+**Files:**
+- Modify: `src/api/sonarr.py` (add method after `get_calendar`)
+- Test: `tests/test_api/test_sonarr.py`
+- Modify: `tests/fixtures/sample_data.py` (add `SONARR_HISTORY` sample data)
+
+**Context:**
+- Sonarr history endpoint: identical URL pattern to Radarr (`/api/v3/history?...`)
+- Event types: `grabbed`, `downloadFolderImported`, `downloadFailed`, `episodeFileDeleted`, `episodeFileRenamed`
+- Each record has: `id`, `seriesId`, `episodeId`, `date`, `eventType`, `sourceTitle`, `quality`, `data`, plus `series` and `episode` objects
+- Implementation is identical to Radarr's `get_history()` except for logger name
+
+**Sample data:**
+
+```python
+SONARR_HISTORY = {
+    "page": 1,
+    "pageSize": 20,
+    "totalRecords": 2,
+    "records": [
+        {
+            "id": 101, "seriesId": 42, "episodeId": 201,
+            "sourceTitle": "Breaking.Bad.S01E01.720p",
+            "quality": {"quality": {"name": "HDTV-720p"}},
+            "date": "2026-03-09T12:00:00Z",
+            "eventType": "grabbed",
+            "data": {"indexer": "NZBgeek"},
+            "series": {"title": "Breaking Bad", "year": 2008, "tvdbId": 81189},
+            "episode": {"title": "Pilot", "seasonNumber": 1, "episodeNumber": 1},
+        },
+        {
+            "id": 102, "seriesId": 42, "episodeId": 201,
+            "sourceTitle": "Breaking.Bad.S01E01.720p",
+            "quality": {"quality": {"name": "HDTV-720p"}},
+            "date": "2026-03-09T12:30:00Z",
+            "eventType": "downloadFolderImported",
+            "data": {},
+            "series": {"title": "Breaking Bad", "year": 2008, "tvdbId": 81189},
+            "episode": {"title": "Pilot", "seasonNumber": 1, "episodeNumber": 1},
+        },
+    ],
+}
+```
+
+**Implementation:** Same shape as RadarrClient's `get_history()` with "Sonarr" in log messages.
+
+**Tests:** Mirror Task 1.1 tests.
+
+---
+
+## Phase 2: Service Layer — Aggregate history in MediaService
+
+### Task 2.1: Add `get_history()` to MediaService
+
+**Files:**
+- Modify: `src/services/media.py` (add method + two normalizer statics)
+- Test: `tests/test_services/test_media_service.py`
+
+**Context:**
+- Follow the `get_upcoming()` pattern: gather from both services, normalize, merge, sort by date descending
+- Normalize into a unified schema that the handler can display without knowing the source service
+
+**Normalized schema:**
+
+```python
+{
+    "type": "movie" | "episode",        # from service_name
+    "title": str,                        # movie title or series title
+    "episode_title": str | None,         # episode title (Sonarr only)
+    "season": int | None,                # season number (Sonarr only)
+    "episode": int | None,               # episode number (Sonarr only)
+    "date": str,                         # ISO date string
+    "event_type": str,                   # grabbed, imported, failed, etc.
+    "quality": str,                      # quality name
+    "source_title": str,                 # release name
+    "service": "radarr" | "sonarr",      # source service
+}
+```
+
+**Implementation:**
+
+```python
+async def get_history(self, page: int = 1, page_size: int = 20,
+                      event_type: str = None) -> List[Dict]:
+    """Get recent history from Radarr and Sonarr.
+
+    Returns a normalized, date-sorted (newest first) list of history items.
+    """
+    tasks = []
+    if self.radarr:
+        tasks.append(("radarr", self.radarr.get_history(
+            page, page_size, event_type
+        )))
+    if self.sonarr:
+        tasks.append(("sonarr", self.sonarr.get_history(
+            page, page_size, event_type
+        )))
+
+    if not tasks:
+        return []
+
+    results = await asyncio.gather(
+        *(t[1] for t in tasks), return_exceptions=True
+    )
+
+    items = []
+    for (service_name, _), result in zip(tasks, results):
+        if isinstance(result, Exception):
+            logger.error(f"History fetch failed for {service_name}: {result}")
+            continue
+
+        if service_name == "radarr":
+            for record in result:
+                items.append(self._normalize_radarr_history(record))
+        else:
+            for record in result:
+                items.append(self._normalize_sonarr_history(record))
+
+    # Sort by date descending (newest first)
+    items.sort(key=lambda x: x.get("date", ""), reverse=True)
+    return items
+
+@staticmethod
+def _normalize_radarr_history(record: Dict) -> Dict:
+    """Normalize a Radarr history record."""
+    movie = record.get("movie", {})
+    return {
+        "type": "movie",
+        "title": movie.get("title", ""),
+        "episode_title": None,
+        "season": None,
+        "episode": None,
+        "date": record.get("date", ""),
+        "event_type": record.get("eventType", ""),
+        "quality": record.get("quality", {}).get("quality", {}).get("name", ""),
+        "source_title": record.get("sourceTitle", ""),
+        "service": "radarr",
+    }
+
+@staticmethod
+def _normalize_sonarr_history(record: Dict) -> Dict:
+    """Normalize a Sonarr history record."""
+    series = record.get("series", {})
+    ep = record.get("episode", {})
+    return {
+        "type": "episode",
+        "title": series.get("title", ""),
+        "episode_title": ep.get("title"),
+        "season": ep.get("seasonNumber"),
+        "episode": ep.get("episodeNumber"),
+        "date": record.get("date", ""),
+        "event_type": record.get("eventType", ""),
+        "quality": record.get("quality", {}).get("quality", {}).get("name", ""),
+        "source_title": record.get("sourceTitle", ""),
+        "service": "sonarr",
+    }
+```
+
+**Tests:**
+1. `test_get_history_both_services` — both radarr and sonarr return items, verify merged and sorted by date descending
+2. `test_get_history_radarr_only` — sonarr is None, verify only radarr items returned
+3. `test_get_history_sonarr_only` — radarr is None, verify only sonarr items returned
+4. `test_get_history_no_services` — both None, returns `[]`
+5. `test_get_history_exception_handling` — one service raises, other returns data, verify partial result
+6. `test_get_history_with_event_type` — verify event_type passed through to clients
+7. `test_normalize_radarr_history` — test normalizer with sample record
+8. `test_normalize_sonarr_history` — test normalizer with sample record
+
+---
+
+## Phase 3: Translation Keys
+
+### Task 3.1: Add history translation keys to all locales
+
+**Files:**
+- Modify: All 10 locale files in `translations/` + template
+- No test file (validated by `--validate-i18n`)
+
+**Keys to add (after the Queue section in each file):**
+
+English (`addarr.en-us.yml`):
+```yaml
+  # History
+  History: "📜 History"
+  CommandHistory: "Browse recent activity"
+  HistoryTitle: "📜 Recent Activity"
+  HistoryEmpty: "No recent activity found."
+  HistoryGrabbed: "Grabbed"
+  HistoryImported: "Imported"
+  HistoryFailed: "Failed"
+  HistoryAll: "All"
+```
+
+For non-English locales, keep the same keys with translated values. The emoji prefixes stay the same. Use reasonable translations for each language.
+
+**Validation:** Run `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` to verify all keys present.
+
+---
+
+## Phase 4: Keyboards
+
+### Task 4.1: Add history keyboard functions to `keyboards.py`
+
+**Files:**
+- Modify: `src/bot/keyboards.py`
+- Test: `tests/test_bot/test_keyboards.py`
+
+**Context:**
+- Follow the `get_calendar_items_keyboard` / `get_missing_items_keyboard` pattern
+- Need two keyboards: items display with pagination, and filter selection
+
+**Implementation:**
+
+```python
+_HISTORY_EVENT_EMOJI = {
+    "grabbed": "\U0001f4e5",          # inbox tray
+    "downloadFolderImported": "\u2705",  # check mark
+    "downloadFailed": "\u274c",          # cross mark
+    "movieFileDeleted": "\U0001f5d1",    # wastebasket
+    "episodeFileDeleted": "\U0001f5d1",
+    "movieFileRenamed": "\U0001f4dd",    # memo
+    "episodeFileRenamed": "\U0001f4dd",
+}
+
+
+def get_history_items_keyboard(
+    items: list, page: int = 0, page_size: int = 5,
+    event_filter: str = None,
+) -> InlineKeyboardMarkup:
+    """Paginated history items keyboard with filter tabs."""
+    translation = TranslationService()
+    total_pages = max(1, -(-len(items) // page_size))
+    start = page * page_size
+    page_items = items[start:start + page_size]
+
+    keyboard = []
+
+    # Filter tabs row
+    filters = [
+        ("HistoryAll", None),
+        ("HistoryGrabbed", "grabbed"),
+        ("HistoryImported", "downloadFolderImported"),
+        ("HistoryFailed", "downloadFailed"),
+    ]
+    filter_row = []
+    for label_key, filter_val in filters:
+        prefix = "\u2022 " if event_filter == filter_val else ""
+        cb = f"hist_filter_{filter_val}" if filter_val else "hist_filter_all"
+        filter_row.append(
+            InlineKeyboardButton(
+                f"{prefix}{translation.get_text(label_key)}",
+                callback_data=cb,
+            )
+        )
+    keyboard.append(filter_row)
+
+    # Item rows
+    for item in page_items:
+        emoji = _HISTORY_EVENT_EMOJI.get(item.get("event_type"), "\u2753")
+        type_emoji = _MEDIA_TYPE_EMOJI.get(item.get("type"), "")
+        title = item.get("title", "")
+        # Truncate long titles
+        if len(title) > 30:
+            title = title[:27] + "..."
+        quality = item.get("quality", "")
+        date_str = item.get("date", "")[:10]
+
+        label = f"{emoji} {type_emoji} {title} [{quality}] {date_str}"
+        keyboard.append([
+            InlineKeyboardButton(label, callback_data="hist_noop")
+        ])
+
+    # Pagination row
+    if total_pages > 1:
+        nav_row = []
+        if page > 0:
+            nav_row.append(InlineKeyboardButton(
+                f"\u25c0\ufe0f {translation.get_text('Previous')}",
+                callback_data=f"hist_page_{page - 1}",
+            ))
+        nav_row.append(InlineKeyboardButton(
+            f"{page + 1}/{total_pages}",
+            callback_data="hist_noop",
+        ))
+        if page < total_pages - 1:
+            nav_row.append(InlineKeyboardButton(
+                f"{translation.get_text('Next')} \u25b6\ufe0f",
+                callback_data=f"hist_page_{page + 1}",
+            ))
+        keyboard.append(nav_row)
+
+    # Action row
+    keyboard.append([
+        InlineKeyboardButton(
+            "\U0001f504 " + translation.get_text("Search"),
+            callback_data="hist_refresh",
+        ),
+        InlineKeyboardButton(
+            "\u25c0\ufe0f " + translation.get_text("Back"),
+            callback_data="hist_back",
+        ),
+    ])
+
+    return InlineKeyboardMarkup(keyboard)
+
+
+def get_history_empty_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard for empty history state."""
+    translation = TranslationService()
+    return InlineKeyboardMarkup([[
+        InlineKeyboardButton(
+            "\U0001f504 " + translation.get_text("Search"),
+            callback_data="hist_refresh",
+        ),
+        InlineKeyboardButton(
+            "\u25c0\ufe0f " + translation.get_text("Back"),
+            callback_data="hist_back",
+        ),
+    ]])
+```
+
+**Tests:**
+1. `test_get_history_items_keyboard_with_items` — 6 items, verify pagination present
+2. `test_get_history_items_keyboard_empty` — 0 items, verify no item rows
+3. `test_get_history_items_keyboard_filter_active` — verify bullet prefix on active filter
+4. `test_get_history_empty_keyboard` — verify refresh and back buttons
+
+---
+
+## Phase 5: Handler
+
+### Task 5.1: Create HistoryHandler
+
+**Files:**
+- Create: `src/bot/handlers/history.py`
+- Test: `tests/test_handlers/test_history_handler.py`
+- Modify: `tests/test_handlers/conftest.py` (add `history_handler` fixture)
+
+**Context:**
+- Follow CalendarHandler pattern exactly: command handler + callback handler + `_build_response` helper
+- Use `context.user_data` for caching items, current page, current filter
+- `@require_auth` on both public methods
+
+**Implementation:**
+
+```python
+"""
+Filename: history.py
+Author: Addarr Contributors
+Created Date: 2026-03-09
+Description: History handler for recent Radarr/Sonarr activity.
+"""
+
+from telegram import Update
+from telegram.ext import CommandHandler, CallbackQueryHandler, ContextTypes
+
+from src.utils.logger import get_logger, log_user_interaction
+from src.bot.handlers.auth import require_auth
+from src.bot.keyboards import (
+    get_history_items_keyboard,
+    get_history_empty_keyboard,
+    get_main_menu_keyboard,
+)
+from src.services.media import MediaService
+from src.services.translation import TranslationService
+
+logger = get_logger("addarr.history")
+
+
+class HistoryHandler:
+    """Handler for /history command showing recent activity."""
+
+    def __init__(self):
+        self.media_service = MediaService()
+        self.translation = TranslationService()
+
+    def get_handler(self):
+        """Get history command handlers."""
+        return [
+            CommandHandler("history", self.show_history),
+            CallbackQueryHandler(
+                self.handle_history_action, pattern="^hist_"
+            ),
+        ]
+
+    @require_auth
+    async def show_history(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Show recent activity with inline keyboard."""
+        if not update.effective_user:  # pragma: no cover
+            return
+
+        log_user_interaction(logger, update.effective_user, "/history")
+
+        context.user_data["hist_filter"] = None
+        context.user_data["hist_page"] = 0
+
+        items = await self.media_service.get_history()
+        context.user_data["hist_items"] = items
+
+        text, keyboard = self._build_response(items)
+
+        if update.callback_query:
+            await update.callback_query.message.edit_text(
+                text, reply_markup=keyboard
+            )
+        else:
+            await update.message.reply_text(text, reply_markup=keyboard)
+
+    @require_auth
+    async def handle_history_action(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle history callback button presses."""
+        if not update.callback_query:
+            return
+
+        query = update.callback_query
+        data = query.data
+
+        log_user_interaction(logger, query.from_user, data)
+
+        if data.startswith("hist_filter_"):
+            await self._handle_filter(query, context)
+        elif data.startswith("hist_page_"):
+            await self._handle_page(query, context)
+        elif data == "hist_refresh":
+            await self._handle_refresh(query, context)
+        elif data == "hist_back":
+            await self._handle_back(query)
+        else:
+            await query.answer()
+
+    async def _handle_filter(self, query, context):
+        """Change event type filter and re-fetch."""
+        raw = query.data.replace("hist_filter_", "")
+        event_filter = None if raw == "all" else raw
+        context.user_data["hist_filter"] = event_filter
+        context.user_data["hist_page"] = 0
+
+        items = await self.media_service.get_history(
+            event_type=event_filter
+        )
+        context.user_data["hist_items"] = items
+
+        text, keyboard = self._build_response(
+            items, event_filter=event_filter
+        )
+        await query.message.edit_text(text, reply_markup=keyboard)
+        await query.answer()
+
+    async def _handle_page(self, query, context):
+        """Show a different page of cached history items."""
+        page = int(query.data.split("_")[-1])
+        context.user_data["hist_page"] = page
+        items = context.user_data.get("hist_items", [])
+        event_filter = context.user_data.get("hist_filter")
+
+        text, keyboard = self._build_response(
+            items, page=page, event_filter=event_filter
+        )
+        await query.message.edit_text(text, reply_markup=keyboard)
+        await query.answer()
+
+    async def _handle_refresh(self, query, context):
+        """Re-fetch history data."""
+        event_filter = context.user_data.get("hist_filter")
+        context.user_data["hist_page"] = 0
+
+        items = await self.media_service.get_history(
+            event_type=event_filter
+        )
+        context.user_data["hist_items"] = items
+
+        text, keyboard = self._build_response(
+            items, event_filter=event_filter
+        )
+        await query.message.edit_text(text, reply_markup=keyboard)
+        await query.answer()
+
+    async def _handle_back(self, query):
+        """Return to the main menu."""
+        await query.message.edit_text(
+            "\U0001f3e0 Main Menu",
+            reply_markup=get_main_menu_keyboard(),
+        )
+        await query.answer()
+
+    def _build_response(self, items, page=0, event_filter=None):
+        """Build history text and keyboard from items."""
+        if items:
+            title = self.translation.get_text("HistoryTitle")
+            text = f"\U0001f4dc {title}\n\n{len(items)} items"
+            keyboard = get_history_items_keyboard(
+                items, page, event_filter=event_filter
+            )
+        else:
+            text = (
+                f"\U0001f4dc {self.translation.get_text('HistoryTitle')}"
+                f"\n\n{self.translation.get_text('HistoryEmpty')}"
+            )
+            keyboard = get_history_empty_keyboard()
+        return text, keyboard
+```
+
+**Handler fixture (add to `tests/test_handlers/conftest.py`):**
+
+```python
+@pytest.fixture
+def history_handler(mock_media_service, mock_translation_service):
+    """Create a HistoryHandler with patched services."""
+    with (
+        patch("src.bot.handlers.history.MediaService") as mock_ms_class,
+        patch("src.bot.handlers.history.TranslationService") as mock_ts_class,
+        patch("src.bot.handlers.history.get_history_items_keyboard") as mock_items_kbd,
+        patch("src.bot.handlers.history.get_history_empty_keyboard") as mock_empty_kbd,
+        patch("src.bot.handlers.history.get_main_menu_keyboard") as mock_menu_kbd,
+    ):
+        mock_ts_class.return_value = mock_translation_service
+        mock_ms_class.return_value = mock_media_service
+        mock_media_service.get_history = AsyncMock(return_value=[])
+        mock_items_kbd.return_value = MagicMock()
+        mock_empty_kbd.return_value = MagicMock()
+        mock_menu_kbd.return_value = MagicMock()
+
+        from src.bot.handlers.history import HistoryHandler
+        from src.bot.handlers.auth import AuthHandler
+
+        AuthHandler._authenticated_users = {12345}
+        handler = HistoryHandler()
+        handler._mock_service = mock_media_service
+        handler._mock_ts = mock_translation_service
+        handler._mock_items_kbd = mock_items_kbd
+        handler._mock_empty_kbd = mock_empty_kbd
+        handler._mock_menu_kbd = mock_menu_kbd
+        yield handler
+```
+
+**Tests:**
+1. `test_show_history_with_results` — service returns items, verify reply_text called with title, items cached in user_data
+2. `test_show_history_empty` — service returns [], verify empty text shown, empty keyboard used
+3. `test_show_history_via_callback` — callback_query present, verify edit_text called instead of reply_text
+4. `test_show_history_no_user` — effective_user is None, verify returns immediately
+5. `test_handle_filter_grabbed` — callback `hist_filter_grabbed`, verify `get_history(event_type="grabbed")` called
+6. `test_handle_filter_all` — callback `hist_filter_all`, verify `get_history(event_type=None)` called
+7. `test_handle_page` — callback `hist_page_1`, verify page 1 shown from cached items
+8. `test_handle_refresh` — callback `hist_refresh`, verify `get_history()` re-called
+9. `test_handle_back` — callback `hist_back`, verify main menu shown
+10. `test_handle_noop` — callback `hist_noop`, verify `query.answer()` called
+
+---
+
+## Phase 6: Registration and Integration
+
+### Task 6.1: Register HistoryHandler in main.py and commands
+
+**Files:**
+- Modify: `src/main.py` (add import + registration in `_add_handlers`)
+- Modify: `src/bot/commands.py` (add `history` command description)
+- Modify: `src/bot/handlers/__init__.py` (add to `__all__`)
+- Test: `tests/test_main.py` (verify handler registered)
+- Test: `tests/test_bot/test_commands.py` (verify command listed)
+
+**Registration location:** After Queue handler, before Transmission handler (follows the logical grouping of media information commands).
+
+```python
+# In _add_handlers():
+# History handler
+history_handler = HistoryHandler()
+for handler in history_handler.get_handler():
+    self.application.add_handler(handler)
+```
+
+**Command registration in `src/bot/commands.py`:**
+Add `("history", "CommandHistory")` to the default commands list.
+
+### Task 6.2: Update architecture test conventions
+
+**Files:**
+- Verify: `tests/test_architecture/test_conventions.py` — HistoryHandler will be auto-detected by the `test_all_handlers_have_get_handler` test since it checks all `*Handler` classes. No manual changes needed unless a new service singleton is added (none in this plan).
+
+---
+
+## Verification
+
+After all tasks complete:
+
+1. `python -m pytest --tb=short -q` — all tests pass
+2. `python -m flake8 .` — no lint errors
+3. `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` — all translation keys present
+4. `python -m pytest --cov=src.api.radarr --cov=src.api.sonarr --cov=src.services.media --cov=src.bot.handlers.history --cov=src.bot.keyboards --cov-report=term-missing` — 100% coverage on new code

--- a/src/api/radarr.py
+++ b/src/api/radarr.py
@@ -291,6 +291,32 @@ class RadarrClient(BaseApiClient):
             logger.error(Fore.RED + f"❌ Failed to get calendar: {str(e)}")
             return []
 
+    async def get_history(self, page: int = 1, page_size: int = 20,
+                          event_type: str = None) -> List[Dict]:
+        """Get recent history from Radarr."""
+        try:
+            logger.info(Fore.BLUE + "📜 Getting history from Radarr")
+            endpoint = (
+                f"history?sortKey=date&sortDirection=descending"
+                f"&page={page}&pageSize={page_size}"
+            )
+            if event_type:
+                endpoint += f"&eventType={event_type}"
+
+            result = await self._request(endpoint)
+
+            if not result or not isinstance(result, dict):
+                logger.warning(Fore.YELLOW + "⚠️ No history found in Radarr")
+                return []
+
+            records = result.get("records", [])
+            logger.info(Fore.GREEN + f"✅ Found {len(records)} history items in Radarr")
+            return records
+
+        except Exception as e:
+            logger.error(Fore.RED + f"❌ Failed to get Radarr history: {str(e)}")
+            return []
+
     async def get_movies(self) -> List[Dict]:
         """Get all movies in the library"""
         try:

--- a/src/api/sonarr.py
+++ b/src/api/sonarr.py
@@ -297,6 +297,32 @@ class SonarrClient(BaseApiClient):
             logger.error(Fore.RED + f"❌ Failed to get calendar: {str(e)}")
             return []
 
+    async def get_history(self, page: int = 1, page_size: int = 20,
+                          event_type: str = None) -> List[Dict]:
+        """Get recent history from Sonarr."""
+        try:
+            logger.info(Fore.BLUE + "📜 Getting history from Sonarr")
+            endpoint = (
+                f"history?sortKey=date&sortDirection=descending"
+                f"&page={page}&pageSize={page_size}"
+            )
+            if event_type:
+                endpoint += f"&eventType={event_type}"
+
+            result = await self._request(endpoint)
+
+            if not result or not isinstance(result, dict):
+                logger.warning(Fore.YELLOW + "⚠️ No history found in Sonarr")
+                return []
+
+            records = result.get("records", [])
+            logger.info(Fore.GREEN + f"✅ Found {len(records)} history items in Sonarr")
+            return records
+
+        except Exception as e:
+            logger.error(Fore.RED + f"❌ Failed to get Sonarr history: {str(e)}")
+            return []
+
     async def get_all_series(self) -> List[Dict]:
         """Get all series in the library"""
         try:

--- a/src/bot/commands.py
+++ b/src/bot/commands.py
@@ -63,6 +63,9 @@ def build_authenticated_commands() -> list:
             or config.get("lidarr", {}).get("enable")):
         commands.append(BotCommand("queue", translation.get_text("CommandQueue")))
 
+    if config.get("radarr", {}).get("enable") or config.get("sonarr", {}).get("enable"):
+        commands.append(BotCommand("history", translation.get_text("CommandHistory")))
+
     if config.get("transmission", {}).get("enable", False):
         commands.append(BotCommand("transmission", translation.get_text("CommandTransmission")))
 

--- a/src/bot/handlers/__init__.py
+++ b/src/bot/handlers/__init__.py
@@ -11,6 +11,7 @@ Each handler is responsible for managing a specific type of user interaction.
 
 from .auth import AuthHandler
 from .calendar import CalendarHandler
+from .history import HistoryHandler
 from .media import MediaHandler
 from .delete import DeleteHandler
 from .library import LibraryHandler
@@ -18,6 +19,6 @@ from .settings import SettingsHandler
 from .system import SystemHandler
 
 __all__ = [
-    'AuthHandler', 'CalendarHandler', 'MediaHandler', 'DeleteHandler',
-    'LibraryHandler', 'SettingsHandler', 'SystemHandler',
+    'AuthHandler', 'CalendarHandler', 'HistoryHandler', 'MediaHandler',
+    'DeleteHandler', 'LibraryHandler', 'SettingsHandler', 'SystemHandler',
 ]

--- a/src/bot/handlers/history.py
+++ b/src/bot/handlers/history.py
@@ -1,0 +1,158 @@
+"""
+Filename: history.py
+Author: Addarr Contributors
+Created Date: 2026-03-09
+Description: History handler for recent Radarr/Sonarr activity.
+"""
+
+from telegram import Update
+from telegram.ext import CommandHandler, CallbackQueryHandler, ContextTypes
+
+from src.utils.logger import get_logger, log_user_interaction
+from src.bot.handlers.auth import require_auth
+from src.bot.keyboards import (
+    get_history_items_keyboard,
+    get_history_empty_keyboard,
+    get_main_menu_keyboard,
+)
+from src.services.media import MediaService
+from src.services.translation import TranslationService
+
+logger = get_logger("addarr.history")
+
+
+class HistoryHandler:
+    """Handler for /history command showing recent activity."""
+
+    def __init__(self):
+        self.media_service = MediaService()
+        self.translation = TranslationService()
+
+    def get_handler(self):
+        """Get history command handlers."""
+        return [
+            CommandHandler("history", self.show_history),
+            CallbackQueryHandler(
+                self.handle_history_action, pattern="^hist_"
+            ),
+        ]
+
+    @require_auth
+    async def show_history(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Show recent activity with inline keyboard."""
+        if not update.effective_user:  # pragma: no cover
+            return
+
+        log_user_interaction(logger, update.effective_user, "/history")
+
+        context.user_data["hist_filter"] = None
+        context.user_data["hist_page"] = 0
+
+        items = await self.media_service.get_history()
+        context.user_data["hist_items"] = items
+
+        text, keyboard = self._build_response(items)
+
+        if update.callback_query:
+            await update.callback_query.message.edit_text(
+                text, reply_markup=keyboard
+            )
+        else:
+            await update.message.reply_text(text, reply_markup=keyboard)
+
+    @require_auth
+    async def handle_history_action(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle history callback button presses."""
+        if not update.callback_query:
+            return
+
+        query = update.callback_query
+        data = query.data
+
+        log_user_interaction(logger, query.from_user, data)
+
+        if data.startswith("hist_filter_"):
+            await self._handle_filter(query, context)
+        elif data.startswith("hist_page_"):
+            await self._handle_page(query, context)
+        elif data == "hist_refresh":
+            await self._handle_refresh(query, context)
+        elif data == "hist_back":
+            await self._handle_back(query)
+        else:
+            await query.answer()
+
+    async def _handle_filter(self, query, context):
+        """Change event type filter and re-fetch."""
+        raw = query.data.replace("hist_filter_", "")
+        event_filter = None if raw == "all" else raw
+        context.user_data["hist_filter"] = event_filter
+        context.user_data["hist_page"] = 0
+
+        items = await self.media_service.get_history(
+            event_type=event_filter
+        )
+        context.user_data["hist_items"] = items
+
+        text, keyboard = self._build_response(
+            items, event_filter=event_filter
+        )
+        await query.message.edit_text(text, reply_markup=keyboard)
+        await query.answer()
+
+    async def _handle_page(self, query, context):
+        """Show a different page of cached history items."""
+        page = int(query.data.split("_")[-1])
+        context.user_data["hist_page"] = page
+        items = context.user_data.get("hist_items", [])
+        event_filter = context.user_data.get("hist_filter")
+
+        text, keyboard = self._build_response(
+            items, page=page, event_filter=event_filter
+        )
+        await query.message.edit_text(text, reply_markup=keyboard)
+        await query.answer()
+
+    async def _handle_refresh(self, query, context):
+        """Re-fetch history data."""
+        event_filter = context.user_data.get("hist_filter")
+        context.user_data["hist_page"] = 0
+
+        items = await self.media_service.get_history(
+            event_type=event_filter
+        )
+        context.user_data["hist_items"] = items
+
+        text, keyboard = self._build_response(
+            items, event_filter=event_filter
+        )
+        await query.message.edit_text(text, reply_markup=keyboard)
+        await query.answer()
+
+    async def _handle_back(self, query):
+        """Return to the main menu."""
+        await query.message.edit_text(
+            "\U0001f3e0 Main Menu",
+            reply_markup=get_main_menu_keyboard(),
+        )
+        await query.answer()
+
+    def _build_response(self, items, page=0, event_filter=None):
+        """Build history text and keyboard from items."""
+        if items:
+            title = self.translation.get_text("HistoryTitle")
+            text = f"\U0001f4dc {title}\n\n{len(items)} items"
+            keyboard = get_history_items_keyboard(
+                items, page, event_filter=event_filter
+            )
+        else:
+            text = (
+                f"\U0001f4dc {self.translation.get_text('HistoryTitle')}"
+                f"\n\n{self.translation.get_text('HistoryEmpty')}"
+            )
+            keyboard = get_history_empty_keyboard()
+        return text, keyboard

--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -1057,3 +1057,113 @@ def get_yes_no_keyboard(callback_prefix: str, yes_text: str = "Yes", no_text: st
         ]
     ]
     return InlineKeyboardMarkup(keyboard)
+
+
+# ---------------------------------------------------------------------------
+# History keyboards
+# ---------------------------------------------------------------------------
+
+_HISTORY_EVENT_EMOJI = {
+    "grabbed": "\U0001f4e5",
+    "downloadFolderImported": "\u2705",
+    "downloadFailed": "\u274c",
+    "movieFileDeleted": "\U0001f5d1",
+    "episodeFileDeleted": "\U0001f5d1",
+    "movieFileRenamed": "\U0001f4dd",
+    "episodeFileRenamed": "\U0001f4dd",
+}
+
+
+def get_history_items_keyboard(
+    items: list, page: int = 0, page_size: int = 5,
+    event_filter: str = None,
+) -> InlineKeyboardMarkup:
+    """Paginated history items keyboard with filter tabs."""
+    translation = TranslationService()
+    total_pages = max(1, -(-len(items) // page_size))
+    start = page * page_size
+    page_items = items[start:start + page_size]
+
+    keyboard = []
+
+    # Filter tabs row
+    filters = [
+        ("HistoryAll", None),
+        ("HistoryGrabbed", "grabbed"),
+        ("HistoryImported", "downloadFolderImported"),
+        ("HistoryFailed", "downloadFailed"),
+    ]
+    filter_row = []
+    for label_key, filter_val in filters:
+        prefix = "\u2022 " if event_filter == filter_val else ""
+        cb = f"hist_filter_{filter_val}" if filter_val else "hist_filter_all"
+        filter_row.append(
+            InlineKeyboardButton(
+                f"{prefix}{translation.get_text(label_key)}",
+                callback_data=cb,
+            )
+        )
+    keyboard.append(filter_row)
+
+    # Item rows
+    for item in page_items:
+        emoji = _HISTORY_EVENT_EMOJI.get(item.get("event_type"), "\u2753")
+        type_emoji = _MEDIA_TYPE_EMOJI.get(item.get("type"), "")
+        title = item.get("title", "")
+        if len(title) > 30:
+            title = title[:27] + "..."
+        quality = item.get("quality", "")
+        date_str = item.get("date", "")[:10]
+
+        label = f"{emoji} {type_emoji} {title} [{quality}] {date_str}"
+        keyboard.append([
+            InlineKeyboardButton(label, callback_data="hist_noop")
+        ])
+
+    # Pagination row
+    if total_pages > 1:
+        nav_row = []
+        if page > 0:
+            nav_row.append(InlineKeyboardButton(
+                f"\u25c0\ufe0f {translation.get_text('Previous')}",
+                callback_data=f"hist_page_{page - 1}",
+            ))
+        nav_row.append(InlineKeyboardButton(
+            f"{page + 1}/{total_pages}",
+            callback_data="hist_noop",
+        ))
+        if page < total_pages - 1:
+            nav_row.append(InlineKeyboardButton(
+                f"{translation.get_text('Next')} \u25b6\ufe0f",
+                callback_data=f"hist_page_{page + 1}",
+            ))
+        keyboard.append(nav_row)
+
+    # Action row
+    keyboard.append([
+        InlineKeyboardButton(
+            "\U0001f504 " + translation.get_text("Search"),
+            callback_data="hist_refresh",
+        ),
+        InlineKeyboardButton(
+            "\u25c0\ufe0f " + translation.get_text("Back"),
+            callback_data="hist_back",
+        ),
+    ])
+
+    return InlineKeyboardMarkup(keyboard)
+
+
+def get_history_empty_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard for empty history state."""
+    translation = TranslationService()
+    return InlineKeyboardMarkup([[
+        InlineKeyboardButton(
+            "\U0001f504 " + translation.get_text("Search"),
+            callback_data="hist_refresh",
+        ),
+        InlineKeyboardButton(
+            "\u25c0\ufe0f " + translation.get_text("Back"),
+            callback_data="hist_back",
+        ),
+    ]])

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ from src.bot.handlers.auth import AuthHandler
 from src.bot.handlers.calendar import CalendarHandler
 from src.bot.handlers.missing import MissingHandler
 from src.bot.handlers.queue import QueueHandler
+from src.bot.handlers.history import HistoryHandler
 from src.bot.handlers.delete import DeleteHandler
 from src.bot.handlers.library import LibraryHandler
 from src.bot.handlers.media import MediaHandler
@@ -149,6 +150,11 @@ class AddarrBot:
             # Queue handler
             queue_handler = QueueHandler()
             for handler in queue_handler.get_handler():
+                self.application.add_handler(handler)
+
+            # History handler
+            history_handler = HistoryHandler()
+            for handler in history_handler.get_handler():
                 self.application.add_handler(handler)
 
             # Transmission handler (if enabled)

--- a/src/services/media.py
+++ b/src/services/media.py
@@ -972,6 +972,80 @@ class MediaService:
             logger.error(f"Error checking Transmission status: {e}")
             return False
 
+    async def get_history(self, page: int = 1, page_size: int = 20,
+                          event_type: str = None) -> List[Dict]:
+        """Get recent history from Radarr and Sonarr.
+
+        Returns a normalized, date-sorted (newest first) list of history items.
+        """
+        tasks = []
+        if self.radarr:
+            tasks.append(("radarr", self.radarr.get_history(
+                page, page_size, event_type
+            )))
+        if self.sonarr:
+            tasks.append(("sonarr", self.sonarr.get_history(
+                page, page_size, event_type
+            )))
+
+        if not tasks:
+            return []
+
+        results = await asyncio.gather(
+            *(t[1] for t in tasks), return_exceptions=True
+        )
+
+        items = []
+        for (service_name, _), result in zip(tasks, results):
+            if isinstance(result, Exception):
+                logger.error(f"History fetch failed for {service_name}: {result}")
+                continue
+
+            if service_name == "radarr":
+                for record in result:
+                    items.append(self._normalize_radarr_history(record))
+            else:
+                for record in result:
+                    items.append(self._normalize_sonarr_history(record))
+
+        items.sort(key=lambda x: x.get("date", ""), reverse=True)
+        return items
+
+    @staticmethod
+    def _normalize_radarr_history(record: Dict) -> Dict:
+        """Normalize a Radarr history record."""
+        movie = record.get("movie", {})
+        return {
+            "type": "movie",
+            "title": movie.get("title", ""),
+            "episode_title": None,
+            "season": None,
+            "episode": None,
+            "date": record.get("date", ""),
+            "event_type": record.get("eventType", ""),
+            "quality": record.get("quality", {}).get("quality", {}).get("name", ""),
+            "source_title": record.get("sourceTitle", ""),
+            "service": "radarr",
+        }
+
+    @staticmethod
+    def _normalize_sonarr_history(record: Dict) -> Dict:
+        """Normalize a Sonarr history record."""
+        series = record.get("series", {})
+        ep = record.get("episode", {})
+        return {
+            "type": "episode",
+            "title": series.get("title", ""),
+            "episode_title": ep.get("title"),
+            "season": ep.get("seasonNumber"),
+            "episode": ep.get("episodeNumber"),
+            "date": record.get("date", ""),
+            "event_type": record.get("eventType", ""),
+            "quality": record.get("quality", {}).get("quality", {}).get("name", ""),
+            "source_title": record.get("sourceTitle", ""),
+            "service": "sonarr",
+        }
+
     async def get_sabnzbd_status(self) -> bool:
         """Check if SABnzbd is available"""
         try:

--- a/tests/fixtures/sample_data.py
+++ b/tests/fixtures/sample_data.py
@@ -410,6 +410,69 @@ SONARR_QUEUE = {
     ],
 }
 
+RADARR_HISTORY = {
+    "page": 1,
+    "pageSize": 20,
+    "totalRecords": 3,
+    "records": [
+        {
+            "id": 1, "movieId": 10,
+            "sourceTitle": "Fight.Club.1999.1080p.BluRay",
+            "quality": {"quality": {"name": "Bluray-1080p"}},
+            "date": "2026-03-09T14:30:00Z",
+            "eventType": "grabbed",
+            "data": {"indexer": "NZBgeek"},
+            "movie": {"title": "Fight Club", "year": 1999, "tmdbId": 550},
+        },
+        {
+            "id": 2, "movieId": 10,
+            "sourceTitle": "Fight.Club.1999.1080p.BluRay",
+            "quality": {"quality": {"name": "Bluray-1080p"}},
+            "date": "2026-03-09T15:00:00Z",
+            "eventType": "downloadFolderImported",
+            "data": {},
+            "movie": {"title": "Fight Club", "year": 1999, "tmdbId": 550},
+        },
+        {
+            "id": 3, "movieId": 20,
+            "sourceTitle": "Pulp.Fiction.1994.720p",
+            "quality": {"quality": {"name": "Bluray-720p"}},
+            "date": "2026-03-08T10:00:00Z",
+            "eventType": "downloadFailed",
+            "data": {"indexer": "Drunken Slug"},
+            "movie": {"title": "Pulp Fiction", "year": 1994, "tmdbId": 680},
+        },
+    ],
+}
+
+SONARR_HISTORY = {
+    "page": 1,
+    "pageSize": 20,
+    "totalRecords": 2,
+    "records": [
+        {
+            "id": 101, "seriesId": 42, "episodeId": 201,
+            "sourceTitle": "Breaking.Bad.S01E01.720p",
+            "quality": {"quality": {"name": "HDTV-720p"}},
+            "date": "2026-03-09T12:00:00Z",
+            "eventType": "grabbed",
+            "data": {"indexer": "NZBgeek"},
+            "series": {"title": "Breaking Bad", "year": 2008, "tvdbId": 81189},
+            "episode": {"title": "Pilot", "seasonNumber": 1, "episodeNumber": 1},
+        },
+        {
+            "id": 102, "seriesId": 42, "episodeId": 201,
+            "sourceTitle": "Breaking.Bad.S01E01.720p",
+            "quality": {"quality": {"name": "HDTV-720p"}},
+            "date": "2026-03-09T12:30:00Z",
+            "eventType": "downloadFolderImported",
+            "data": {},
+            "series": {"title": "Breaking Bad", "year": 2008, "tvdbId": 81189},
+            "episode": {"title": "Pilot", "seasonNumber": 1, "episodeNumber": 1},
+        },
+    ],
+}
+
 LIDARR_QUEUE = {
     "page": 1,
     "pageSize": 1000,

--- a/tests/test_api/test_radarr.py
+++ b/tests/test_api/test_radarr.py
@@ -17,6 +17,7 @@ from tests.fixtures.sample_data import (
     RADARR_WANTED_CUTOFF,
     RADARR_QUEUE,
     RADARR_DISK_SPACE,
+    RADARR_HISTORY,
 )
 
 
@@ -990,4 +991,74 @@ class TestRadarrGetDiskSpace:
         """Exception during get_disk_space returns empty list."""
         with patch.object(radarr_client, "_make_request", side_effect=Exception("boom")):
             results = await radarr_client.get_disk_space()
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# get_history
+# ---------------------------------------------------------------------------
+
+
+class TestRadarrGetHistory:
+    @pytest.mark.asyncio
+    async def test_get_history_success(self, aio_mock, radarr_client):
+        """Happy path: returns list of history records."""
+        aio_mock.get(
+            f"{BASE}/history?sortKey=date&sortDirection=descending"
+            f"&page=1&pageSize=20",
+            payload=RADARR_HISTORY,
+            status=200,
+        )
+        results = await radarr_client.get_history()
+        assert len(results) == 3
+        assert results[0]["movie"]["title"] == "Fight Club"
+        assert results[0]["eventType"] == "grabbed"
+
+    @pytest.mark.asyncio
+    async def test_get_history_with_event_type(self, aio_mock, radarr_client):
+        """Event type filter appended to URL."""
+        filtered = {
+            "page": 1, "pageSize": 20, "totalRecords": 1,
+            "records": [RADARR_HISTORY["records"][0]],
+        }
+        aio_mock.get(
+            f"{BASE}/history?sortKey=date&sortDirection=descending"
+            f"&page=1&pageSize=20&eventType=grabbed",
+            payload=filtered,
+            status=200,
+        )
+        results = await radarr_client.get_history(event_type="grabbed")
+        assert len(results) == 1
+        assert results[0]["eventType"] == "grabbed"
+
+    @pytest.mark.asyncio
+    async def test_get_history_empty(self, aio_mock, radarr_client):
+        """Empty records returns empty list."""
+        aio_mock.get(
+            f"{BASE}/history?sortKey=date&sortDirection=descending"
+            f"&page=1&pageSize=20",
+            payload={"page": 1, "pageSize": 20, "totalRecords": 0, "records": []},
+            status=200,
+        )
+        results = await radarr_client.get_history()
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_get_history_error(self, radarr_client):
+        """Exception during get_history returns empty list."""
+        with patch.object(radarr_client, "_make_request", side_effect=Exception("boom")):
+            results = await radarr_client.get_history()
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_get_history_non_dict_response(self, aio_mock, radarr_client):
+        """Non-dict response (None) returns empty list."""
+        aio_mock.get(
+            f"{BASE}/history?sortKey=date&sortDirection=descending"
+            f"&page=1&pageSize=20",
+            payload="",
+            status=200,
+        )
+        with patch.object(radarr_client, "_request", return_value=None):
+            results = await radarr_client.get_history()
         assert results == []

--- a/tests/test_api/test_sonarr.py
+++ b/tests/test_api/test_sonarr.py
@@ -15,6 +15,7 @@ from tests.fixtures.sample_data import (
     SONARR_WANTED_MISSING,
     SONARR_WANTED_CUTOFF,
     SONARR_QUEUE,
+    SONARR_HISTORY,
 )
 
 
@@ -921,4 +922,68 @@ class TestSonarrGetQueue:
         """Exception during get_queue returns empty list."""
         with patch.object(sonarr_client, "_make_request", side_effect=Exception("boom")):
             results = await sonarr_client.get_queue()
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# get_history
+# ---------------------------------------------------------------------------
+
+
+class TestSonarrGetHistory:
+    @pytest.mark.asyncio
+    async def test_get_history_success(self, aio_mock, sonarr_client):
+        """Happy path: returns list of history records."""
+        aio_mock.get(
+            f"{BASE}/history?sortKey=date&sortDirection=descending"
+            f"&page=1&pageSize=20",
+            payload=SONARR_HISTORY,
+            status=200,
+        )
+        results = await sonarr_client.get_history()
+        assert len(results) == 2
+        assert results[0]["series"]["title"] == "Breaking Bad"
+        assert results[0]["eventType"] == "grabbed"
+
+    @pytest.mark.asyncio
+    async def test_get_history_with_event_type(self, aio_mock, sonarr_client):
+        """Event type filter appended to URL."""
+        filtered = {
+            "page": 1, "pageSize": 20, "totalRecords": 1,
+            "records": [SONARR_HISTORY["records"][0]],
+        }
+        aio_mock.get(
+            f"{BASE}/history?sortKey=date&sortDirection=descending"
+            f"&page=1&pageSize=20&eventType=grabbed",
+            payload=filtered,
+            status=200,
+        )
+        results = await sonarr_client.get_history(event_type="grabbed")
+        assert len(results) == 1
+        assert results[0]["eventType"] == "grabbed"
+
+    @pytest.mark.asyncio
+    async def test_get_history_empty(self, aio_mock, sonarr_client):
+        """Empty records returns empty list."""
+        aio_mock.get(
+            f"{BASE}/history?sortKey=date&sortDirection=descending"
+            f"&page=1&pageSize=20",
+            payload={"page": 1, "pageSize": 20, "totalRecords": 0, "records": []},
+            status=200,
+        )
+        results = await sonarr_client.get_history()
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_get_history_error(self, sonarr_client):
+        """Exception during get_history returns empty list."""
+        with patch.object(sonarr_client, "_make_request", side_effect=Exception("boom")):
+            results = await sonarr_client.get_history()
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_get_history_non_dict_response(self, sonarr_client):
+        """Non-dict response (None) returns empty list."""
+        with patch.object(sonarr_client, "_request", return_value=None):
+            results = await sonarr_client.get_history()
         assert results == []

--- a/tests/test_bot/test_commands.py
+++ b/tests/test_bot/test_commands.py
@@ -95,7 +95,7 @@ class TestBuildAuthenticatedCommands:
         names = [c.command for c in commands]
         assert "movie" in names
         assert "allmovies" in names
-        assert len(commands) == 12  # 7 base + 2 + upcoming + missing + queue
+        assert len(commands) == 13  # 7 base + 2 + upcoming + missing + queue + history
 
     def test_sonarr_adds_series_and_allseries(self, mock_config):
         """Sonarr enabled adds series + allseries + upcoming + missing."""
@@ -108,7 +108,7 @@ class TestBuildAuthenticatedCommands:
         names = [c.command for c in commands]
         assert "series" in names
         assert "allseries" in names
-        assert len(commands) == 12  # 7 base + 2 + upcoming + missing + queue
+        assert len(commands) == 13  # 7 base + 2 + upcoming + missing + queue + history
 
     def test_lidarr_adds_music_and_allmusic(self, mock_config):
         """Lidarr enabled adds music + allmusic commands."""
@@ -186,7 +186,7 @@ class TestBuildAuthenticatedCommands:
         assert "missing" not in names
 
     def test_all_services_enabled(self, mock_config):
-        """All services enabled returns all 17 commands."""
+        """All services enabled returns all commands."""
         cfg = self._make_config(
             mock_config,
             radarr={"enable": True},
@@ -200,14 +200,14 @@ class TestBuildAuthenticatedCommands:
             from src.bot.commands import build_authenticated_commands
             commands = build_authenticated_commands()
 
-        assert len(commands) == 19
+        assert len(commands) == 20
         names = [c.command for c in commands]
         expected = [
             "start", "auth", "help", "status", "settings",
             "preferences", "delete", "movie", "allmovies",
             "series", "allseries", "music", "allmusic",
-            "upcoming", "missing", "queue", "transmission",
-            "sabnzbd", "downloads",
+            "upcoming", "missing", "queue", "history",
+            "transmission", "sabnzbd", "downloads",
         ]
         assert names == expected
 

--- a/tests/test_bot/test_keyboards.py
+++ b/tests/test_bot/test_keyboards.py
@@ -2075,7 +2075,6 @@ class TestHistoryItemsKeyboard:
         all_btn = [b for b in filter_row if b.callback_data == "hist_filter_all"][0]
         assert not all_btn.text.startswith("\u2022 ")
 
-
     @patch("src.bot.keyboards.TranslationService")
     def test_title_truncation(self, mock_ts):
         """Titles longer than 30 chars are truncated with ellipsis."""

--- a/tests/test_bot/test_keyboards.py
+++ b/tests/test_bot/test_keyboards.py
@@ -8,6 +8,8 @@ from src.bot.keyboards import (
     get_confirmation_keyboard,
     get_downloads_history_keyboard,
     get_downloads_queue_keyboard,
+    get_history_items_keyboard,
+    get_history_empty_keyboard,
     get_main_menu_keyboard,
     get_settings_keyboard,
     get_system_keyboard,
@@ -1986,3 +1988,132 @@ class TestDownloadsHistoryKeyboardClientTabs:
         ]
         assert "dl_client_sab" in callbacks
         assert "dl_client_tx" in callbacks
+
+
+# ---------------------------------------------------------------------------
+# History keyboards
+# ---------------------------------------------------------------------------
+
+HISTORY_ITEMS = [
+    {
+        "type": "movie", "title": "Fight Club", "event_type": "grabbed",
+        "quality": "Bluray-1080p", "date": "2026-03-09T14:30:00Z",
+        "source_title": "Fight.Club.1999.1080p.BluRay", "service": "radarr",
+    },
+    {
+        "type": "episode", "title": "Breaking Bad", "event_type": "downloadFolderImported",
+        "quality": "HDTV-720p", "date": "2026-03-09T12:00:00Z",
+        "source_title": "Breaking.Bad.S01E01.720p", "service": "sonarr",
+    },
+    {
+        "type": "movie", "title": "Pulp Fiction", "event_type": "downloadFailed",
+        "quality": "Bluray-720p", "date": "2026-03-08T10:00:00Z",
+        "source_title": "Pulp.Fiction.1994.720p", "service": "radarr",
+    },
+    {
+        "type": "movie", "title": "Inception", "event_type": "grabbed",
+        "quality": "Bluray-1080p", "date": "2026-03-07T10:00:00Z",
+        "source_title": "Inception.2010.1080p", "service": "radarr",
+    },
+    {
+        "type": "episode", "title": "Severance", "event_type": "grabbed",
+        "quality": "WEBDL-1080p", "date": "2026-03-06T10:00:00Z",
+        "source_title": "Severance.S02E01.1080p", "service": "sonarr",
+    },
+    {
+        "type": "movie", "title": "The Matrix", "event_type": "grabbed",
+        "quality": "Bluray-1080p", "date": "2026-03-05T10:00:00Z",
+        "source_title": "The.Matrix.1999.1080p", "service": "radarr",
+    },
+]
+
+
+class TestHistoryItemsKeyboard:
+    @patch("src.bot.keyboards.TranslationService")
+    def test_with_items_pagination_present(self, mock_ts):
+        """6 items with page_size=5: pagination row should be present."""
+        _mock_translation(mock_ts)
+        result = get_history_items_keyboard(HISTORY_ITEMS, page=0, page_size=5)
+        assert isinstance(result, InlineKeyboardMarkup)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        # Pagination should exist (6 items, 5 per page = 2 pages)
+        assert "hist_page_1" in callbacks
+        # Filter tabs should exist
+        assert "hist_filter_all" in callbacks
+        assert "hist_filter_grabbed" in callbacks
+        # Action row
+        assert "hist_refresh" in callbacks
+        assert "hist_back" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_empty_items_no_item_rows(self, mock_ts):
+        """0 items: no item rows, but filter tabs and action row present."""
+        _mock_translation(mock_ts)
+        result = get_history_items_keyboard([], page=0, page_size=5)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        # Filter tabs still present
+        assert "hist_filter_all" in callbacks
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_filter_active_highlight(self, mock_ts):
+        """Active filter shows bullet prefix."""
+        _mock_translation(mock_ts)
+        result = get_history_items_keyboard(
+            HISTORY_ITEMS, page=0, page_size=5, event_filter="grabbed"
+        )
+        filter_row = result.inline_keyboard[0]
+        # Find the "grabbed" filter button — should have bullet prefix
+        grabbed_btn = [b for b in filter_row if "grabbed" in b.callback_data][0]
+        assert grabbed_btn.text.startswith("\u2022 ")
+        # "All" should NOT have bullet
+        all_btn = [b for b in filter_row if b.callback_data == "hist_filter_all"][0]
+        assert not all_btn.text.startswith("\u2022 ")
+
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_title_truncation(self, mock_ts):
+        """Titles longer than 30 chars are truncated with ellipsis."""
+        _mock_translation(mock_ts)
+        long_item = {
+            "type": "movie", "title": "A" * 35, "event_type": "grabbed",
+            "quality": "HD", "date": "2026-03-09T14:30:00Z",
+            "source_title": "test", "service": "radarr",
+        }
+        result = get_history_items_keyboard([long_item], page=0, page_size=5)
+        item_row = result.inline_keyboard[1]
+        assert "..." in item_row[0].text
+        assert "A" * 27 in item_row[0].text
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_page_two_has_previous_button(self, mock_ts):
+        """Page > 0 shows Previous button."""
+        _mock_translation(mock_ts)
+        result = get_history_items_keyboard(
+            HISTORY_ITEMS, page=1, page_size=5
+        )
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "hist_page_0" in callbacks
+
+
+class TestHistoryEmptyKeyboard:
+    @patch("src.bot.keyboards.TranslationService")
+    def test_empty_keyboard_buttons(self, mock_ts):
+        """Empty keyboard has refresh and back buttons."""
+        _mock_translation(mock_ts)
+        result = get_history_empty_keyboard()
+        assert isinstance(result, InlineKeyboardMarkup)
+        callbacks = [
+            btn.callback_data
+            for row in result.inline_keyboard for btn in row
+        ]
+        assert "hist_refresh" in callbacks
+        assert "hist_back" in callbacks

--- a/tests/test_handlers/conftest.py
+++ b/tests/test_handlers/conftest.py
@@ -474,6 +474,40 @@ def queue_handler(mock_media_service, mock_translation_service):
 
 
 @pytest.fixture
+def history_handler(mock_media_service, mock_translation_service):
+    """Create a HistoryHandler with patched services."""
+    with (
+        patch("src.bot.handlers.history.MediaService") as mock_ms_class,
+        patch("src.bot.handlers.history.TranslationService") as mock_ts_class,
+        patch(
+            "src.bot.handlers.history.get_history_items_keyboard"
+        ) as mock_items_kbd,
+        patch(
+            "src.bot.handlers.history.get_history_empty_keyboard"
+        ) as mock_empty_kbd,
+        patch("src.bot.handlers.history.get_main_menu_keyboard") as mock_menu_kbd,
+    ):
+        mock_ts_class.return_value = mock_translation_service
+        mock_ms_class.return_value = mock_media_service
+        mock_media_service.get_history = AsyncMock(return_value=[])
+        mock_items_kbd.return_value = MagicMock()
+        mock_empty_kbd.return_value = MagicMock()
+        mock_menu_kbd.return_value = MagicMock()
+
+        from src.bot.handlers.history import HistoryHandler
+        from src.bot.handlers.auth import AuthHandler
+
+        AuthHandler._authenticated_users = {12345}
+        handler = HistoryHandler()
+        handler._mock_service = mock_media_service
+        handler._mock_ts = mock_translation_service
+        handler._mock_items_kbd = mock_items_kbd
+        handler._mock_empty_kbd = mock_empty_kbd
+        handler._mock_menu_kbd = mock_menu_kbd
+        yield handler
+
+
+@pytest.fixture
 def preferences_handler(mock_translation_service):
     """Create a PreferencesHandler with patched services."""
     with (

--- a/tests/test_handlers/test_history_handler.py
+++ b/tests/test_handlers/test_history_handler.py
@@ -1,0 +1,265 @@
+"""
+Tests for src/bot/handlers/history.py - HistoryHandler.
+
+HistoryHandler owns /history and hist_* callbacks. show_history and
+handle_history_action are decorated with @require_auth.
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+
+
+# ---------------------------------------------------------------------------
+# Sample history items for reuse
+# ---------------------------------------------------------------------------
+
+SAMPLE_HISTORY_MOVIE = {
+    "type": "movie", "title": "Fight Club",
+    "episode_title": None, "season": None, "episode": None,
+    "date": "2026-03-09T14:30:00Z", "event_type": "grabbed",
+    "quality": "Bluray-1080p",
+    "source_title": "Fight.Club.1999.1080p.BluRay", "service": "radarr",
+}
+
+SAMPLE_HISTORY_EPISODE = {
+    "type": "episode", "title": "Breaking Bad",
+    "episode_title": "Pilot", "season": 1, "episode": 1,
+    "date": "2026-03-09T12:00:00Z", "event_type": "grabbed",
+    "quality": "HDTV-720p",
+    "source_title": "Breaking.Bad.S01E01.720p", "service": "sonarr",
+}
+
+
+# ---------------------------------------------------------------------------
+# get_handler
+# ---------------------------------------------------------------------------
+
+
+def test_get_handler_returns_list(history_handler):
+    """get_handler returns a list of handlers."""
+    handlers = history_handler.get_handler()
+    assert isinstance(handlers, list)
+    assert len(handlers) == 2
+
+
+# ---------------------------------------------------------------------------
+# show_history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_show_history_with_results(
+    history_handler, make_update, make_context
+):
+    """show_history sends message with items keyboard when results exist."""
+    items = [SAMPLE_HISTORY_MOVIE, SAMPLE_HISTORY_EPISODE]
+    history_handler._mock_service.get_history = AsyncMock(
+        return_value=items
+    )
+    update = make_update(text="/history")
+    context = make_context()
+
+    await history_handler.show_history(update, context)
+
+    history_handler._mock_service.get_history.assert_awaited_once()
+    update.message.reply_text.assert_called_once()
+    call_args = update.message.reply_text.call_args
+    assert "HistoryTitle" in call_args[0][0]
+    assert call_args[1]["reply_markup"] == \
+        history_handler._mock_items_kbd.return_value
+    assert context.user_data["hist_items"] == items
+
+
+@pytest.mark.asyncio
+async def test_show_history_empty(
+    history_handler, make_update, make_context
+):
+    """show_history sends empty-state message when no results."""
+    history_handler._mock_service.get_history = AsyncMock(
+        return_value=[]
+    )
+    update = make_update(text="/history")
+    context = make_context()
+
+    await history_handler.show_history(update, context)
+
+    update.message.reply_text.assert_called_once()
+    call_args = update.message.reply_text.call_args
+    assert "HistoryEmpty" in call_args[0][0]
+    assert call_args[1]["reply_markup"] == \
+        history_handler._mock_empty_kbd.return_value
+
+
+@pytest.mark.asyncio
+async def test_show_history_via_callback(
+    history_handler, make_update, make_context
+):
+    """show_history edits message when invoked via callback query."""
+    items = [SAMPLE_HISTORY_MOVIE]
+    history_handler._mock_service.get_history = AsyncMock(
+        return_value=items
+    )
+    update = make_update(callback_data="menu_history")
+    context = make_context()
+
+    await history_handler.show_history(update, context)
+
+    update.callback_query.message.edit_text.assert_called_once()
+    call_args = update.callback_query.message.edit_text.call_args
+    assert "HistoryTitle" in call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_show_history_no_user(
+    history_handler, make_update, make_context
+):
+    """@require_auth returns None when effective_user is None."""
+    update = make_update(text="/history")
+    update.effective_user = None
+    context = make_context()
+
+    result = await history_handler.show_history(update, context)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# handle_history_action — filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_filter_grabbed(
+    history_handler, make_update, make_context
+):
+    """hist_filter_grabbed fetches with event_type='grabbed'."""
+    items = [SAMPLE_HISTORY_MOVIE]
+    history_handler._mock_service.get_history = AsyncMock(
+        return_value=items
+    )
+    update = make_update(callback_data="hist_filter_grabbed")
+    context = make_context(user_data={
+        "hist_items": [], "hist_filter": None, "hist_page": 0,
+    })
+
+    await history_handler.handle_history_action(update, context)
+
+    history_handler._mock_service.get_history.assert_awaited_once_with(
+        event_type="grabbed"
+    )
+    assert context.user_data["hist_filter"] == "grabbed"
+    assert context.user_data["hist_page"] == 0
+    update.callback_query.message.edit_text.assert_called_once()
+    update.callback_query.answer.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_filter_all(
+    history_handler, make_update, make_context
+):
+    """hist_filter_all fetches with event_type=None."""
+    items = [SAMPLE_HISTORY_MOVIE]
+    history_handler._mock_service.get_history = AsyncMock(
+        return_value=items
+    )
+    update = make_update(callback_data="hist_filter_all")
+    context = make_context(user_data={
+        "hist_items": [], "hist_filter": "grabbed", "hist_page": 0,
+    })
+
+    await history_handler.handle_history_action(update, context)
+
+    history_handler._mock_service.get_history.assert_awaited_once_with(
+        event_type=None
+    )
+    assert context.user_data["hist_filter"] is None
+
+
+# ---------------------------------------------------------------------------
+# handle_history_action — navigation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_page_navigation(
+    history_handler, make_update, make_context
+):
+    """hist_page_1 shows page 1 from cached items."""
+    items = [SAMPLE_HISTORY_MOVIE] * 8
+    update = make_update(callback_data="hist_page_1")
+    context = make_context(user_data={
+        "hist_items": items, "hist_filter": None, "hist_page": 0,
+    })
+
+    await history_handler.handle_history_action(update, context)
+
+    assert context.user_data["hist_page"] == 1
+    update.callback_query.message.edit_text.assert_called_once()
+    update.callback_query.answer.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh(
+    history_handler, make_update, make_context
+):
+    """hist_refresh re-fetches history and resets page."""
+    new_items = [SAMPLE_HISTORY_MOVIE]
+    history_handler._mock_service.get_history = AsyncMock(
+        return_value=new_items
+    )
+    update = make_update(callback_data="hist_refresh")
+    context = make_context(user_data={
+        "hist_items": [], "hist_filter": "grabbed", "hist_page": 2,
+    })
+
+    await history_handler.handle_history_action(update, context)
+
+    history_handler._mock_service.get_history.assert_awaited_once_with(
+        event_type="grabbed"
+    )
+    assert context.user_data["hist_page"] == 0
+    assert context.user_data["hist_items"] == new_items
+
+
+@pytest.mark.asyncio
+async def test_back(
+    history_handler, make_update, make_context
+):
+    """hist_back returns to main menu."""
+    update = make_update(callback_data="hist_back")
+    context = make_context()
+
+    await history_handler.handle_history_action(update, context)
+
+    update.callback_query.message.edit_text.assert_called_once()
+    call_args = update.callback_query.message.edit_text.call_args
+    assert "Main Menu" in call_args[0][0]
+    assert call_args[1]["reply_markup"] == \
+        history_handler._mock_menu_kbd.return_value
+    update.callback_query.answer.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_action_no_callback_query(
+    history_handler, make_update, make_context
+):
+    """handle_history_action returns early when no callback_query."""
+    update = make_update(text="/history")
+    update.callback_query = None
+    context = make_context()
+
+    result = await history_handler.handle_history_action(update, context)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_noop(
+    history_handler, make_update, make_context
+):
+    """hist_noop just answers the callback query."""
+    update = make_update(callback_data="hist_noop")
+    context = make_context()
+
+    await history_handler.handle_history_action(update, context)
+
+    update.callback_query.answer.assert_called_once()
+    update.callback_query.message.edit_text.assert_not_called()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,6 +63,7 @@ def _make_handler_patches():
         "CalendarHandler": _mock_handler_class(),
         "MissingHandler": _mock_handler_class(),
         "QueueHandler": _mock_handler_class(),
+        "HistoryHandler": _mock_handler_class(),
         "TransmissionHandler": _mock_handler_class(),
         "SabnzbdHandler": _mock_handler_class(),
         "DownloadsHandler": _mock_handler_class(),
@@ -275,10 +276,10 @@ class TestAddHandlers:
         with patch.multiple("src.main", **_make_handler_patches()):
             bot._add_handlers()
 
-        # 13 always-on handlers (Start, Auth, Media, Settings, Delete,
-        # Library, Calendar, Missing, Queue, Downloads, Help, Preferences,
-        # System)
-        assert mock_app.add_handler.call_count == 13
+        # 14 always-on handlers (Start, Auth, Media, Settings, Delete,
+        # Library, Calendar, Missing, Queue, History, Downloads, Help,
+        # Preferences, System)
+        assert mock_app.add_handler.call_count == 14
 
     @patch("src.main.config")
     def test_transmission_enabled(self, mock_cfg, bot, mock_app):
@@ -295,8 +296,8 @@ class TestAddHandlers:
         with patch.multiple("src.main", **_make_handler_patches()):
             bot._add_handlers()
 
-        # 13 always-on + 1 transmission
-        assert mock_app.add_handler.call_count == 14
+        # 14 always-on + 1 transmission
+        assert mock_app.add_handler.call_count == 15
 
     @patch("src.main.config")
     def test_sabnzbd_enabled(self, mock_cfg, bot, mock_app):
@@ -313,8 +314,8 @@ class TestAddHandlers:
         with patch.multiple("src.main", **_make_handler_patches()):
             bot._add_handlers()
 
-        # 13 always-on + 1 sabnzbd
-        assert mock_app.add_handler.call_count == 14
+        # 14 always-on + 1 sabnzbd
+        assert mock_app.add_handler.call_count == 15
 
     @patch("src.main.config")
     def test_both_optional_enabled(self, mock_cfg, bot, mock_app):
@@ -331,8 +332,8 @@ class TestAddHandlers:
         with patch.multiple("src.main", **_make_handler_patches()):
             bot._add_handlers()
 
-        # 13 + 2
-        assert mock_app.add_handler.call_count == 15
+        # 14 + 2
+        assert mock_app.add_handler.call_count == 16
 
     def test_handler_error_reraises(self, bot, mock_app):
         """Exception during handler registration is re-raised."""

--- a/tests/test_services/conftest.py
+++ b/tests/test_services/conftest.py
@@ -25,6 +25,7 @@ def mock_radarr_client():
     client.get_cutoff_unmet = AsyncMock(return_value=[])
     client.search_command = AsyncMock(return_value=True)
     client.get_queue = AsyncMock(return_value=[])
+    client.get_history = AsyncMock(return_value=[])
     return client
 
 
@@ -48,6 +49,7 @@ def mock_sonarr_client():
     client.get_cutoff_unmet = AsyncMock(return_value=[])
     client.search_command = AsyncMock(return_value=True)
     client.get_queue = AsyncMock(return_value=[])
+    client.get_history = AsyncMock(return_value=[])
     return client
 
 

--- a/tests/test_services/test_media_service.py
+++ b/tests/test_services/test_media_service.py
@@ -2550,3 +2550,154 @@ class TestGetQueueMedia:
         assert len(results) == 1
         assert results[0]["type"] == "album"
         assert results[0]["service"] == "lidarr"
+
+
+# ---------------------------------------------------------------------------
+# get_history
+# ---------------------------------------------------------------------------
+
+RADARR_HISTORY_RECORD = {
+    "id": 1, "movieId": 10,
+    "sourceTitle": "Fight.Club.1999.1080p.BluRay",
+    "quality": {"quality": {"name": "Bluray-1080p"}},
+    "date": "2026-03-09T14:30:00Z",
+    "eventType": "grabbed",
+    "data": {"indexer": "NZBgeek"},
+    "movie": {"title": "Fight Club", "year": 1999, "tmdbId": 550},
+}
+
+SONARR_HISTORY_RECORD = {
+    "id": 101, "seriesId": 42, "episodeId": 201,
+    "sourceTitle": "Breaking.Bad.S01E01.720p",
+    "quality": {"quality": {"name": "HDTV-720p"}},
+    "date": "2026-03-09T12:00:00Z",
+    "eventType": "grabbed",
+    "data": {"indexer": "NZBgeek"},
+    "series": {"title": "Breaking Bad", "year": 2008, "tvdbId": 81189},
+    "episode": {"title": "Pilot", "seasonNumber": 1, "episodeNumber": 1},
+}
+
+
+class TestGetHistory:
+    @pytest.mark.asyncio
+    async def test_both_services_merged_sorted_desc(
+        self, mock_radarr_client, mock_sonarr_client
+    ):
+        """Both services return items — merged and sorted by date descending."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = mock_sonarr_client
+        mock_radarr_client.get_history.return_value = [RADARR_HISTORY_RECORD]
+        mock_sonarr_client.get_history.return_value = [SONARR_HISTORY_RECORD]
+
+        results = await service.get_history()
+
+        assert len(results) == 2
+        # Radarr (14:30) should come before Sonarr (12:00) — newest first
+        assert results[0]["service"] == "radarr"
+        assert results[0]["title"] == "Fight Club"
+        assert results[1]["service"] == "sonarr"
+        assert results[1]["title"] == "Breaking Bad"
+
+    @pytest.mark.asyncio
+    async def test_radarr_only(self, mock_radarr_client):
+        """Only Radarr enabled — returns only movie items."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = None
+        mock_radarr_client.get_history.return_value = [RADARR_HISTORY_RECORD]
+
+        results = await service.get_history()
+
+        assert len(results) == 1
+        assert results[0]["type"] == "movie"
+
+    @pytest.mark.asyncio
+    async def test_sonarr_only(self, mock_sonarr_client):
+        """Only Sonarr enabled — returns only episode items."""
+        service = MediaService()
+        MediaService._radarr = None
+        MediaService._sonarr = mock_sonarr_client
+        mock_sonarr_client.get_history.return_value = [SONARR_HISTORY_RECORD]
+
+        results = await service.get_history()
+
+        assert len(results) == 1
+        assert results[0]["type"] == "episode"
+
+    @pytest.mark.asyncio
+    async def test_no_services(self):
+        """Neither enabled — returns empty list."""
+        service = MediaService()
+        MediaService._radarr = None
+        MediaService._sonarr = None
+
+        results = await service.get_history()
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_one_exception_partial_result(
+        self, mock_radarr_client, mock_sonarr_client
+    ):
+        """One service raises — other still returns results."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = mock_sonarr_client
+        mock_radarr_client.get_history.side_effect = Exception("Radarr down")
+        mock_sonarr_client.get_history.return_value = [SONARR_HISTORY_RECORD]
+
+        results = await service.get_history()
+
+        assert len(results) == 1
+        assert results[0]["service"] == "sonarr"
+
+    @pytest.mark.asyncio
+    async def test_event_type_passthrough(
+        self, mock_radarr_client, mock_sonarr_client
+    ):
+        """Event type parameter passed through to both clients."""
+        service = MediaService()
+        MediaService._radarr = mock_radarr_client
+        MediaService._sonarr = mock_sonarr_client
+
+        await service.get_history(event_type="grabbed")
+
+        mock_radarr_client.get_history.assert_called_once_with(
+            1, 20, "grabbed"
+        )
+        mock_sonarr_client.get_history.assert_called_once_with(
+            1, 20, "grabbed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_normalize_radarr_history(self):
+        """Radarr normalizer produces correct schema."""
+        result = MediaService._normalize_radarr_history(RADARR_HISTORY_RECORD)
+
+        assert result["type"] == "movie"
+        assert result["title"] == "Fight Club"
+        assert result["episode_title"] is None
+        assert result["season"] is None
+        assert result["episode"] is None
+        assert result["date"] == "2026-03-09T14:30:00Z"
+        assert result["event_type"] == "grabbed"
+        assert result["quality"] == "Bluray-1080p"
+        assert result["source_title"] == "Fight.Club.1999.1080p.BluRay"
+        assert result["service"] == "radarr"
+
+    @pytest.mark.asyncio
+    async def test_normalize_sonarr_history(self):
+        """Sonarr normalizer produces correct schema."""
+        result = MediaService._normalize_sonarr_history(SONARR_HISTORY_RECORD)
+
+        assert result["type"] == "episode"
+        assert result["title"] == "Breaking Bad"
+        assert result["episode_title"] == "Pilot"
+        assert result["season"] == 1
+        assert result["episode"] == 1
+        assert result["date"] == "2026-03-09T12:00:00Z"
+        assert result["event_type"] == "grabbed"
+        assert result["quality"] == "HDTV-720p"
+        assert result["source_title"] == "Breaking.Bad.S01E01.720p"
+        assert result["service"] == "sonarr"

--- a/translations/addarr.de-de.yml
+++ b/translations/addarr.de-de.yml
@@ -273,6 +273,15 @@ de-de:
   QueueTitle: "📥 Download-Warteschlange"
   QueueEmpty: "Keine Elemente in der Download-Warteschlange."
 
+  History: "📜 Verlauf"
+  CommandHistory: "Letzte Aktivitäten anzeigen"
+  HistoryTitle: "📜 Letzte Aktivitäten"
+  HistoryEmpty: "Keine aktuellen Aktivitäten gefunden."
+  HistoryGrabbed: "Geholt"
+  HistoryImported: "Importiert"
+  HistoryFailed: "Fehlgeschlagen"
+  HistoryAll: "Alle"
+
   # Handler error and status messages
   SearchError: "❌ An error occurred while searching.\nPlease try again later."
   SearchInvalidType: "❌ Invalid search type"

--- a/translations/addarr.en-us.yml
+++ b/translations/addarr.en-us.yml
@@ -276,6 +276,15 @@ en-us:
   QueueTitle: "📥 Download Queue"
   QueueEmpty: "No items in the download queue."
 
+  History: "📜 History"
+  CommandHistory: "Browse recent activity"
+  HistoryTitle: "📜 Recent Activity"
+  HistoryEmpty: "No recent activity found."
+  HistoryGrabbed: "Grabbed"
+  HistoryImported: "Imported"
+  HistoryFailed: "Failed"
+  HistoryAll: "All"
+
   # Handler error and status messages
   SearchError: "❌ An error occurred while searching.\nPlease try again later."
   SearchInvalidType: "❌ Invalid search type"

--- a/translations/addarr.es-es.yml
+++ b/translations/addarr.es-es.yml
@@ -273,6 +273,15 @@ es-es:
   QueueTitle: "📥 Cola de Descargas"
   QueueEmpty: "No hay elementos en la cola de descargas."
 
+  History: "📜 Historial"
+  CommandHistory: "Ver actividad reciente"
+  HistoryTitle: "📜 Actividad Reciente"
+  HistoryEmpty: "No se encontró actividad reciente."
+  HistoryGrabbed: "Descargado"
+  HistoryImported: "Importado"
+  HistoryFailed: "Fallido"
+  HistoryAll: "Todos"
+
   # Handler error and status messages
   SearchError: "❌ An error occurred while searching.\nPlease try again later."
   SearchInvalidType: "❌ Invalid search type"

--- a/translations/addarr.fr-fr.yml
+++ b/translations/addarr.fr-fr.yml
@@ -273,6 +273,15 @@ fr-fr:
   QueueTitle: "📥 File de Téléchargement"
   QueueEmpty: "Aucun élément dans la file de téléchargement."
 
+  History: "📜 Historique"
+  CommandHistory: "Parcourir l'activité récente"
+  HistoryTitle: "📜 Activité Récente"
+  HistoryEmpty: "Aucune activité récente trouvée."
+  HistoryGrabbed: "Téléchargé"
+  HistoryImported: "Importé"
+  HistoryFailed: "Échoué"
+  HistoryAll: "Tous"
+
   # Handler error and status messages
   SearchError: "❌ An error occurred while searching.\nPlease try again later."
   SearchInvalidType: "❌ Invalid search type"

--- a/translations/addarr.it-it.yml
+++ b/translations/addarr.it-it.yml
@@ -273,6 +273,15 @@ it-it:
   QueueTitle: "📥 Coda di Download"
   QueueEmpty: "Nessun elemento nella coda di download."
 
+  History: "📜 Cronologia"
+  CommandHistory: "Visualizza attività recente"
+  HistoryTitle: "📜 Attività Recente"
+  HistoryEmpty: "Nessuna attività recente trovata."
+  HistoryGrabbed: "Scaricato"
+  HistoryImported: "Importato"
+  HistoryFailed: "Fallito"
+  HistoryAll: "Tutti"
+
   # Handler error and status messages
   SearchError: "❌ An error occurred while searching.\nPlease try again later."
   SearchInvalidType: "❌ Invalid search type"

--- a/translations/addarr.nl-be.yml
+++ b/translations/addarr.nl-be.yml
@@ -273,6 +273,15 @@ nl-be:
   QueueTitle: "📥 Downloadwachtrij"
   QueueEmpty: "Geen items in de downloadwachtrij."
 
+  History: "📜 Geschiedenis"
+  CommandHistory: "Bekijk recente activiteit"
+  HistoryTitle: "📜 Recente Activiteit"
+  HistoryEmpty: "Geen recente activiteit gevonden."
+  HistoryGrabbed: "Opgehaald"
+  HistoryImported: "Geïmporteerd"
+  HistoryFailed: "Mislukt"
+  HistoryAll: "Alles"
+
   # Handler error and status messages
   SearchError: "❌ An error occurred while searching.\nPlease try again later."
   SearchInvalidType: "❌ Invalid search type"

--- a/translations/addarr.pl-pl.yml
+++ b/translations/addarr.pl-pl.yml
@@ -273,6 +273,15 @@ pl-pl:
   QueueTitle: "📥 Kolejka Pobierania"
   QueueEmpty: "Brak elementów w kolejce pobierania."
 
+  History: "📜 Historia"
+  CommandHistory: "Przeglądaj ostatnią aktywność"
+  HistoryTitle: "📜 Ostatnia Aktywność"
+  HistoryEmpty: "Nie znaleziono ostatniej aktywności."
+  HistoryGrabbed: "Pobrano"
+  HistoryImported: "Zaimportowano"
+  HistoryFailed: "Nieudane"
+  HistoryAll: "Wszystko"
+
   # Handler error and status messages
   SearchError: "❌ An error occurred while searching.\nPlease try again later."
   SearchInvalidType: "❌ Invalid search type"

--- a/translations/addarr.pt-pt.yml
+++ b/translations/addarr.pt-pt.yml
@@ -273,6 +273,15 @@ pt-pt:
   QueueTitle: "📥 Fila de Downloads"
   QueueEmpty: "Sem itens na fila de downloads."
 
+  History: "📜 Histórico"
+  CommandHistory: "Ver atividade recente"
+  HistoryTitle: "📜 Atividade Recente"
+  HistoryEmpty: "Nenhuma atividade recente encontrada."
+  HistoryGrabbed: "Transferido"
+  HistoryImported: "Importado"
+  HistoryFailed: "Falhado"
+  HistoryAll: "Todos"
+
   # Handler error and status messages
   SearchError: "❌ An error occurred while searching.\nPlease try again later."
   SearchInvalidType: "❌ Invalid search type"

--- a/translations/addarr.ru-ru.yml
+++ b/translations/addarr.ru-ru.yml
@@ -273,6 +273,15 @@ ru-ru:
   QueueTitle: "📥 Очередь Загрузок"
   QueueEmpty: "В очереди загрузок нет элементов."
 
+  History: "📜 История"
+  CommandHistory: "Просмотр недавней активности"
+  HistoryTitle: "📜 Недавняя Активность"
+  HistoryEmpty: "Недавняя активность не найдена."
+  HistoryGrabbed: "Загружено"
+  HistoryImported: "Импортировано"
+  HistoryFailed: "Ошибка"
+  HistoryAll: "Все"
+
   # Handler error and status messages
   SearchError: "❌ An error occurred while searching.\nPlease try again later."
   SearchInvalidType: "❌ Invalid search type"

--- a/translations/addarr.template.yml
+++ b/translations/addarr.template.yml
@@ -298,6 +298,15 @@ template:
   QueueTitle: "📥 Download Queue"
   QueueEmpty: "No items in the download queue."
 
+  History: ""
+  CommandHistory: ""
+  HistoryTitle: ""
+  HistoryEmpty: ""
+  HistoryGrabbed: ""
+  HistoryImported: ""
+  HistoryFailed: ""
+  HistoryAll: ""
+
   # Handler error and status messages
   SearchError: "❌ An error occurred while searching.\nPlease try again later."
   SearchInvalidType: "❌ Invalid search type"


### PR DESCRIPTION
## Summary

Closes #107

- Add `get_history()` to RadarrClient and SonarrClient with optional event type filtering and pagination
- Add `get_history()` to MediaService with normalizers that merge and sort results from both services
- Add `/history` command with inline keyboard UI: filter tabs (All/Grabbed/Imported/Failed), paginated item list, refresh and back buttons
- Add 8 translation keys across all 10 locales + template

## Changes

- **API layer**: `get_history(page, page_size, event_type)` on both clients following existing `get_missing` pattern
- **Service layer**: `MediaService.get_history()` with `_normalize_radarr_history` / `_normalize_sonarr_history` statics, parallel fetch via `asyncio.gather`
- **UI layer**: `get_history_items_keyboard()` / `get_history_empty_keyboard()` in keyboards.py, `HistoryHandler` with filter/page/refresh/back actions
- **Wiring**: Registered in main.py, added to commands.py and `__init__.py`
- **Tests**: 26 new tests (10 API, 8 service, 6 keyboard, 12 handler = 36 total new tests across all layers), 100% coverage on new code

## Test plan

- [x] `pytest --tb=short -q` — 1845 tests pass
- [x] `flake8` — clean
- [x] `python run.py --validate-i18n` — all locales valid
- [x] 100% coverage on all new/modified source modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)
