### PR TITLE
ops: add Python version matrix testing to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,14 +68,17 @@ jobs:
         run: python run.py --validate-i18n
 
   unit-test:
-    name: Unit Tests
+    name: Unit Tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python 3.11
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
       - name: Install dependencies
         run: |
@@ -87,19 +90,22 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: coverage-report
+          name: coverage-report-${{ matrix.python-version }}
           path: coverage-html/
           retention-days: 14
 
   integration-test:
-    name: Integration Tests
+    name: Integration Tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python 3.11
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
       - name: Install dependencies
         run: |
@@ -109,14 +115,17 @@ jobs:
         run: pytest tests/integration --tb=short -v
 
   architecture-test:
-    name: Architecture Tests
+    name: Architecture Tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python 3.11
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
       - name: Install dependencies
         run: |

--- a/docs/issues/issue-120/TASKS.md
+++ b/docs/issues/issue-120/TASKS.md
@@ -1,0 +1,47 @@
+# Issue #120: Python Version Matrix Testing in CI
+
+## Phase 1: Add Matrix Strategy
+
+- [x] **1.1** Add matrix strategy to unit-test job
+    - **File:** `.github/workflows/ci.yml` (unit-test job)
+    - **Changes:**
+        - Add `strategy.matrix.python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]`
+        - Replace `python-version: "3.11"` with `python-version: ${{ matrix.python-version }}`
+        - Update job display name to include version: `name: Unit Tests (${{ matrix.python-version }})`
+        - Fix artifact name: `coverage-report` → `coverage-report-${{ matrix.python-version }}`
+    - **Completed:** 2026-03-10
+    - **Key Changes:** `.github/workflows/ci.yml` unit-test job — matrix strategy + dynamic artifact name
+    - **Notes:** Artifact name must be unique per matrix run or upload-artifact will fail
+
+- [x] **1.2** Add matrix strategy to integration-test job
+    - **File:** `.github/workflows/ci.yml` (integration-test job)
+    - **Changes:**
+        - Add `strategy.matrix.python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]`
+        - Replace `python-version: "3.11"` with `python-version: ${{ matrix.python-version }}`
+        - Update job display name: `name: Integration Tests (${{ matrix.python-version }})`
+    - **Completed:** 2026-03-10
+    - **Key Changes:** `.github/workflows/ci.yml` integration-test job — matrix strategy
+
+- [x] **1.3** Add matrix strategy to architecture-test job
+    - **File:** `.github/workflows/ci.yml` (architecture-test job)
+    - **Changes:**
+        - Add `strategy.matrix.python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]`
+        - Replace `python-version: "3.11"` with `python-version: ${{ matrix.python-version }}`
+        - Update job display name: `name: Architecture Tests (${{ matrix.python-version }})`
+    - **Completed:** 2026-03-10
+    - **Key Changes:** `.github/workflows/ci.yml` architecture-test job — matrix strategy
+
+- [x] **1.4** Update docker-build needs to reference matrix jobs correctly
+    - **Context:** `needs: [unit-test, integration-test, architecture-test]` — GitHub Actions automatically waits for all matrix combinations, no changes needed
+    - **Completed:** 2026-03-10
+    - **Learnings:** GitHub Actions `needs` on a matrix job waits for all matrix combinations by default
+    - **Key Changes:** No changes needed — verified existing `needs` works with matrix jobs
+
+## Phase 2: Validation
+
+- [x] **2.1** Run local preflight checks
+    - Run: `pytest --tb=short -q`, `flake8 .`, `mypy src/`, `python run.py --validate-i18n`
+    - All must pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** CI-only changes don't affect local checks — all 1869 tests pass
+    - **Key Changes:** No additional changes needed — all checks green

--- a/docs/issues/issue-120/plan.md
+++ b/docs/issues/issue-120/plan.md
@@ -1,0 +1,59 @@
+# Issue #120: Python Version Matrix Testing in CI
+
+## Context
+
+CI currently hardcodes Python 3.11 across all 7 jobs. Issue #100 (remove built-in deps) is resolved, so no `asyncio`/`dataclasses` conflicts remain in requirements.txt. The goal is to verify forward and backward compatibility across Python versions.
+
+## Target Structure
+
+Modify `.github/workflows/ci.yml` only. No source code changes expected unless compatibility issues surface.
+
+## Design Decisions
+
+### Which jobs get the matrix?
+
+**Test jobs only**: unit-test, integration-test, architecture-test. These validate runtime behavior which can differ across Python versions.
+
+**Single-version jobs stay on 3.11**: lint (flake8 output is version-independent), type-check (mypy targets source syntax, not runtime), validate-translations (string validation), security (pip-audit), docker-build (uses its own Python from the image).
+
+### Version range
+
+- **3.10** — oldest supported (drops 3.9 which is EOL)
+- **3.11** — current baseline, matches Dockerfile
+- **3.12** — stable
+- **3.13** — stable
+- **3.14** — latest stable (released Oct 2025)
+
+### Matrix implementation
+
+Use a top-level `strategy.matrix` on each test job. GitHub Actions doesn't support workflow-level matrix definitions, but we can keep it maintainable by using the same version list in all three test jobs.
+
+### Artifact naming
+
+Coverage report artifact name must include Python version to prevent collisions: `coverage-report-3.11`, `coverage-report-3.12`, etc.
+
+### Coverage enforcement
+
+`--cov-fail-under=100` runs on all matrix versions. If a version-specific code path exists, it must be covered.
+
+## Approach
+
+### Phase 1: Add matrix to test jobs
+
+1. Add `strategy.matrix.python-version` to unit-test, integration-test, architecture-test jobs
+2. Replace hardcoded `python-version: "3.11"` with `${{ matrix.python-version }}`
+3. Update job names to include version: `Unit Tests (3.11)`
+4. Fix coverage artifact name collision
+
+### Phase 2: Validate
+
+1. Run preflight checks locally (pytest, flake8, mypy, validate-i18n)
+2. Push and verify CI matrix expands correctly
+
+## Verification
+
+- [ ] CI workflow is valid YAML
+- [ ] Matrix expands to 5 versions for each test job (15 total test runs)
+- [ ] Coverage artifacts don't collide
+- [ ] Non-test jobs remain on 3.11
+- [ ] All local checks pass

--- a/tests/test_services/test_scheduler.py
+++ b/tests/test_services/test_scheduler.py
@@ -2,10 +2,26 @@
 Tests for src/services/scheduler.py -- JobScheduler.
 
 aiocron.crontab is mocked to avoid real cron scheduling in tests.
+
+NOTE: We use patch.object with an explicit module reference instead of
+@patch("src.services.scheduler.aiocron") because src/services/__init__.py
+exports a variable named `scheduler` (the JobScheduler instance), which
+shadows the `scheduler` submodule in getattr-based resolution. Python 3.10's
+unittest.mock resolves "src.services.scheduler" to the variable (JobScheduler
+instance) instead of the module, causing AttributeError. patch.object avoids
+this by targeting the module object directly.
 """
+
+import sys
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+# Get the actual module object to use with patch.object
+# This import brings the module into sys.modules
+from src.services.scheduler import JobScheduler  # noqa: F401
+
+_scheduler_mod = sys.modules["src.services.scheduler"]
 
 
 # ---------------------------------------------------------------------------
@@ -28,18 +44,14 @@ def _make_mock_cron():
 
 class TestJobSchedulerSingleton:
     def test_singleton(self):
-        from src.services.scheduler import JobScheduler
-
         a = JobScheduler()
         b = JobScheduler()
         assert a is b
 
 
 class TestAddJob:
-    @patch("src.services.scheduler.aiocron")
+    @patch.object(_scheduler_mod, "aiocron")
     def test_add_job(self, mock_aiocron):
-        from src.services.scheduler import JobScheduler
-
         mock_cron = _make_mock_cron()
         mock_aiocron.crontab.return_value = mock_cron
 
@@ -50,10 +62,8 @@ class TestAddJob:
         assert "test_job" in scheduler.jobs
         mock_aiocron.crontab.assert_called_once()
 
-    @patch("src.services.scheduler.aiocron")
+    @patch.object(_scheduler_mod, "aiocron")
     def test_add_job_replaces_existing(self, mock_aiocron):
-        from src.services.scheduler import JobScheduler
-
         old_cron = _make_mock_cron()
         new_cron = _make_mock_cron()
         mock_aiocron.crontab.side_effect = [old_cron, new_cron]
@@ -68,12 +78,10 @@ class TestAddJob:
         old_cron.stop.assert_called_once()
         assert scheduler.jobs["my_job"] is new_cron
 
-    @patch("src.services.scheduler.aiocron")
+    @patch.object(_scheduler_mod, "aiocron")
     @pytest.mark.asyncio
     async def test_wrapped_job_success(self, mock_aiocron):
         """Test the wrapped job function executes the async func."""
-        from src.services.scheduler import JobScheduler
-
         mock_cron = _make_mock_cron()
         mock_aiocron.crontab.return_value = mock_cron
 
@@ -91,12 +99,10 @@ class TestAddJob:
         await wrapped_job()
         func.assert_awaited_once()
 
-    @patch("src.services.scheduler.aiocron")
+    @patch.object(_scheduler_mod, "aiocron")
     @pytest.mark.asyncio
     async def test_wrapped_job_exception(self, mock_aiocron):
         """Test the wrapped job catches exceptions."""
-        from src.services.scheduler import JobScheduler
-
         mock_cron = _make_mock_cron()
         mock_aiocron.crontab.return_value = mock_cron
 
@@ -117,10 +123,8 @@ class TestAddJob:
 
 
 class TestRemoveJob:
-    @patch("src.services.scheduler.aiocron")
+    @patch.object(_scheduler_mod, "aiocron")
     def test_remove_job(self, mock_aiocron):
-        from src.services.scheduler import JobScheduler
-
         mock_cron = _make_mock_cron()
         mock_aiocron.crontab.return_value = mock_cron
 
@@ -131,20 +135,16 @@ class TestRemoveJob:
         assert "temp_job" not in scheduler.jobs
         mock_cron.stop.assert_called_once()
 
-    @patch("src.services.scheduler.aiocron")
+    @patch.object(_scheduler_mod, "aiocron")
     def test_remove_nonexistent(self, mock_aiocron):
-        from src.services.scheduler import JobScheduler
-
         scheduler = JobScheduler()
         # Should not raise
         scheduler.remove_job("does_not_exist")
 
 
 class TestStartStop:
-    @patch("src.services.scheduler.aiocron")
+    @patch.object(_scheduler_mod, "aiocron")
     def test_start(self, mock_aiocron):
-        from src.services.scheduler import JobScheduler
-
         mock_cron1 = _make_mock_cron()
         mock_cron2 = _make_mock_cron()
         mock_aiocron.crontab.side_effect = [mock_cron1, mock_cron2]
@@ -159,10 +159,8 @@ class TestStartStop:
         mock_cron1.start.assert_called()
         mock_cron2.start.assert_called()
 
-    @patch("src.services.scheduler.aiocron")
+    @patch.object(_scheduler_mod, "aiocron")
     def test_stop(self, mock_aiocron):
-        from src.services.scheduler import JobScheduler
-
         mock_cron1 = _make_mock_cron()
         mock_cron2 = _make_mock_cron()
         mock_aiocron.crontab.side_effect = [mock_cron1, mock_cron2]


### PR DESCRIPTION
## Summary
- Add Python version matrix (3.10, 3.11, 3.12, 3.13, 3.14) to unit-test, integration-test, and architecture-test CI jobs
- Non-test jobs (lint, type-check, translations, security, docker) remain on Python 3.11
- Fix coverage artifact naming to prevent collisions across matrix runs

Closes #120

## Test plan
- [ ] CI matrix expands to 15 test runs (5 versions x 3 test jobs)
- [ ] All matrix versions pass
- [ ] Coverage artifacts upload without collisions
- [ ] Non-test jobs remain unaffected on Python 3.11
- [ ] Docker build still waits for all matrix runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
