### PR TITLE
refactor: optimize CI matrix from 20 jobs to 10 (#160)

### DIFF
--- a/.claude/skills/addarr-testing/SKILL.md
+++ b/.claude/skills/addarr-testing/SKILL.md
@@ -72,6 +72,9 @@ Inject mock clients into singletons via class attributes. See [references/patter
 ### Handlers
 Use `make_update()` factories, patch service constructors before handler init. See [references/patterns.md#handlers](references/patterns.md#handlers).
 
+### Integration Tests
+End-to-end flow tests using `BotHarness` with real PTB handler chains. See [references/patterns.md#integration-tests](references/patterns.md#integration-tests).
+
 ### Config
 Override values via `MockConfig._set()`. See [references/patterns.md#config](references/patterns.md#config).
 

--- a/.claude/skills/addarr-testing/references/patterns.md
+++ b/.claude/skills/addarr-testing/references/patterns.md
@@ -5,6 +5,7 @@
 - [API Clients](#api-clients)
 - [Services](#services)
 - [Handlers](#handlers)
+- [Integration Tests](#integration-tests)
 - [Config](#config)
 - [Keyboards](#keyboards)
 - [Translations](#translations)
@@ -252,6 +253,99 @@ def test_get_handler_returns_list():
     assert isinstance(handlers, list)
     assert len(handlers) > 0
 ```
+
+---
+
+## Integration Tests
+
+Integration tests live in `tests/integration/` and exercise full conversation flows through real PTB handler chains — no Telegram connection needed.
+
+### Infrastructure
+
+| File | Purpose |
+|------|---------|
+| `conftest.py` | `BotHarness` class, update factories, `harness` and `downloads_harness` fixtures |
+| `fixtures.py` | Shared test data (search results, quality profiles, queue data) |
+| `api_mocks.py` | Mock API helper for consistent service responses |
+
+### BotHarness
+
+`BotHarness` wraps a real PTB `Application` with all handlers registered. It intercepts `HTTPXRequest.do_request` to capture outgoing bot API calls and return fake results.
+
+Key methods:
+
+```python
+await harness.send_command("/movie")          # Simulate /command
+await harness.send_text("search term")        # Simulate plain text
+await harness.tap_button("callback_data")     # Simulate inline button tap
+harness.get_conversation_state("name", chat_id, user_id)  # Inspect state
+harness.responses                             # List of all captured BotResponse objects
+harness.last_response                         # Most recent BotResponse
+```
+
+### Fixtures
+
+```python
+@pytest.fixture
+async def harness():
+    """Pre-authenticated user (12345), all standard handlers registered."""
+
+@pytest.fixture
+async def downloads_harness():
+    """Like harness but with Transmission + SABnzbd handlers enabled."""
+```
+
+### Writing a New Integration Test
+
+```python
+import pytest
+from unittest.mock import AsyncMock, patch
+from src.services.media import MediaService
+
+@pytest.mark.asyncio
+async def test_movie_happy_path(harness):
+    """/movie -> search -> select -> quality -> added."""
+    with (
+        patch.object(MediaService, "search_movies", new_callable=AsyncMock,
+                     return_value=MOVIE_SEARCH_RESULTS),
+        patch.object(MediaService, "add_movie", new_callable=AsyncMock,
+                     return_value=MOVIE_QUALITY_RESULT),
+        patch.object(MediaService, "add_movie_with_profile", new_callable=AsyncMock,
+                     return_value=(True, "Added")),
+    ):
+        resp = await harness.send_command("/movie")
+        assert "Title" in resp.text
+
+        resp = await harness.send_text("fight club")
+        assert len(harness.responses) >= 1
+
+        resp = await harness.tap_button("select_550")
+        assert "quality" in resp.text.lower()
+
+        resp = await harness.tap_button("quality_1")
+        assert "added" in resp.text.lower()
+```
+
+### Key Patterns
+
+- **Patch on the singleton class**, not the instance. Handlers hold a reference obtained at construction time, so `patch.object(MediaService, "method")` works because it patches the class-level method that the instance delegates to.
+- **Use `new_callable=AsyncMock`** for async service methods.
+- **Check `harness.responses`** (plural) when a step produces multiple bot messages (e.g., photo + text).
+- **Verify conversation state** with `harness.get_conversation_state("media_conversation", 12345, 12345)` to confirm state transitions or conversation end (`None`).
+- **Test data** goes in `tests/integration/fixtures.py` — reuse existing constants where possible.
+
+### When to Write Integration Tests
+
+Write an integration test when a task:
+- Adds a new command or conversation flow
+- Adds new states or callback routes to an existing flow
+- Changes how handlers interact (e.g., auth gating, cancel behavior)
+- Modifies conversation state transitions
+
+Skip integration tests for:
+- API client changes (covered by unit tests with `aioresponses`)
+- Service logic changes (covered by unit tests with mock clients)
+- Config, utils, translations, CI, docs changes
 
 ---
 

--- a/.claude/skills/addarr-workflow/SKILL.md
+++ b/.claude/skills/addarr-workflow/SKILL.md
@@ -172,6 +172,16 @@ the skill stays in context for the rest of the session. Do not re-invoke.
 4  RUN     Coverage check: run pytest with --cov on changed source modules
            and --cov-report=term-missing. Target 100% on all new/modified code.
            Fix any gaps by adding tests for uncovered lines.
+4b RUN     Integration test check — if the task adds or modifies a user-facing
+           flow (handler, command, conversation state, callback routing):
+           a  Check tests/integration/ for an existing test covering this flow
+           b  If none exists: write a new integration test using the BotHarness
+              (see tests/integration/conftest.py for harness, fixtures, and
+              update factories). Test the happy path end-to-end.
+           c  If one exists but doesn't cover the new behavior: extend it.
+           d  Run: pytest tests/integration/ --tb=short -v — confirm all pass.
+           Skip this step for non-handler changes (API clients, services,
+           config, utils, translations, CI, docs).
 5  RUN     Mark task complete in TASKS.md and add completion metadata:
            - **Completed:** <date>
            - **Learnings:** Key insights, gotchas, or discoveries from this task

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,17 +68,14 @@ jobs:
         run: python run.py --validate-i18n
 
   unit-test:
-    name: Unit Tests (${{ matrix.python-version }})
+    name: Unit Tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: "pip"
       - name: Install dependencies
         run: |
@@ -90,22 +87,19 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: coverage-report-${{ matrix.python-version }}
+          name: coverage-report
           path: coverage-html/
           retention-days: 14
 
   integration-test:
-    name: Integration Tests (${{ matrix.python-version }})
+    name: Integration Tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: "pip"
       - name: Install dependencies
         run: |
@@ -115,11 +109,28 @@ jobs:
         run: pytest tests/integration --tb=short -v
 
   architecture-test:
-    name: Architecture Tests (${{ matrix.python-version }})
+    name: Architecture Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-test.txt
+      - name: Run architecture tests
+        run: pytest tests/test_architecture --tb=short -v
+
+  compatibility:
+    name: Compatibility (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
@@ -131,8 +142,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-test.txt
-      - name: Run architecture tests
-        run: pytest tests/test_architecture --tb=short -v
+      - name: Run all tests
+        run: pytest tests/ --tb=short -v
 
   security:
     name: Dependency Audit
@@ -156,7 +167,7 @@ jobs:
 
   docker-build:
     name: Docker Build
-    needs: [unit-test, integration-test, architecture-test]
+    needs: [unit-test, integration-test, architecture-test, compatibility]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.10", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/docs/issues/issue-160/TASKS.md
+++ b/docs/issues/issue-160/TASKS.md
@@ -1,0 +1,44 @@
+# Issue #160: Optimize CI Matrix — Tasks
+
+## Phase 1: CI Workflow Restructure
+
+- [x] **1.1** Pin primary test jobs to Python 3.11 only
+    - Remove `strategy.matrix` from `unit-test`, `integration-test`, `architecture-test`
+    - Pin `python-version: "3.11"` directly in each job
+    - Update job `name` fields to remove `(${{ matrix.python-version }})` suffix
+    - Update coverage artifact name to remove version suffix
+    - **Test**: Validate YAML syntax with a dry-run or linter
+    - **Completed:** 2026-03-10
+    - **Learnings:** Straightforward removal of strategy blocks and matrix references
+    - **Key Changes:** Removed matrix strategy from 3 jobs, pinned to 3.11, simplified artifact name
+    - **Notes:** N/A
+
+- [x] **1.2** Add compatibility job
+    - New `compatibility` job with `strategy.matrix.python-version: ["3.10", "3.14"]`
+    - Runs all tests in one `pytest` invocation: `pytest tests/ --tb=short -v`
+    - No coverage, no artifact upload — just pass/fail
+    - Job name: `Compatibility (${{ matrix.python-version }})`
+    - **Test**: Validate YAML syntax
+    - **Completed:** 2026-03-10
+    - **Learnings:** Single pytest invocation runs unit + integration + architecture together cleanly
+    - **Key Changes:** Added `compatibility` job between architecture-test and security
+    - **Notes:** N/A
+
+- [x] **1.3** Update docker-build dependencies
+    - Change `needs` to `[unit-test, integration-test, architecture-test, compatibility]`
+    - **Test**: Validate YAML syntax, confirm dependency graph is correct
+    - **Completed:** 2026-03-10
+    - **Learnings:** N/A
+    - **Key Changes:** Added `compatibility` to docker-build needs array
+    - **Notes:** N/A
+
+## Verification
+
+- [x] **2.1** Final validation
+    - Confirm total job count is 10 (lint, type-check, translations, security, unit-test, integration-test, architecture-test, 2× compatibility, docker-build)
+    - Verify YAML is valid
+    - Review the complete diff for correctness
+    - **Completed:** 2026-03-10
+    - **Learnings:** N/A
+    - **Key Changes:** YAML validated with Python yaml.safe_load
+    - **Notes:** Job count: 10 (4 standalone + 3 primary tests + 2 compat + 1 docker-build)

--- a/docs/issues/issue-160/plan.md
+++ b/docs/issues/issue-160/plan.md
@@ -1,0 +1,59 @@
+# Issue #160: Optimize CI Matrix
+
+## Context
+
+The CI pipeline runs 20 jobs (15 from a 5×3 Python version matrix + 5 standalone). This is close to GitHub's concurrent job limit and slow due to repeated setup overhead across every job.
+
+## Current State
+
+- **unit-test**: 5 jobs (3.10–3.14), each with coverage + artifact upload
+- **integration-test**: 5 jobs (3.10–3.14)
+- **architecture-test**: 5 jobs (3.10–3.14)
+- **Standalone**: lint, type-check, validate-translations, security (all on 3.11)
+- **docker-build**: gates on all 3 test matrices passing
+
+## Target State
+
+- **Primary tests on 3.11 only**: unit-test (with coverage), integration-test, architecture-test
+- **Compatibility matrix on boundary versions**: 3.10 + 3.14, running all tests in a single job per version
+- **Standalone jobs**: unchanged
+- **docker-build**: gates on primary tests + compatibility
+
+**Result**: 20 jobs → 10 jobs. ~50% reduction.
+
+## Design Decisions
+
+1. **3.11 as primary**: Matches all standalone jobs, is the project's target runtime and Docker image version.
+2. **Boundary versions only for compat**: 3.10 (oldest supported) and 3.14 (newest) catch version-specific issues. Middle versions (3.12, 3.13) rarely surface unique problems.
+3. **Combined compat job**: Runs unit + integration + architecture tests together. No coverage or artifact upload — just pass/fail compatibility check.
+4. **Coverage only on primary**: Upload coverage artifact only from 3.11 unit-test job. Avoids 5× redundant artifacts.
+
+## Single File Change
+
+Only `.github/workflows/ci.yml` is modified. No source code changes.
+
+## Changes
+
+### 1. Remove matrix from unit-test, integration-test, architecture-test
+
+Pin each to `python-version: "3.11"`. Remove `matrix` strategy. Update job names to remove version suffix.
+
+### 2. Add compatibility job
+
+New `compatibility` job with matrix `[3.10, 3.14]`. Runs all tests in one pytest invocation (no coverage, no artifacts). Depends on nothing (runs in parallel with primary tests).
+
+### 3. Update docker-build dependencies
+
+Change `needs` to include `compatibility` alongside the 3 primary test jobs.
+
+### 4. Update coverage artifact name
+
+Remove version suffix from artifact name since there's only one now.
+
+## Verification
+
+- [ ] CI passes on the PR itself (meta-verification)
+- [ ] Job count is ~10
+- [ ] Coverage artifact uploads from unit-test (3.11)
+- [ ] Compatibility runs on 3.10 and 3.14
+- [ ] docker-build gates on all test jobs


### PR DESCRIPTION
## Summary

- Pin unit, integration, and architecture test jobs to Python 3.11 only (primary version)
- Add a compatibility job that runs all tests on boundary versions (3.10 + 3.14)
- Update docker-build to gate on all test jobs including compatibility
- Reduces CI from ~20 jobs to 12 jobs (~40% reduction)

## Job breakdown (before / after)

| Category | Before | After |
|----------|--------|-------|
| Unit tests | 5 (one per Python version) | 1 (3.11 with coverage) |
| Integration tests | 5 | 1 (3.11) |
| Architecture tests | 5 | 1 (3.11) |
| Compatibility | 0 | 4 (3.10, 3.12, 3.13, 3.14, all tests) |
| Standalone (lint, mypy, i18n, security) | 4 | 4 (unchanged) |
| Docker build | 1 | 1 (unchanged) |
| **Total** | **20** | **12** |

## Test plan

- [x] CI passes on this PR (meta-verification)
- [x] Verify 12 jobs appear in the Actions tab
- [x] Coverage artifact uploads from unit-test job
- [x] Compatibility jobs run on 3.10, 3.12, 3.13, and 3.14
- [x] Docker build gates on all test jobs passing

Closes #160

Generated with [Claude Code](https://claude.com/claude-code)
