### PR TITLE
feat: help command translation and dynamic content

### DIFF
--- a/docs/issues/issue-113/TASKS.md
+++ b/docs/issues/issue-113/TASKS.md
@@ -1,0 +1,44 @@
+# Issue #113: Help Command Translation & Dynamic Content
+
+**Goal:** Replace hardcoded English help text with translated, service-aware dynamic help output.
+
+**Plan:** See `plan.md` for full context, design decisions, and translation key definitions.
+
+---
+
+### Phase 1: Translation Keys & Dynamic Handler (2 tasks)
+
+**Goal:** Add section-based help translation keys and rewrite the handler to use them dynamically.
+
+- [x] **1.1** Add help section translation keys to all locale files
+    - **Context:** See plan.md Phase 1. The template has a monolithic `HelpText` key (lines 128-153) that must be replaced with section keys (`HelpHeader`, `HelpBasicCommands`, `HelpMediaMovies`, `HelpMediaSeries`, `HelpMediaMusic`, `HelpDownloadTransmission`, `HelpDownloadSabnzbd`, `HelpVersion`, `HelpFooter`). See plan.md for exact YAML content.
+    - **Watch out:** Remove the old `HelpText` block. YAML multiline `|` blocks need consistent indentation. All 9 locale files + template need identical keys (English defaults for non-English locales).
+    - **Scope:** Replace `HelpText` in template, add section keys to all 10 translation files
+    - **Touches:** `translations/addarr.template.yml`, `translations/addarr.en-us.yml`, 8 other locale files
+    - **Action items:**
+        - [GREEN] Replace `HelpText` block in template with section keys from plan.md
+        - [GREEN] Add same keys to `addarr.en-us.yml`
+        - [GREEN] Add same keys to remaining 8 locale files
+    - **Success:** `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` passes
+    - **Completed:** 2026-03-10
+    - **Learnings:** All 9 locale files had identical HelpText blocks that needed replacing
+    - **Key Changes:** Replaced monolithic `HelpText` key with 9 section keys (`HelpHeader`, `HelpBasicCommands`, `HelpMediaMovies`, `HelpMediaSeries`, `HelpMediaMusic`, `HelpDownloadTransmission`, `HelpDownloadSabnzbd`, `HelpVersion`, `HelpFooter`) in template + all 9 locale files
+    - **Notes:** Non-English locales have English defaults; native speakers can translate later
+
+- [x] **1.2** Rewrite help handler with dynamic translated text + tests
+    - **Context:** See plan.md Phase 2-3. `src/bot/handlers/help.py` currently has hardcoded English text (lines 42-66) with wrong version ("0.1.0") and wrong repo URLs. Rewrite to use `_build_help_text()` that assembles sections from translations, filtered by enabled services via `config.get("radarr", {}).get("enable")` (same pattern as `src/bot/commands.py:45`). Version from `src.__version__` ("0.8").
+    - **Watch out:** Patch config at `src.bot.handlers.help.config` (module-level import binding). Existing tests in `test_help_handler.py` assert `/movie` and `/series` in output — update them to mock config with those services enabled. `get_text()` uses `%(key)s` formatting for version substitution.
+    - **Scope:** Handler rewrite + test updates + new test cases
+    - **Touches:** `src/bot/handlers/help.py`, `tests/test_handlers/test_help_handler.py`
+    - **Action items:**
+        - [RED] Write `test_show_help_hides_disabled_services` — config with radarr disabled, verify `/movie` absent
+        - [RED] Write `test_show_help_shows_version` — verify `__version__` appears in output
+        - [RED] Write `test_show_help_shows_download_clients` — enable transmission+sabnzbd, verify they appear
+        - [RED] Write `test_show_help_hides_download_clients` — disable both, verify absent
+        - [GREEN] Add `_build_help_text()` method and rewrite `show_help` to use it (see plan.md for implementation)
+        - [GREEN] Update existing `test_show_help_command` to mock config with services enabled
+    - **Success:** `pytest tests/test_handlers/test_help_handler.py -v` all pass, `pytest --cov=src.bot.handlers.help --cov-report=term-missing` shows 100% on changed code
+    - **Completed:** 2026-03-10
+    - **Learnings:** The conftest fake `src` module didn't have `__version__`, causing `from src import __version__` to fail and preventing `help.py` from loading in tests. Fixed by adding `__version__` to the fake module. Used `with patch(...)` context managers instead of `@patch` decorators for config mocking to avoid module resolution issues with `help` (Python builtin name collision).
+    - **Key Changes:** Rewrote `help.py` with `_build_help_text()` method using config checks and translations. Added 5 new test cases (disabled services, version, download clients show/hide). Updated `conftest.py` to set `__version__` on fake src module.
+    - **Notes:** 100% coverage on help.py, 1861 tests pass, no lint errors

--- a/docs/issues/issue-113/plan.md
+++ b/docs/issues/issue-113/plan.md
@@ -1,0 +1,192 @@
+# Help Command Translation & Dynamic Content — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace hardcoded English help text with translated, service-aware dynamic help output.
+
+**Architecture:** Split the monolithic `HelpText` translation key into section-based keys so download client commands (Transmission/SABnzbd) can be conditionally included. The help handler builds the text by checking config for enabled services and assembling only relevant translation sections. Version is pulled from `src.__version__`.
+
+**Tech Stack:** python-telegram-bot v20+, TranslationService (python-i18n wrapper), pytest + unittest.mock
+
+---
+
+## Context
+
+### Current State
+- `src/bot/handlers/help.py` has fully hardcoded English help text (lines 42-66)
+- Hardcoded version "0.1.0" — actual version is `src.__version__` = "0.8"
+- Hardcoded repo URLs point to `Cyneric/addarr` — should be `Krypt0nBull3t/Addarr`
+- Shows ALL commands regardless of which services are enabled
+- `TranslationService` is imported but only used in `handle_back`, not in `show_help`
+
+### Translation Template
+The template (`translations/addarr.template.yml`) already has a `HelpText` key (lines 129-153) but it's a single block including Transmission/SABnzbd unconditionally. We'll replace it with section keys.
+
+### Existing Patterns
+- `src/bot/commands.py` already checks `config.get("radarr", {}).get("enable")` etc. to build dynamic command lists — we follow this exact pattern
+- Translation keys use flat top-level names: `HelpButton`, `CommandHelp`, `CommandStart`, etc.
+- `get_text()` supports `%(key)s` formatting: `translation.get_text("key", param=value)`
+
+### Files to Touch
+| File | Action |
+|------|--------|
+| `src/bot/handlers/help.py` | Rewrite `show_help` to build dynamic translated text |
+| `translations/addarr.template.yml` | Replace `HelpText` with section keys |
+| `translations/addarr.en-us.yml` | Add English section keys |
+| `translations/addarr.{8 other locales}.yml` | Add section keys (English defaults) |
+| `tests/test_handlers/test_help_handler.py` | Update tests for new behavior |
+
+---
+
+## Design Decisions
+
+1. **Section-based translation keys** rather than one monolithic `HelpText`:
+   - `HelpHeader` — title line
+   - `HelpBasicCommands` — always-shown commands (start, auth, help, status, settings, delete, library)
+   - `HelpMediaMovies` — movie commands (when radarr enabled)
+   - `HelpMediaSeries` — series commands (when sonarr enabled)
+   - `HelpMediaMusic` — music commands (when lidarr enabled)
+   - `HelpDownloadTransmission` — transmission command (when enabled)
+   - `HelpDownloadSabnzbd` — sabnzbd command (when enabled)
+   - `HelpFooter` — version + repo links
+
+2. **Config access** follows `commands.py` pattern: `config.get("radarr", {}).get("enable")`.
+
+3. **Version** imported from `src.__version__` — no hardcoding.
+
+4. **Repo URLs** updated to `Krypt0nBull3t/Addarr`.
+
+5. **Remove old `HelpText` key** from template and all locale files (replaced by section keys).
+
+---
+
+## Phase 1: Translation Keys
+
+### Task 1.1: Add help section keys to template
+
+**Files:**
+- Modify: `translations/addarr.template.yml` (lines 128-153)
+
+Replace the existing `HelpText` block with individual section keys:
+
+```yaml
+  # Help sections
+  HelpHeader: "🤖 *Available Commands:*"
+  HelpBasicCommands: |
+    🚀 /start - Start the bot
+    🔐 /auth - Authenticate with password
+    ❓ /help - Show this help message
+    📊 /status - Check system status
+    ⚙️ /settings - Manage settings
+    🗑️ /delete - Delete media
+    📚 /library - Browse your library
+  HelpMediaMovies: |
+    🎬 /movie - Search and add movies
+    🎬 /allmovies - Show all movies
+  HelpMediaSeries: |
+    📺 /series - Search and add TV shows
+    📺 /allseries - Show all series
+  HelpMediaMusic: |
+    🎵 /music - Search and add music
+    🎵 /allmusic - Show all music
+  HelpDownloadTransmission: "📡 /transmission - Manage Transmission"
+  HelpDownloadSabnzbd: "📥 /sabnzbd - Manage SABnzbd"
+  HelpVersion: "🔄 Version: %(version)s"
+  HelpFooter: |
+    📖 Wiki: https://github.com/Krypt0nBull3t/Addarr/wiki
+    🐞 Issues: https://github.com/Krypt0nBull3t/Addarr/issues
+```
+
+### Task 1.2: Add help section keys to en-us locale
+
+**Files:**
+- Modify: `translations/addarr.en-us.yml`
+
+Add the same keys with English text (identical to template).
+
+### Task 1.3: Add help section keys to remaining 8 locale files
+
+**Files:**
+- Modify: All 8 non-English locale files
+
+Add the same English keys as defaults. Native speakers can translate later.
+
+---
+
+## Phase 2: Dynamic Help Handler
+
+### Task 2.1: Rewrite `show_help` to build dynamic translated text
+
+**Files:**
+- Modify: `src/bot/handlers/help.py`
+- Test: `tests/test_handlers/test_help_handler.py`
+
+**Implementation approach:**
+
+```python
+from src.config.settings import config
+from src import __version__
+
+# In show_help:
+def _build_help_text(self):
+    """Build help text from translations, filtered by enabled services."""
+    t = self.translation
+    sections = [t.get_text("HelpHeader"), "", t.get_text("HelpBasicCommands")]
+
+    # Media commands — only show enabled services
+    if config.get("radarr", {}).get("enable"):
+        sections.append(t.get_text("HelpMediaMovies"))
+    if config.get("sonarr", {}).get("enable"):
+        sections.append(t.get_text("HelpMediaSeries"))
+    if config.get("lidarr", {}).get("enable"):
+        sections.append(t.get_text("HelpMediaMusic"))
+
+    # Download clients
+    if config.get("transmission", {}).get("enable", False):
+        sections.append(t.get_text("HelpDownloadTransmission"))
+    if config.get("sabnzbd", {}).get("enable", False):
+        sections.append(t.get_text("HelpDownloadSabnzbd"))
+
+    # Footer
+    sections.append("")
+    sections.append(t.get_text("HelpVersion", version=__version__))
+    sections.append(t.get_text("HelpFooter"))
+
+    return "\n".join(sections)
+```
+
+The `show_help` method calls `_build_help_text()` instead of using the hardcoded string.
+
+---
+
+## Phase 3: Tests
+
+### Task 3.1: Test help text includes only enabled service commands
+
+**Files:**
+- Modify: `tests/test_handlers/test_help_handler.py`
+
+Update existing tests and add new ones:
+
+1. **Update `test_show_help_command`** — mock config to enable radarr+sonarr, verify those commands appear in output
+2. **Add `test_show_help_hides_disabled_services`** — mock config with radarr disabled, verify `/movie` and `/allmovies` do NOT appear
+3. **Add `test_show_help_shows_version`** — verify `__version__` value appears in output
+4. **Add `test_show_help_shows_download_clients`** — enable transmission+sabnzbd in config, verify they appear
+5. **Add `test_show_help_hides_download_clients`** — disable both, verify they don't appear
+
+Config mocking pattern (from `commands.py` tests):
+```python
+@patch("src.bot.handlers.help.config")
+```
+Since `help.py` will import `from src.config.settings import config`, patch at the import site.
+
+---
+
+## Verification
+
+After all tasks:
+1. `pytest tests/test_handlers/test_help_handler.py -v` — all tests pass
+2. `pytest --tb=short -q` — full suite passes
+3. `python -m flake8 .` — no lint errors
+4. `pytest --cov=src.bot.handlers.help --cov-report=term-missing` — 100% on new/changed code
+5. `PYTHONIOENCODING=utf-8 python run.py --validate-i18n` — translation validation passes

--- a/src/bot/handlers/help.py
+++ b/src/bot/handlers/help.py
@@ -12,7 +12,9 @@ from telegram.ext import CommandHandler, CallbackQueryHandler, ContextTypes
 from src.utils.logger import get_logger, log_user_interaction
 from src.bot.handlers.auth import require_auth
 from src.bot.keyboards import get_main_menu_keyboard
+from src.config.settings import config
 from src.services.translation import TranslationService
+from src import __version__
 
 logger = get_logger("addarr.help")
 
@@ -30,6 +32,29 @@ class HelpHandler:
             CallbackQueryHandler(self.handle_back, pattern="^menu_back$")
         ]
 
+    def _build_help_text(self):
+        """Build help text from translations, filtered by enabled services."""
+        t = self.translation
+        sections = [t.get_text("HelpHeader"), "", t.get_text("HelpBasicCommands")]
+
+        if config.get("radarr", {}).get("enable"):
+            sections.append(t.get_text("HelpMediaMovies"))
+        if config.get("sonarr", {}).get("enable"):
+            sections.append(t.get_text("HelpMediaSeries"))
+        if config.get("lidarr", {}).get("enable"):
+            sections.append(t.get_text("HelpMediaMusic"))
+
+        if config.get("transmission", {}).get("enable", False):
+            sections.append(t.get_text("HelpDownloadTransmission"))
+        if config.get("sabnzbd", {}).get("enable", False):
+            sections.append(t.get_text("HelpDownloadSabnzbd"))
+
+        sections.append("")
+        sections.append(t.get_text("HelpVersion", version=__version__))
+        sections.append(t.get_text("HelpFooter"))
+
+        return "\n".join(sections)
+
     @require_auth
     async def show_help(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Show help message with available commands"""
@@ -39,33 +64,8 @@ class HelpHandler:
         user = update.effective_user
         log_user_interaction(logger, user, "/help")
 
-        help_text = (
-            "🤖 *Available Commands:*\n\n"
-            "🎬 */movie* - Search and add movies\n"
-            "📺 */series* - Search and add TV shows\n"
-            "🎵 */music* - Search and add music\n\n"
+        help_text = self._build_help_text()
 
-            "🚫 */cancel* - Cancel current action\n"
-            "❌ */delete* - Delete media\n"
-            "📊 */status* - Check system status\n"
-            "⚙️ */settings* - Manage settings\n\n"
-
-            "🚀 */allSeries* - Show all series\n"
-            "🎬 */allMovies* - Show all movies\n"
-            "🎵 */allMusic* - Show all music\n\n"
-
-            "❓ */help* - Show this help message\n\n"
-
-
-            "📖 Wiki: https://github.com/Cyneric/addarr/wiki\n"
-            "🐞 Issues: https://github.com/Cyneric/addarr/issues\n"
-            "🔗 Repository: https://github.com/Cyneric/addarr\n\n"
-
-            "👨‍💻 Author: Christian Blank (https://github.com/Cyneric)\n\n"
-            "🔄 Version: 0.1.0\n"
-        )
-
-        # Handle both direct commands and callback queries
         if update.callback_query:
             await update.callback_query.message.edit_text(
                 help_text,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,7 +183,12 @@ _src_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "src")
 if "src" not in sys.modules:
     _src_mod = types.ModuleType("src")
     _src_mod.__path__ = [_src_dir]
+    _src_mod.__version__ = "0.8"
     sys.modules["src"] = _src_mod
+else:
+    # Ensure __version__ is available even if src was already imported
+    if not hasattr(sys.modules["src"], "__version__"):
+        sys.modules["src"].__version__ = "0.8"
 if "src.config" not in sys.modules:
     _config_mod = types.ModuleType("src.config")
     _config_mod.__path__ = [os.path.join(_src_dir, "config")]

--- a/tests/test_handlers/test_help_handler.py
+++ b/tests/test_handlers/test_help_handler.py
@@ -2,12 +2,37 @@
 Tests for src/bot/handlers/help.py - HelpHandler with show_help and handle_back.
 
 HelpHandler.__init__ creates TranslationService().
-show_help displays help text with available commands (decorated with @require_auth).
+show_help builds dynamic help text from translations, filtered by enabled services.
 handle_back returns to the main menu (decorated with @require_auth).
 """
 
 import pytest
 from unittest.mock import patch, MagicMock
+
+
+def _make_config(radarr=False, sonarr=False, lidarr=False,
+                 transmission=False, sabnzbd=False):
+    """Build a mock config dict with service enable flags."""
+    data = {
+        "radarr": {"enable": True} if radarr else {},
+        "sonarr": {"enable": True} if sonarr else {},
+        "lidarr": {"enable": True} if lidarr else {},
+        "transmission": {"enable": True} if transmission else {},
+        "sabnzbd": {"enable": True} if sabnzbd else {},
+    }
+    mock = MagicMock()
+    mock.get = lambda key, default=None: data.get(
+        key, default if default is not None else {}
+    )
+    return mock
+
+
+def _make_translation_mock():
+    mock_ts_class = MagicMock()
+    mock_ts = MagicMock()
+    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
+    mock_ts_class.return_value = mock_ts
+    return mock_ts_class
 
 
 # ---------------------------------------------------------------------------
@@ -16,83 +41,172 @@ from unittest.mock import patch, MagicMock
 
 
 @pytest.mark.asyncio
-@patch("src.bot.handlers.help.get_main_menu_keyboard")
-@patch("src.bot.handlers.help.TranslationService")
-async def test_show_help_command(
-    mock_ts_class, mock_keyboard, make_update, make_context
-):
-    """show_help replies with help text containing command info."""
-    mock_ts = MagicMock()
-    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
-    mock_ts_class.return_value = mock_ts
+async def test_show_help_command(make_update, make_context):
+    """show_help replies with help text containing enabled service commands."""
+    mock_config = _make_config(radarr=True, sonarr=True, lidarr=True)
 
-    from src.bot.handlers.help import HelpHandler
-    from src.bot.handlers.auth import AuthHandler
+    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
+         patch("src.bot.handlers.help.config", mock_config), \
+         patch("src.bot.handlers.help.get_main_menu_keyboard"):
 
-    AuthHandler._authenticated_users = {12345}
+        from src.bot.handlers.help import HelpHandler
+        from src.bot.handlers.auth import AuthHandler
+        AuthHandler._authenticated_users = {12345}
 
-    handler = HelpHandler()
-    update = make_update(text="/help")
-    context = make_context()
+        handler = HelpHandler()
+        update = make_update(text="/help")
+        context = make_context()
 
-    await handler.show_help(update, context)
+        await handler.show_help(update, context)
 
-    update.message.reply_text.assert_called_once()
-    call_args = update.message.reply_text.call_args
-    help_text = call_args[0][0]
-    assert "/movie" in help_text
-    assert "/series" in help_text
+        update.message.reply_text.assert_called_once()
+        help_text = update.message.reply_text.call_args[0][0]
+        assert "HelpHeader" in help_text
+        assert "HelpBasicCommands" in help_text
+        assert "HelpMediaMovies" in help_text
+        assert "HelpMediaSeries" in help_text
+        assert "HelpMediaMusic" in help_text
 
 
 @pytest.mark.asyncio
-@patch("src.bot.handlers.help.get_main_menu_keyboard")
-@patch("src.bot.handlers.help.TranslationService")
-async def test_show_help_callback(
-    mock_ts_class, mock_keyboard, make_update, make_context
-):
+async def test_show_help_hides_disabled_services(make_update, make_context):
+    """show_help omits media commands when services are disabled."""
+    mock_config = _make_config()
+
+    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
+         patch("src.bot.handlers.help.config", mock_config), \
+         patch("src.bot.handlers.help.get_main_menu_keyboard"):
+
+        from src.bot.handlers.help import HelpHandler
+        from src.bot.handlers.auth import AuthHandler
+        AuthHandler._authenticated_users = {12345}
+
+        handler = HelpHandler()
+        update = make_update(text="/help")
+        context = make_context()
+
+        await handler.show_help(update, context)
+
+        help_text = update.message.reply_text.call_args[0][0]
+        assert "HelpMediaMovies" not in help_text
+        assert "HelpMediaSeries" not in help_text
+        assert "HelpMediaMusic" not in help_text
+
+
+@pytest.mark.asyncio
+async def test_show_help_shows_version(make_update, make_context):
+    """show_help includes the bot version from src.__version__."""
+    mock_config = _make_config()
+
+    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
+         patch("src.bot.handlers.help.config", mock_config), \
+         patch("src.bot.handlers.help.get_main_menu_keyboard"):
+
+        from src.bot.handlers.help import HelpHandler
+        from src.bot.handlers.auth import AuthHandler
+        AuthHandler._authenticated_users = {12345}
+
+        handler = HelpHandler()
+        update = make_update(text="/help")
+        context = make_context()
+
+        await handler.show_help(update, context)
+
+        help_text = update.message.reply_text.call_args[0][0]
+        assert "HelpVersion" in help_text
+
+
+@pytest.mark.asyncio
+async def test_show_help_shows_download_clients(make_update, make_context):
+    """show_help includes download client commands when enabled."""
+    mock_config = _make_config(transmission=True, sabnzbd=True)
+
+    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
+         patch("src.bot.handlers.help.config", mock_config), \
+         patch("src.bot.handlers.help.get_main_menu_keyboard"):
+
+        from src.bot.handlers.help import HelpHandler
+        from src.bot.handlers.auth import AuthHandler
+        AuthHandler._authenticated_users = {12345}
+
+        handler = HelpHandler()
+        update = make_update(text="/help")
+        context = make_context()
+
+        await handler.show_help(update, context)
+
+        help_text = update.message.reply_text.call_args[0][0]
+        assert "HelpDownloadTransmission" in help_text
+        assert "HelpDownloadSabnzbd" in help_text
+
+
+@pytest.mark.asyncio
+async def test_show_help_hides_download_clients(make_update, make_context):
+    """show_help omits download client commands when disabled."""
+    mock_config = _make_config()
+
+    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
+         patch("src.bot.handlers.help.config", mock_config), \
+         patch("src.bot.handlers.help.get_main_menu_keyboard"):
+
+        from src.bot.handlers.help import HelpHandler
+        from src.bot.handlers.auth import AuthHandler
+        AuthHandler._authenticated_users = {12345}
+
+        handler = HelpHandler()
+        update = make_update(text="/help")
+        context = make_context()
+
+        await handler.show_help(update, context)
+
+        help_text = update.message.reply_text.call_args[0][0]
+        assert "HelpDownloadTransmission" not in help_text
+        assert "HelpDownloadSabnzbd" not in help_text
+
+
+@pytest.mark.asyncio
+async def test_show_help_callback(make_update, make_context):
     """show_help via callback query edits message text."""
-    mock_ts = MagicMock()
-    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
-    mock_ts_class.return_value = mock_ts
+    mock_config = _make_config()
 
-    from src.bot.handlers.help import HelpHandler
-    from src.bot.handlers.auth import AuthHandler
+    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
+         patch("src.bot.handlers.help.config", mock_config), \
+         patch("src.bot.handlers.help.get_main_menu_keyboard"):
 
-    AuthHandler._authenticated_users = {12345}
+        from src.bot.handlers.help import HelpHandler
+        from src.bot.handlers.auth import AuthHandler
+        AuthHandler._authenticated_users = {12345}
 
-    handler = HelpHandler()
-    update = make_update(callback_data="menu_help")
-    context = make_context()
+        handler = HelpHandler()
+        update = make_update(callback_data="menu_help")
+        context = make_context()
 
-    await handler.show_help(update, context)
+        await handler.show_help(update, context)
 
-    update.callback_query.message.edit_text.assert_called_once()
+        update.callback_query.message.edit_text.assert_called_once()
 
 
 @pytest.mark.asyncio
-@patch("src.bot.handlers.help.get_main_menu_keyboard")
-@patch("src.bot.handlers.help.TranslationService")
-async def test_show_help_no_user(
-    mock_ts_class, mock_keyboard, make_update, make_context
-):
+async def test_show_help_no_user(make_update, make_context):
     """show_help returns when no effective_user."""
-    mock_ts = MagicMock()
-    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
-    mock_ts_class.return_value = mock_ts
+    mock_config = _make_config()
 
-    from src.bot.handlers.help import HelpHandler
-    from src.bot.handlers.auth import AuthHandler
+    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
+         patch("src.bot.handlers.help.config", mock_config), \
+         patch("src.bot.handlers.help.get_main_menu_keyboard"):
 
-    AuthHandler._authenticated_users = {12345}
+        from src.bot.handlers.help import HelpHandler
+        from src.bot.handlers.auth import AuthHandler
+        AuthHandler._authenticated_users = {12345}
 
-    handler = HelpHandler()
-    update = make_update(text="/help")
-    update.effective_user = None
-    context = make_context()
+        handler = HelpHandler()
+        update = make_update(text="/help")
+        update.effective_user = None
+        context = make_context()
 
-    result = await handler.show_help(update, context)
+        result = await handler.show_help(update, context)
 
-    assert result is None
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_handlers/test_help_handler.py
+++ b/tests/test_handlers/test_help_handler.py
@@ -7,6 +7,7 @@ handle_back returns to the main menu (decorated with @require_auth).
 """
 
 import pytest
+from contextlib import contextmanager
 from unittest.mock import patch, MagicMock
 
 
@@ -27,12 +28,26 @@ def _make_config(radarr=False, sonarr=False, lidarr=False,
     return mock
 
 
-def _make_translation_mock():
+@contextmanager
+def _help_patches(**config_kwargs):
+    """Patch TranslationService, config, and keyboard for help handler tests."""
     mock_ts_class = MagicMock()
     mock_ts = MagicMock()
     mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
     mock_ts_class.return_value = mock_ts
-    return mock_ts_class
+
+    with patch("src.bot.handlers.help.TranslationService", mock_ts_class), \
+         patch("src.bot.handlers.help.config", _make_config(**config_kwargs)), \
+         patch("src.bot.handlers.help.get_main_menu_keyboard"):
+
+        from src.bot.handlers.auth import AuthHandler
+        AuthHandler._authenticated_users = {12345}
+        yield
+
+
+def _make_handler():
+    from src.bot.handlers.help import HelpHandler
+    return HelpHandler()
 
 
 # ---------------------------------------------------------------------------
@@ -43,23 +58,11 @@ def _make_translation_mock():
 @pytest.mark.asyncio
 async def test_show_help_command(make_update, make_context):
     """show_help replies with help text containing enabled service commands."""
-    mock_config = _make_config(radarr=True, sonarr=True, lidarr=True)
-
-    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
-         patch("src.bot.handlers.help.config", mock_config), \
-         patch("src.bot.handlers.help.get_main_menu_keyboard"):
-
-        from src.bot.handlers.help import HelpHandler
-        from src.bot.handlers.auth import AuthHandler
-        AuthHandler._authenticated_users = {12345}
-
-        handler = HelpHandler()
+    with _help_patches(radarr=True, sonarr=True, lidarr=True):
+        handler = _make_handler()
         update = make_update(text="/help")
-        context = make_context()
+        await handler.show_help(update, make_context())
 
-        await handler.show_help(update, context)
-
-        update.message.reply_text.assert_called_once()
         help_text = update.message.reply_text.call_args[0][0]
         assert "HelpHeader" in help_text
         assert "HelpBasicCommands" in help_text
@@ -71,21 +74,10 @@ async def test_show_help_command(make_update, make_context):
 @pytest.mark.asyncio
 async def test_show_help_hides_disabled_services(make_update, make_context):
     """show_help omits media commands when services are disabled."""
-    mock_config = _make_config()
-
-    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
-         patch("src.bot.handlers.help.config", mock_config), \
-         patch("src.bot.handlers.help.get_main_menu_keyboard"):
-
-        from src.bot.handlers.help import HelpHandler
-        from src.bot.handlers.auth import AuthHandler
-        AuthHandler._authenticated_users = {12345}
-
-        handler = HelpHandler()
+    with _help_patches():
+        handler = _make_handler()
         update = make_update(text="/help")
-        context = make_context()
-
-        await handler.show_help(update, context)
+        await handler.show_help(update, make_context())
 
         help_text = update.message.reply_text.call_args[0][0]
         assert "HelpMediaMovies" not in help_text
@@ -96,21 +88,10 @@ async def test_show_help_hides_disabled_services(make_update, make_context):
 @pytest.mark.asyncio
 async def test_show_help_shows_version(make_update, make_context):
     """show_help includes the bot version from src.__version__."""
-    mock_config = _make_config()
-
-    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
-         patch("src.bot.handlers.help.config", mock_config), \
-         patch("src.bot.handlers.help.get_main_menu_keyboard"):
-
-        from src.bot.handlers.help import HelpHandler
-        from src.bot.handlers.auth import AuthHandler
-        AuthHandler._authenticated_users = {12345}
-
-        handler = HelpHandler()
+    with _help_patches():
+        handler = _make_handler()
         update = make_update(text="/help")
-        context = make_context()
-
-        await handler.show_help(update, context)
+        await handler.show_help(update, make_context())
 
         help_text = update.message.reply_text.call_args[0][0]
         assert "HelpVersion" in help_text
@@ -119,21 +100,10 @@ async def test_show_help_shows_version(make_update, make_context):
 @pytest.mark.asyncio
 async def test_show_help_shows_download_clients(make_update, make_context):
     """show_help includes download client commands when enabled."""
-    mock_config = _make_config(transmission=True, sabnzbd=True)
-
-    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
-         patch("src.bot.handlers.help.config", mock_config), \
-         patch("src.bot.handlers.help.get_main_menu_keyboard"):
-
-        from src.bot.handlers.help import HelpHandler
-        from src.bot.handlers.auth import AuthHandler
-        AuthHandler._authenticated_users = {12345}
-
-        handler = HelpHandler()
+    with _help_patches(transmission=True, sabnzbd=True):
+        handler = _make_handler()
         update = make_update(text="/help")
-        context = make_context()
-
-        await handler.show_help(update, context)
+        await handler.show_help(update, make_context())
 
         help_text = update.message.reply_text.call_args[0][0]
         assert "HelpDownloadTransmission" in help_text
@@ -143,21 +113,10 @@ async def test_show_help_shows_download_clients(make_update, make_context):
 @pytest.mark.asyncio
 async def test_show_help_hides_download_clients(make_update, make_context):
     """show_help omits download client commands when disabled."""
-    mock_config = _make_config()
-
-    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
-         patch("src.bot.handlers.help.config", mock_config), \
-         patch("src.bot.handlers.help.get_main_menu_keyboard"):
-
-        from src.bot.handlers.help import HelpHandler
-        from src.bot.handlers.auth import AuthHandler
-        AuthHandler._authenticated_users = {12345}
-
-        handler = HelpHandler()
+    with _help_patches():
+        handler = _make_handler()
         update = make_update(text="/help")
-        context = make_context()
-
-        await handler.show_help(update, context)
+        await handler.show_help(update, make_context())
 
         help_text = update.message.reply_text.call_args[0][0]
         assert "HelpDownloadTransmission" not in help_text
@@ -167,21 +126,10 @@ async def test_show_help_hides_download_clients(make_update, make_context):
 @pytest.mark.asyncio
 async def test_show_help_callback(make_update, make_context):
     """show_help via callback query edits message text."""
-    mock_config = _make_config()
-
-    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
-         patch("src.bot.handlers.help.config", mock_config), \
-         patch("src.bot.handlers.help.get_main_menu_keyboard"):
-
-        from src.bot.handlers.help import HelpHandler
-        from src.bot.handlers.auth import AuthHandler
-        AuthHandler._authenticated_users = {12345}
-
-        handler = HelpHandler()
+    with _help_patches():
+        handler = _make_handler()
         update = make_update(callback_data="menu_help")
-        context = make_context()
-
-        await handler.show_help(update, context)
+        await handler.show_help(update, make_context())
 
         update.callback_query.message.edit_text.assert_called_once()
 
@@ -189,22 +137,12 @@ async def test_show_help_callback(make_update, make_context):
 @pytest.mark.asyncio
 async def test_show_help_no_user(make_update, make_context):
     """show_help returns when no effective_user."""
-    mock_config = _make_config()
-
-    with patch("src.bot.handlers.help.TranslationService", _make_translation_mock()), \
-         patch("src.bot.handlers.help.config", mock_config), \
-         patch("src.bot.handlers.help.get_main_menu_keyboard"):
-
-        from src.bot.handlers.help import HelpHandler
-        from src.bot.handlers.auth import AuthHandler
-        AuthHandler._authenticated_users = {12345}
-
-        handler = HelpHandler()
+    with _help_patches():
+        handler = _make_handler()
         update = make_update(text="/help")
         update.effective_user = None
-        context = make_context()
 
-        result = await handler.show_help(update, context)
+        result = await handler.show_help(update, make_context())
 
         assert result is None
 
@@ -215,54 +153,26 @@ async def test_show_help_no_user(make_update, make_context):
 
 
 @pytest.mark.asyncio
-@patch("src.bot.handlers.help.get_main_menu_keyboard")
-@patch("src.bot.handlers.help.TranslationService")
-async def test_handle_back(
-    mock_ts_class, mock_keyboard, make_update, make_context
-):
+async def test_handle_back(make_update, make_context):
     """handle_back edits message with welcome text and main menu keyboard."""
-    mock_ts = MagicMock()
-    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
-    mock_ts_class.return_value = mock_ts
-    mock_keyboard.return_value = MagicMock()
+    with _help_patches():
+        handler = _make_handler()
+        update = make_update(callback_data="menu_back")
+        await handler.handle_back(update, make_context())
 
-    from src.bot.handlers.help import HelpHandler
-    from src.bot.handlers.auth import AuthHandler
-
-    AuthHandler._authenticated_users = {12345}
-
-    handler = HelpHandler()
-    update = make_update(callback_data="menu_back")
-    context = make_context()
-
-    await handler.handle_back(update, context)
-
-    update.callback_query.answer.assert_called_once()
-    update.callback_query.message.edit_text.assert_called_once()
+        update.callback_query.answer.assert_called_once()
+        update.callback_query.message.edit_text.assert_called_once()
 
 
 @pytest.mark.asyncio
-@patch("src.bot.handlers.help.get_main_menu_keyboard")
-@patch("src.bot.handlers.help.TranslationService")
-async def test_handle_back_no_callback(
-    mock_ts_class, mock_keyboard, make_update, make_context
-):
+async def test_handle_back_no_callback(make_update, make_context):
     """handle_back returns early if no callback query."""
-    mock_ts = MagicMock()
-    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
-    mock_ts_class.return_value = mock_ts
+    with _help_patches():
+        handler = _make_handler()
+        update = make_update(text="/back")
 
-    from src.bot.handlers.help import HelpHandler
-    from src.bot.handlers.auth import AuthHandler
-
-    AuthHandler._authenticated_users = {12345}
-
-    handler = HelpHandler()
-    update = make_update(text="/back")
-    context = make_context()
-
-    result = await handler.handle_back(update, context)
-    assert result is None
+        result = await handler.handle_back(update, make_context())
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -270,17 +180,11 @@ async def test_handle_back_no_callback(
 # ---------------------------------------------------------------------------
 
 
-@patch("src.bot.handlers.help.TranslationService")
-def test_get_handler_returns_list(mock_ts_class):
+def test_get_handler_returns_list():
     """get_handler returns a list of handlers."""
-    mock_ts = MagicMock()
-    mock_ts.get_text = MagicMock(side_effect=lambda key, **kw: key)
-    mock_ts_class.return_value = mock_ts
+    with _help_patches():
+        handler = _make_handler()
+        handlers = handler.get_handler()
 
-    from src.bot.handlers.help import HelpHandler
-
-    handler = HelpHandler()
-    handlers = handler.get_handler()
-
-    assert isinstance(handlers, list)
-    assert len(handlers) > 0
+        assert isinstance(handlers, list)
+        assert len(handlers) > 0

--- a/translations/addarr.de-de.yml
+++ b/translations/addarr.de-de.yml
@@ -133,32 +133,31 @@ de-de:
     ChangedTo100: "✅ Kein Geschwindigkeitslimit"
     Error: "❌ Bei der Änderung des Geschwindigkeitslimits ist ein Fehler aufgetreten"
   
-  # Help text
-  HelpText: "❓ Möchtest du diesen Text erneut sehen? Benutze /%{help}.
-
-    🚀 Basis-Befehle:
-    • Zur Authentifizierung benutze /%{authenticate}
-    • Um Medien hinzuzufügen benutze /%{add}
-    • Um Medien zu löschen, benutze /%{delete}
-    • Um Medien direkt hinzuzufügen benutze /%{movie}, /%{serie} oder /%{music}
-
-    📊 Status-Befehle:
-    • Um alle verfügbaren Serien in Sonarr anzuzeigen benutze /%{allSeries}
-    • Um alle verfügbaren Filme in Radarr anzuzeigen benutze /%{allMovies}
-    • Um alle verfügbaren Künstler in Lidarr anzuzeigen benutze /%{allMusic}
-
-    ⚙️ System-Befehle:
-    • Um die Up- und Download Geschwindigkeit von Transmission umzuschalten benutze /%{transmission}
-    • Um die Up- und Download Geschwindigkeit von SABnzbd umzuschalten benutze /%{sabnzbd}
-
-    🛠️ Admin-Befehle:
-    • python run.py --setup - Setup-Assistent ausführen
-    • python run.py --configure - Dienste hinzufügen/bearbeiten
-    • python run.py --check - Konfigurationsstatus anzeigen
-    • python run.py --validate-i18n - Übersetzungsdateien validieren
-    • python run.py --backup - Konfiguration sichern
-    • python run.py --reset - Konfiguration zurücksetzen
-    • python run.py --help - Alle Befehle anzeigen"
+  # Help sections
+  HelpHeader: "🤖 *Available Commands:*"
+  HelpBasicCommands: |
+    🚀 /start - Start the bot
+    🔐 /auth - Authenticate with password
+    ❓ /help - Show this help message
+    📊 /status - Check system status
+    ⚙️ /settings - Manage settings
+    🗑️ /delete - Delete media
+    📚 /library - Browse your library
+  HelpMediaMovies: |
+    🎬 /movie - Search and add movies
+    🎬 /allmovies - Show all movies
+  HelpMediaSeries: |
+    📺 /series - Search and add TV shows
+    📺 /allseries - Show all series
+  HelpMediaMusic: |
+    🎵 /music - Search and add music
+    🎵 /allmusic - Show all music
+  HelpDownloadTransmission: "📡 /transmission - Manage Transmission"
+  HelpDownloadSabnzbd: "📥 /sabnzbd - Manage SABnzbd"
+  HelpVersion: "🔄 Version: %(version)s"
+  HelpFooter: |
+    📖 Wiki: https://github.com/Krypt0nBull3t/Addarr/wiki
+    🐞 Issues: https://github.com/Krypt0nBull3t/Addarr/issues
 
   # Error messages
   Error:

--- a/translations/addarr.en-us.yml
+++ b/translations/addarr.en-us.yml
@@ -121,32 +121,31 @@ en-us:
     ChangedTo100: "✅ No speed limit"
     Error: "❌ Something went wrong while trying to set the speed"
   
-  # Help text
-  HelpText: "❓ Want to see this text again? Use /%{help}.
-
-    🚀 Basic Commands:
-    • To authenticate before first use you should use /%{authenticate}
-    • To add media use /%{add}
-    • To delete media use /%{delete}
-    • To immediately add media you can use /%{movie}, /%{serie} or /%{music}
-
-    📊 Status Commands:
-    • To check which series are in Sonarr use /%{allSeries}
-    • To check which movies are in Radarr use /%{allMovies}
-    • To check which artists are in Lidarr use /%{allMusic}
-
-    ⚙️ System Commands:
-    • To toggle Transmission speed use /%{transmission}
-    • To change SABnzbd speed use /%{sabnzbd}
-
-    🛠️ Admin Commands:
-    • python run.py --setup - Run initial setup wizard
-    • python run.py --configure - Add/modify services
-    • python run.py --check - Show configuration status
-    • python run.py --validate-translations - Validate translation files
-    • python run.py --backup - Create configuration backup
-    • python run.py --reset - Reset configuration to default
-    • python run.py --help - Show all commands"
+  # Help sections
+  HelpHeader: "🤖 *Available Commands:*"
+  HelpBasicCommands: |
+    🚀 /start - Start the bot
+    🔐 /auth - Authenticate with password
+    ❓ /help - Show this help message
+    📊 /status - Check system status
+    ⚙️ /settings - Manage settings
+    🗑️ /delete - Delete media
+    📚 /library - Browse your library
+  HelpMediaMovies: |
+    🎬 /movie - Search and add movies
+    🎬 /allmovies - Show all movies
+  HelpMediaSeries: |
+    📺 /series - Search and add TV shows
+    📺 /allseries - Show all series
+  HelpMediaMusic: |
+    🎵 /music - Search and add music
+    🎵 /allmusic - Show all music
+  HelpDownloadTransmission: "📡 /transmission - Manage Transmission"
+  HelpDownloadSabnzbd: "📥 /sabnzbd - Manage SABnzbd"
+  HelpVersion: "🔄 Version: %(version)s"
+  HelpFooter: |
+    📖 Wiki: https://github.com/Krypt0nBull3t/Addarr/wiki
+    🐞 Issues: https://github.com/Krypt0nBull3t/Addarr/issues
   
   # Settings
   Settings:

--- a/translations/addarr.es-es.yml
+++ b/translations/addarr.es-es.yml
@@ -133,32 +133,31 @@ es-es:
     ChangedTo100: "✅ Sin límite aplicado"
     Error: "❌ Algo ha fallado cuando se ha intentado cambiar la velocidad"
   
-  # Help text
-  HelpText: "❓ ¿Quieres volver a ver este texto? Usa /%{help}.
-
-    🚀 Comandos básicos:
-    • Para autenticarte antes del primer uso debes usar /%{authenticate}
-    • Para añadir contenido usa /%{add}
-    • Para eliminar contenido usa /%{delete}
-    • Para añadir directamente contenido usa /%{movie}, /%{serie} o /%{music}
-
-    📊 Comandos de estado:
-    • Para ver qué series hay en Sonarr usa /%{allSeries}
-    • Para ver qué películas hay en Radarr usa /%{allMovies}
-    • Para ver qué artistas hay en Lidarr usa /%{allMusic}
-
-    ⚙️ Comandos del sistema:
-    • Para alternar la velocidad de Transmission usa /%{transmission}
-    • Para cambiar la velocidad de SABnzbd usa /%{sabnzbd}
-
-    🛠️ Comandos de administrador:
-    • python run.py --setup - Ejecutar asistente de configuración
-    • python run.py --configure - Añadir/modificar servicios
-    • python run.py --check - Mostrar estado de configuración
-    • python run.py --validate-i18n - Validar archivos de traducción
-    • python run.py --backup - Crear copia de seguridad
-    • python run.py --reset - Restablecer configuración
-    • python run.py --help - Mostrar todos los comandos"
+  # Help sections
+  HelpHeader: "🤖 *Available Commands:*"
+  HelpBasicCommands: |
+    🚀 /start - Start the bot
+    🔐 /auth - Authenticate with password
+    ❓ /help - Show this help message
+    📊 /status - Check system status
+    ⚙️ /settings - Manage settings
+    🗑️ /delete - Delete media
+    📚 /library - Browse your library
+  HelpMediaMovies: |
+    🎬 /movie - Search and add movies
+    🎬 /allmovies - Show all movies
+  HelpMediaSeries: |
+    📺 /series - Search and add TV shows
+    📺 /allseries - Show all series
+  HelpMediaMusic: |
+    🎵 /music - Search and add music
+    🎵 /allmusic - Show all music
+  HelpDownloadTransmission: "📡 /transmission - Manage Transmission"
+  HelpDownloadSabnzbd: "📥 /sabnzbd - Manage SABnzbd"
+  HelpVersion: "🔄 Version: %(version)s"
+  HelpFooter: |
+    📖 Wiki: https://github.com/Krypt0nBull3t/Addarr/wiki
+    🐞 Issues: https://github.com/Krypt0nBull3t/Addarr/issues
   
   # Error messages
   Error:

--- a/translations/addarr.fr-fr.yml
+++ b/translations/addarr.fr-fr.yml
@@ -133,32 +133,31 @@ fr-fr:
     ChangedTo100: "✅ Pas de limite de vitesse"
     Error: "❌ Une erreur s'est produite lors du réglage de la vitesse"
   
-  # Help text
-  HelpText: "❓ Vous voulez revoir ce texte ? Utilisez /%{help}.
-
-    🚀 Commandes de base:
-    • Pour vous authentifier avant la première utilisation, utilisez /%{authenticate}
-    • Pour ajouter des médias utilisez /%{add}
-    • Pour supprimer des médias utilisez /%{delete}
-    • Pour ajouter directement des médias utilisez /%{movie}, /%{serie} ou /%{music}
-
-    📊 Commandes de statut:
-    • Pour voir les séries dans Sonarr utilisez /%{allSeries}
-    • Pour voir les films dans Radarr utilisez /%{allMovies}
-    • Pour voir les artistes dans Lidarr utilisez /%{allMusic}
-
-    ⚙️ Commandes système:
-    • Pour modifier la vitesse de Transmission utilisez /%{transmission}
-    • Pour modifier la vitesse de SABnzbd utilisez /%{sabnzbd}
-
-    🛠️ Commandes administrateur:
-    • python run.py --setup - Lancer l'assistant de configuration
-    • python run.py --configure - Ajouter/modifier les services
-    • python run.py --check - Afficher l'état de la configuration
-    • python run.py --validate-i18n - Valider les fichiers de traduction
-    • python run.py --backup - Créer une sauvegarde de la configuration
-    • python run.py --reset - Réinitialiser la configuration
-    • python run.py --help - Afficher toutes les commandes"
+  # Help sections
+  HelpHeader: "🤖 *Available Commands:*"
+  HelpBasicCommands: |
+    🚀 /start - Start the bot
+    🔐 /auth - Authenticate with password
+    ❓ /help - Show this help message
+    📊 /status - Check system status
+    ⚙️ /settings - Manage settings
+    🗑️ /delete - Delete media
+    📚 /library - Browse your library
+  HelpMediaMovies: |
+    🎬 /movie - Search and add movies
+    🎬 /allmovies - Show all movies
+  HelpMediaSeries: |
+    📺 /series - Search and add TV shows
+    📺 /allseries - Show all series
+  HelpMediaMusic: |
+    🎵 /music - Search and add music
+    🎵 /allmusic - Show all music
+  HelpDownloadTransmission: "📡 /transmission - Manage Transmission"
+  HelpDownloadSabnzbd: "📥 /sabnzbd - Manage SABnzbd"
+  HelpVersion: "🔄 Version: %(version)s"
+  HelpFooter: |
+    📖 Wiki: https://github.com/Krypt0nBull3t/Addarr/wiki
+    🐞 Issues: https://github.com/Krypt0nBull3t/Addarr/issues
   
   # Error messages
   Error:

--- a/translations/addarr.it-it.yml
+++ b/translations/addarr.it-it.yml
@@ -133,32 +133,31 @@ it-it:
     ChangedTo100: "✅ Nessun limite di velocità"
     Error: "❌ Si è verificato un errore durante l'impostazione della velocità"
   
-  # Help text
-  HelpText: "❓ Vuoi rivedere questo testo? Usa /%{help}.
-
-    🚀 Comandi base:
-    • Per autenticarti prima del primo utilizzo usa /%{authenticate}
-    • Per aggiungere contenuti usa /%{add}
-    • Per eliminare contenuti usa /%{delete}
-    • Per aggiungere direttamente un film o una serie usa /%{movie}, /%{serie} o /%{music}
-
-    📊 Comandi di stato:
-    • Per vedere quali serie sono in Sonarr usa /%{allSeries}
-    • Per vedere quali film sono in Radarr usa /%{allMovies}
-    • Per vedere quali artisti sono in Lidarr usa /%{allMusic}
-
-    ⚙️ Comandi di sistema:
-    • Per modificare la velocità di Transmission usa /%{transmission}
-    • Per modificare la velocità di SABnzbd usa /%{sabnzbd}
-
-    🛠️ Comandi amministratore:
-    • python run.py --setup - Esegui la configurazione iniziale
-    • python run.py --configure - Aggiungi/modifica servizi
-    • python run.py --check - Mostra stato configurazione
-    • python run.py --validate-i18n - Valida file di traduzione
-    • python run.py --backup - Crea backup configurazione
-    • python run.py --reset - Ripristina configurazione predefinita
-    • python run.py --help - Mostra tutti i comandi"
+  # Help sections
+  HelpHeader: "🤖 *Available Commands:*"
+  HelpBasicCommands: |
+    🚀 /start - Start the bot
+    🔐 /auth - Authenticate with password
+    ❓ /help - Show this help message
+    📊 /status - Check system status
+    ⚙️ /settings - Manage settings
+    🗑️ /delete - Delete media
+    📚 /library - Browse your library
+  HelpMediaMovies: |
+    🎬 /movie - Search and add movies
+    🎬 /allmovies - Show all movies
+  HelpMediaSeries: |
+    📺 /series - Search and add TV shows
+    📺 /allseries - Show all series
+  HelpMediaMusic: |
+    🎵 /music - Search and add music
+    🎵 /allmusic - Show all music
+  HelpDownloadTransmission: "📡 /transmission - Manage Transmission"
+  HelpDownloadSabnzbd: "📥 /sabnzbd - Manage SABnzbd"
+  HelpVersion: "🔄 Version: %(version)s"
+  HelpFooter: |
+    📖 Wiki: https://github.com/Krypt0nBull3t/Addarr/wiki
+    🐞 Issues: https://github.com/Krypt0nBull3t/Addarr/issues
   
   # Error messages
   Error:

--- a/translations/addarr.nl-be.yml
+++ b/translations/addarr.nl-be.yml
@@ -133,32 +133,31 @@ nl-be:
     ChangedTo100: "✅ Geen snelheidslimiet"
     Error: "❌ Er ging iets fout tijdens het aanpassen van de snelheid"
   
-  # Help text
-  HelpText: "❓ Wil je deze tekst nog eens zien? Gebruik dan /%{help}.
-
-    🚀 Basis-commando's:
-    • Om de eerste keer te authenticeren gebruik je /%{authenticate}
-    • Om een film of serie toe te voegen kun je /%{add} gebruiken
-    • Om een serie of film te verwijderen gebruik je /%{delete}
-    • Om meteen een film of serie toe te voegen gebruik je /%{movie}, /%{serie} of /%{music}
-
-    📊 Status-commando's:
-    • Om te kijken welke series al in Sonarr zitten gebruik je /%{allSeries}
-    • Om te kijken welke films al in Radarr zitten gebruik je /%{allMovies}
-    • Om te kijken welke artiesten in Lidarr zitten gebruik je /%{allMusic}
-
-    ⚙️ Systeem-commando's:
-    • Om de snelheidslimiet van Transmission te wijzigen gebruik je /%{transmission}
-    • Om de snelheidslimiet van SABnzbd te wijzigen gebruik je /%{sabnzbd}
-
-    🛠️ Admin-commando's:
-    • python run.py --setup - Start configuratie wizard
-    • python run.py --configure - Diensten toevoegen/wijzigen
-    • python run.py --check - Toon configuratie status
-    • python run.py --validate-i18n - Valideer vertaalbestanden
-    • python run.py --backup - Maak backup van configuratie
-    • python run.py --reset - Reset configuratie naar standaard
-    • python run.py --help - Toon alle commando's"
+  # Help sections
+  HelpHeader: "🤖 *Available Commands:*"
+  HelpBasicCommands: |
+    🚀 /start - Start the bot
+    🔐 /auth - Authenticate with password
+    ❓ /help - Show this help message
+    📊 /status - Check system status
+    ⚙️ /settings - Manage settings
+    🗑️ /delete - Delete media
+    📚 /library - Browse your library
+  HelpMediaMovies: |
+    🎬 /movie - Search and add movies
+    🎬 /allmovies - Show all movies
+  HelpMediaSeries: |
+    📺 /series - Search and add TV shows
+    📺 /allseries - Show all series
+  HelpMediaMusic: |
+    🎵 /music - Search and add music
+    🎵 /allmusic - Show all music
+  HelpDownloadTransmission: "📡 /transmission - Manage Transmission"
+  HelpDownloadSabnzbd: "📥 /sabnzbd - Manage SABnzbd"
+  HelpVersion: "🔄 Version: %(version)s"
+  HelpFooter: |
+    📖 Wiki: https://github.com/Krypt0nBull3t/Addarr/wiki
+    🐞 Issues: https://github.com/Krypt0nBull3t/Addarr/issues
   
   # Error messages
   Error:

--- a/translations/addarr.pl-pl.yml
+++ b/translations/addarr.pl-pl.yml
@@ -133,32 +133,31 @@ pl-pl:
     ChangedTo100: "✅ Bez limitu prędkości"
     Error: "❌ Wystąpił błąd podczas ustawiania prędkości"
   
-  # Help text
-  HelpText: "❓ Chcesz zobaczyć ten tekst ponownie? Użyj /%{help}.
-
-    🚀 Podstawowe komendy:
-    • Aby uwierzytelnić się przed pierwszym użyciem, użyj /%{authenticate}
-    • Aby dodać media użyj /%{add}
-    • Aby usunąć media użyj /%{delete}
-    • Aby bezpośrednio dodać media użyj /%{movie}, /%{serie} lub /%{music}
-
-    📊 Komendy statusu:
-    • Aby sprawdzić seriale w Sonarr użyj /%{allSeries}
-    • Aby sprawdzić filmy w Radarr użyj /%{allMovies}
-    • Aby sprawdzić artystów w Lidarr użyj /%{allMusic}
-
-    ⚙️ Komendy systemowe:
-    • Aby zmienić prędkość Transmission użyj /%{transmission}
-    • Aby zmienić prędkość SABnzbd użyj /%{sabnzbd}
-
-    🛠️ Komendy administratora:
-    • python run.py --setup - Uruchom kreator konfiguracji
-    • python run.py --configure - Dodaj/modyfikuj usługi
-    • python run.py --check - Pokaż status konfiguracji
-    • python run.py --validate-i18n - Sprawdź pliki tłumaczeń
-    • python run.py --backup - Utwórz kopię zapasową konfiguracji
-    • python run.py --reset - Przywróć domyślną konfigurację
-    • python run.py --help - Pokaż wszystkie komendy"
+  # Help sections
+  HelpHeader: "🤖 *Available Commands:*"
+  HelpBasicCommands: |
+    🚀 /start - Start the bot
+    🔐 /auth - Authenticate with password
+    ❓ /help - Show this help message
+    📊 /status - Check system status
+    ⚙️ /settings - Manage settings
+    🗑️ /delete - Delete media
+    📚 /library - Browse your library
+  HelpMediaMovies: |
+    🎬 /movie - Search and add movies
+    🎬 /allmovies - Show all movies
+  HelpMediaSeries: |
+    📺 /series - Search and add TV shows
+    📺 /allseries - Show all series
+  HelpMediaMusic: |
+    🎵 /music - Search and add music
+    🎵 /allmusic - Show all music
+  HelpDownloadTransmission: "📡 /transmission - Manage Transmission"
+  HelpDownloadSabnzbd: "📥 /sabnzbd - Manage SABnzbd"
+  HelpVersion: "🔄 Version: %(version)s"
+  HelpFooter: |
+    📖 Wiki: https://github.com/Krypt0nBull3t/Addarr/wiki
+    🐞 Issues: https://github.com/Krypt0nBull3t/Addarr/issues
   
   # Error messages
   Error:

--- a/translations/addarr.pt-pt.yml
+++ b/translations/addarr.pt-pt.yml
@@ -133,32 +133,31 @@ pt-pt:
     ChangedTo100: "✅ Sem limite definido"
     Error: "❌ Algo correu mal ao tentar definir a velocidade"
   
-  # Help text
-  HelpText: "❓ Para ver este texto novamente escreva /%{help}.
-
-    🚀 Comandos básicos:
-    • Para autenticar antes da primeira utilização deve escrever /%{authenticate}
-    • Para adicionar um filme ou série escreva /%{add}
-    • Para apagar uma série ou filme use /%{delete}
-    • Para adicionar imediatamente um filme ou série pode escrever /%{movie}, /%{serie} ou /%{music}
-
-    📊 Comandos de estado:
-    • Para ver que séries existem no Sonarr, escreva /%{allSeries}
-    • Para ver que filmes existem no Radarr, escreva /%{allMovies}
-    • Para ver que artistas existem no Lidarr, escreva /%{allMusic}
-
-    ⚙️ Comandos do sistema:
-    • Para alterar a velocidade de download do Transmission escreva /%{transmission}
-    • Para alterar a velocidade de download do Sabnzbd, utilize /%{sabnzbd}
-
-    🛠️ Comandos de administrador:
-    • python run.py --setup - Executar assistente de configuração
-    • python run.py --configure - Adicionar/modificar serviços
-    • python run.py --check - Mostrar estado da configuração
-    • python run.py --validate-i18n - Validar ficheiros de tradução
-    • python run.py --backup - Criar backup da configuração
-    • python run.py --reset - Repor configuração padrão
-    • python run.py --help - Mostrar todos os comandos"
+  # Help sections
+  HelpHeader: "🤖 *Available Commands:*"
+  HelpBasicCommands: |
+    🚀 /start - Start the bot
+    🔐 /auth - Authenticate with password
+    ❓ /help - Show this help message
+    📊 /status - Check system status
+    ⚙️ /settings - Manage settings
+    🗑️ /delete - Delete media
+    📚 /library - Browse your library
+  HelpMediaMovies: |
+    🎬 /movie - Search and add movies
+    🎬 /allmovies - Show all movies
+  HelpMediaSeries: |
+    📺 /series - Search and add TV shows
+    📺 /allseries - Show all series
+  HelpMediaMusic: |
+    🎵 /music - Search and add music
+    🎵 /allmusic - Show all music
+  HelpDownloadTransmission: "📡 /transmission - Manage Transmission"
+  HelpDownloadSabnzbd: "📥 /sabnzbd - Manage SABnzbd"
+  HelpVersion: "🔄 Version: %(version)s"
+  HelpFooter: |
+    📖 Wiki: https://github.com/Krypt0nBull3t/Addarr/wiki
+    🐞 Issues: https://github.com/Krypt0nBull3t/Addarr/issues
   
   # Error messages
   Error:

--- a/translations/addarr.ru-ru.yml
+++ b/translations/addarr.ru-ru.yml
@@ -133,32 +133,31 @@ ru-ru:
     ChangedTo100: "✅ Без ограничения скорости"
     Error: "❌ Что-то пошло не так при попытке установить скорость"
   
-  # Help text
-  HelpText: "❓ Хотите снова увидеть этот текст? Используйте /%{help}.
-
-    🚀 Основные команды:
-    • Для аутентификации перед первым использованием используйте /%{authenticate}
-    • Чтобы добавить медиа, используйте /%{add}
-    • Чтобы удалить медиа, используйте /%{delete}
-    • Чтобы сразу добавить медиа используйте /%{movie}, /%{serie} или /%{music}
-
-    📊 Команды статуса:
-    • Чтобы проверить сериалы в Sonarr используйте /%{allSeries}
-    • Чтобы проверить фильмы в Radarr используйте /%{allMovies}
-    • Чтобы проверить артистов в Lidarr используйте /%{allMusic}
-
-    ⚙️ Системные команды:
-    • Чтобы изменить скорость Transmission используйте /%{transmission}
-    • Чтобы изменить скорость SABnzbd используйте /%{sabnzbd}
-
-    🛠️ Команды администратора:
-    • python run.py --setup - Запустить мастер настройки
-    • python run.py --configure - Добавить/изменить сервисы
-    • python run.py --check - Показать статус конфигурации
-    • python run.py --validate-i18n - Проверить файлы переводов
-    • python run.py --backup - Создать резервную копию конфигурации
-    • python run.py --reset - Сбросить конфигурацию
-    • python run.py --help - Показать все команды"
+  # Help sections
+  HelpHeader: "🤖 *Available Commands:*"
+  HelpBasicCommands: |
+    🚀 /start - Start the bot
+    🔐 /auth - Authenticate with password
+    ❓ /help - Show this help message
+    📊 /status - Check system status
+    ⚙️ /settings - Manage settings
+    🗑️ /delete - Delete media
+    📚 /library - Browse your library
+  HelpMediaMovies: |
+    🎬 /movie - Search and add movies
+    🎬 /allmovies - Show all movies
+  HelpMediaSeries: |
+    📺 /series - Search and add TV shows
+    📺 /allseries - Show all series
+  HelpMediaMusic: |
+    🎵 /music - Search and add music
+    🎵 /allmusic - Show all music
+  HelpDownloadTransmission: "📡 /transmission - Manage Transmission"
+  HelpDownloadSabnzbd: "📥 /sabnzbd - Manage SABnzbd"
+  HelpVersion: "🔄 Version: %(version)s"
+  HelpFooter: |
+    📖 Wiki: https://github.com/Krypt0nBull3t/Addarr/wiki
+    🐞 Issues: https://github.com/Krypt0nBull3t/Addarr/issues
   
   # Error messages
   Error:

--- a/translations/addarr.template.yml
+++ b/translations/addarr.template.yml
@@ -125,32 +125,31 @@ template:
     ChangedTo100: "✅ No speed limit"
     Error: "❌ Something went wrong while trying to set the speed"
   
-  # Help text
-  HelpText: "❓ Want to see this text again? Use /%{help}.
-
-    🚀 Basic Commands:
-    • To authenticate before first use you should use /%{authenticate}
-    • To add media use /%{add}
-    • To delete media use /%{delete}
-    • To immediately add media you can use /%{movie}, /%{serie} or /%{music}
-
-    📊 Status Commands:
-    • To check which series are in Sonarr use /%{allSeries}
-    • To check which movies are in Radarr use /%{allMovies}
-    • To check which artists are in Lidarr use /%{allMusic}
-
-    ⚙️ System Commands:
-    • To toggle Transmission speed use /%{transmission}
-    • To change SABnzbd speed use /%{sabnzbd}
-
-    🛠️ Admin Commands:
-    • python run.py --setup - Run initial setup wizard
-    • python run.py --configure - Add/modify services
-    • python run.py --check - Show configuration status
-    • python run.py --validate-i18n - Validate translation files
-    • python run.py --backup - Create configuration backup
-    • python run.py --reset - Reset configuration to default
-    • python run.py --help - Show all commands"
+  # Help sections
+  HelpHeader: "🤖 *Available Commands:*"
+  HelpBasicCommands: |
+    🚀 /start - Start the bot
+    🔐 /auth - Authenticate with password
+    ❓ /help - Show this help message
+    📊 /status - Check system status
+    ⚙️ /settings - Manage settings
+    🗑️ /delete - Delete media
+    📚 /library - Browse your library
+  HelpMediaMovies: |
+    🎬 /movie - Search and add movies
+    🎬 /allmovies - Show all movies
+  HelpMediaSeries: |
+    📺 /series - Search and add TV shows
+    📺 /allseries - Show all series
+  HelpMediaMusic: |
+    🎵 /music - Search and add music
+    🎵 /allmusic - Show all music
+  HelpDownloadTransmission: "📡 /transmission - Manage Transmission"
+  HelpDownloadSabnzbd: "📥 /sabnzbd - Manage SABnzbd"
+  HelpVersion: "🔄 Version: %(version)s"
+  HelpFooter: |
+    📖 Wiki: https://github.com/Krypt0nBull3t/Addarr/wiki
+    🐞 Issues: https://github.com/Krypt0nBull3t/Addarr/issues
   
   # Error messages
   Error:


### PR DESCRIPTION
## Summary

- Replace hardcoded English help text with section-based translation keys (`HelpHeader`, `HelpBasicCommands`, `HelpMediaMovies`, etc.) across all 10 locale files
- Help handler now dynamically filters displayed commands based on which services are enabled in config (Radarr, Sonarr, Lidarr, Transmission, SABnzbd)
- Version pulled from `src.__version__` instead of hardcoded "0.1.0"; repo URLs updated to `Krypt0nBull3t/Addarr`

Closes #113

## Test plan

- [x] 10 help handler tests pass (enabled/disabled services, version, callback, no-user edge case)
- [x] 100% coverage on `src/bot/handlers/help.py`
- [x] Full suite: 1861 tests pass
- [x] Lint clean
- [x] Translation validation passes (`--validate-i18n`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
