### PR TITLE
test: add missing integration tests for all handler flows

### DIFF
--- a/docs/issues/issue-162/TASKS.md
+++ b/docs/issues/issue-162/TASKS.md
@@ -32,7 +32,7 @@
 
 **Goal:** Happy-path integration tests for handlers that respond to a single command without complex conversation state.
 
-- [ ] **2.1** Help handler integration test
+- [x] **2.1** Help handler integration test
     - **Context:** See plan.md Task 2.1. Key refs: `src/bot/handlers/help.py` — `/help` command, `menu_back` callback
     - **Watch out:** No service mocks needed — help reads config (already mocked in conftest)
     - **Scope:** `/help` response, `menu_back` callback
@@ -42,8 +42,12 @@
         - [RED] Write test: `menu_back` callback returns response
         - [GREEN] Run tests — should pass immediately (no implementation needed, just verifying harness works)
     - **Success:** `pytest tests/integration/test_help_flow.py -v` — 2 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** No mocks needed — harness conftest already mocks config and translations.
+    - **Key Changes:** Created `tests/integration/test_help_flow.py` with 2 tests.
+    - **Notes:** None.
 
-- [ ] **2.2** System/Status handler integration test
+- [x] **2.2** System/Status handler integration test
     - **Context:** See plan.md Task 2.2. Key refs: `src/bot/handlers/system.py` — `/status` command, `system_refresh`, `system_details`, `system_diskspace`, `system_back` callbacks. Uses module-level `health_service` singleton from `src.services.health`.
     - **Watch out:** Mock `health_service` methods via `patch.object()` on the imported singleton. `get_status()` is sync, `run_health_checks()` and `get_disk_space()` are async.
     - **Scope:** `/status` command + 4 callback actions
@@ -56,8 +60,12 @@
         - [RED] Write test: `system_back` returns to main menu
         - [GREEN] Run tests — should pass with correct mocks
     - **Success:** `pytest tests/integration/test_system_flow.py -v` — 5 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** Callback handlers produce multiple API calls (editMessageText + answerCallbackQuery), so need a `_find_response` helper to locate the edit call specifically.
+    - **Key Changes:** Created `tests/integration/test_system_flow.py` with 5 tests.
+    - **Notes:** `_find_response(harness, method)` pattern is reusable for other callback-driven tests.
 
-- [ ] **2.3** Preferences handler integration test
+- [x] **2.3** Preferences handler integration test
     - **Context:** See plan.md Task 2.3. Key refs: `src/bot/handlers/preferences.py` — `/preferences` command, `pref_toggle_view` callback. Uses `PreferencesService` singleton.
     - **Watch out:** Mock `PreferencesService.get_view_mode` and `toggle_view_mode` via `patch.object()`
     - **Scope:** `/preferences` command + toggle callback
@@ -67,8 +75,12 @@
         - [RED] Write test: `pref_toggle_view` toggles and shows new mode
         - [GREEN] Run tests
     - **Success:** `pytest tests/integration/test_preferences_flow.py -v` — 2 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** `patch.object` on PreferencesService class methods works because singleton delegates to class-level methods.
+    - **Key Changes:** Created `tests/integration/test_preferences_flow.py` with 2 tests.
+    - **Notes:** None.
 
-- [ ] **2.4** History handler integration test
+- [x] **2.4** History handler integration test
     - **Context:** See plan.md Task 2.4. Key refs: `src/bot/handlers/history.py` — `/history` command, `hist_refresh`, `hist_back` callbacks. Uses `MediaService.get_history()`.
     - **Watch out:** Need to add `HISTORY_ITEMS` fixture data to `tests/integration/fixtures.py`
     - **Scope:** `/history` command + empty results + refresh + back
@@ -81,6 +93,10 @@
         - [RED] Write test: `hist_back` returns to main menu
         - [GREEN] Run tests
     - **Success:** `pytest tests/integration/test_history_flow.py -v` — 4 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** Same `_find_response` helper pattern needed for callback tests. Refresh test requires sending `/history` first to populate `user_data`.
+    - **Key Changes:** Added `HISTORY_ITEMS` to `tests/integration/fixtures.py`, created `tests/integration/test_history_flow.py` with 4 tests.
+    - **Notes:** None.
 
 ---
 

--- a/docs/issues/issue-162/TASKS.md
+++ b/docs/issues/issue-162/TASKS.md
@@ -261,7 +261,7 @@
 
 **Goal:** Verify all protected commands gate behind auth.
 
-- [ ] **6.1** Parametrized auth gating test for all commands
+- [x] **6.1** Parametrized auth gating test for all commands
     - **Context:** See plan.md Task 6.1. Key refs: `tests/integration/test_auth_gating.py` (existing file with 3 tests).
     - **Watch out:** Some commands like `/settings` have admin checks on top of auth, but `@require_auth` fires first. The parametrized test covers the auth decorator. Use `AuthHandler._authenticated_users.discard(12345)` before each command.
     - **Scope:** Extend existing test file with parametrized test covering all 12 commands
@@ -270,3 +270,7 @@
         - [RED] Write parametrized test covering: `/help`, `/settings`, `/delete`, `/allMovies`, `/allSeries`, `/allMusic`, `/upcoming`, `/missing`, `/queue`, `/preferences`, `/status`, `/history`
         - [GREEN] Run tests
     - **Success:** `pytest tests/integration/test_auth_gating.py -v` — existing 3 + new parametrized (12 cases) all pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** All 12 commands correctly reject unauthenticated users with auth message. `@require_auth` fires before any handler-specific checks (like admin gate on `/settings`).
+    - **Key Changes:** Added `AUTH_GATED_COMMANDS` list and parametrized `test_unauthenticated_user_blocked_all_commands` to `test_auth_gating.py`.
+    - **Notes:** `/subtitles` excluded because it requires `bazarr_harness`; could add separately if needed.

--- a/docs/issues/issue-162/TASKS.md
+++ b/docs/issues/issue-162/TASKS.md
@@ -239,7 +239,7 @@
 
 **Goal:** At least one error-path test per conversation flow — API failures mid-conversation.
 
-- [ ] **5.1** Error path integration tests
+- [x] **5.1** Error path integration tests
     - **Context:** See plan.md Task 5.1. Key refs: existing happy-path tests in `test_media_flow.py` as template.
     - **Watch out:** Handlers use try/except and send error text — don't expect exceptions to propagate. Assert on the error response text instead.
     - **Scope:** Movie add failure, series search failure, delete failure
@@ -250,6 +250,10 @@
         - [RED] Write test: delete confirm with `delete_movie` returning False → failure text
         - [GREEN] Run tests
     - **Success:** `pytest tests/integration/test_error_paths.py -v` — 3 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** Error paths use `_find_response(harness, "editMessageText")` since handlers catch exceptions and send error text via edit_text. Movie add error is caught in `handle_quality_select` and shows `SelectionProcessError` or `MediaAddError`.
+    - **Key Changes:** Created `tests/integration/test_error_paths.py` with 3 tests: movie add exception, series search exception, delete confirm failure.
+    - **Notes:** None.
 
 ---
 

--- a/docs/issues/issue-162/TASKS.md
+++ b/docs/issues/issue-162/TASKS.md
@@ -199,7 +199,7 @@
 
 **Goal:** Integration tests for handlers using ConversationHandler with state machines.
 
-- [ ] **4.1** Settings handler integration test (admin flow)
+- [x] **4.1** Settings handler integration test (admin flow)
     - **Context:** See plan.md Task 4.1. Key refs: `src/bot/handlers/settings.py` — `/settings` command, `settings_conversation` ConversationHandler. Admin-only via `is_admin()` from `src.definitions`.
     - **Watch out:** Must patch `src.bot.handlers.settings.is_admin` (not `src.definitions.is_admin`). Must also patch `config.update_nested` and `config.save` as no-ops to prevent disk writes.
     - **Scope:** Admin access + non-admin rejection + language flow + back
@@ -211,6 +211,10 @@
         - [RED] Write test: settings → back ends conversation
         - [GREEN] Run tests
     - **Success:** `pytest tests/integration/test_settings_flow.py -v` — 4 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** Language flow requires patching `config` at handler import site to intercept `update_nested`/`save`. `MagicMock` for config with explicit `get`/`update_nested`/`save` works cleanly.
+    - **Key Changes:** Created `tests/integration/test_settings_flow.py` with 4 tests: admin menu, non-admin rejection, language select flow, back ends conversation.
+    - **Notes:** None.
 
 - [ ] **4.2** Bazarr handler integration test
     - **Context:** See plan.md Task 4.2. Key refs: `src/bot/handlers/bazarr.py` — `/subtitles` command, `bazarr_wanted_movies`, `bazarr_cancel` callbacks. Uses `BazarrService` singleton. Requires `bazarr_harness` fixture from task 1.1.

--- a/docs/issues/issue-162/TASKS.md
+++ b/docs/issues/issue-162/TASKS.md
@@ -216,7 +216,7 @@
     - **Key Changes:** Created `tests/integration/test_settings_flow.py` with 4 tests: admin menu, non-admin rejection, language select flow, back ends conversation.
     - **Notes:** None.
 
-- [ ] **4.2** Bazarr handler integration test
+- [x] **4.2** Bazarr handler integration test
     - **Context:** See plan.md Task 4.2. Key refs: `src/bot/handlers/bazarr.py` — `/subtitles` command, `bazarr_wanted_movies`, `bazarr_cancel` callbacks. Uses `BazarrService` singleton. Requires `bazarr_harness` fixture from task 1.1.
     - **Watch out:** Regular `harness` doesn't register BazarrHandler. Use `bazarr_harness` for enabled tests. For "disabled" test, use regular `harness` and send `/subtitles` — BazarrHandler won't be registered, so no response is expected. Alternative: mock `is_enabled()` to return False in bazarr_harness.
     - **Scope:** Menu + disabled check + wanted movies + cancel
@@ -228,6 +228,10 @@
         - [RED] Write test: `bazarr_cancel` sends cancelled message
         - [GREEN] Run tests
     - **Success:** `pytest tests/integration/test_bazarr_flow.py -v` — 3 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** `bazarr_harness` had a recursion bug — `original_get = config.get` captured the mock, not the real method. Fixed by capturing `real_get` before the `patch.object` context.
+    - **Key Changes:** Fixed `bazarr_harness` fixture in `conftest.py` (capture `real_get` before patching). Added `BAZARR_WANTED_MOVIES` to `fixtures.py`. Created `tests/integration/test_bazarr_flow.py` with 3 tests.
+    - **Notes:** None.
 
 ---
 

--- a/docs/issues/issue-162/TASKS.md
+++ b/docs/issues/issue-162/TASKS.md
@@ -1,0 +1,224 @@
+# Issue #162: Add Missing Integration Tests for All Handler Flows
+
+**Source:** [plan.md](plan.md)
+**Branch:** `test/162-add-missing-integration-tests`
+
+---
+
+### Phase 1: Infrastructure — Register Missing Handlers (1 task)
+
+**Goal:** Ensure conftest registers all handlers that main.py does, so integration tests can cover them.
+
+- [x] **1.1** Register HistoryHandler, WebhooksHandler, and BazarrHandler in integration conftest
+    - **Context:** See plan.md Phase 1. Key refs: `tests/integration/conftest.py:313-346` (_register_handlers), `src/main.py:120-200` (handler registration order)
+    - **Watch out:** Handler registration order matters — match main.py. BazarrHandler is conditional (like transmission/sabnzbd). Need a `bazarr_harness` fixture with `BazarrService.is_enabled` patched.
+    - **Scope:** Add imports, update handler list, add bazarr_harness fixture
+    - **Touches:** `tests/integration/conftest.py`
+    - **Action items:**
+        - [GREEN] Add imports for HistoryHandler, WebhooksHandler, BazarrHandler, BazarrService
+        - [GREEN] Add WebhooksHandler and HistoryHandler to handler_classes list (matching main.py order)
+        - [GREEN] Add conditional BazarrHandler registration block
+        - [GREEN] Add `bazarr_harness` fixture
+        - [GREEN] Run existing tests to verify nothing breaks
+    - **Success:** `pytest tests/integration/ --tb=short -q` — all existing tests still pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** Imports were already present in conftest but handlers weren't in the list. Handler order also needed fixing — Help/Preferences/System come after Downloads in main.py.
+    - **Key Changes:** Updated `_register_handlers()` in `tests/integration/conftest.py` — added WebhooksHandler, HistoryHandler to list, conditional BazarrHandler block, reordered Help/Preferences/System after Downloads, added `bazarr_harness` fixture.
+    - **Notes:** `bazarr_harness` uses a wrapping mock on `config.get` to return `{"enable": True}` for the "bazarr" key during handler registration.
+
+---
+
+### Phase 2: Simple Command Tests (4 tasks)
+
+**Goal:** Happy-path integration tests for handlers that respond to a single command without complex conversation state.
+
+- [ ] **2.1** Help handler integration test
+    - **Context:** See plan.md Task 2.1. Key refs: `src/bot/handlers/help.py` — `/help` command, `menu_back` callback
+    - **Watch out:** No service mocks needed — help reads config (already mocked in conftest)
+    - **Scope:** `/help` response, `menu_back` callback
+    - **Touches:** `tests/integration/test_help_flow.py` (new)
+    - **Action items:**
+        - [RED] Write test: `/help` returns sendMessage with non-empty text
+        - [RED] Write test: `menu_back` callback returns response
+        - [GREEN] Run tests — should pass immediately (no implementation needed, just verifying harness works)
+    - **Success:** `pytest tests/integration/test_help_flow.py -v` — 2 tests pass
+
+- [ ] **2.2** System/Status handler integration test
+    - **Context:** See plan.md Task 2.2. Key refs: `src/bot/handlers/system.py` — `/status` command, `system_refresh`, `system_details`, `system_diskspace`, `system_back` callbacks. Uses module-level `health_service` singleton from `src.services.health`.
+    - **Watch out:** Mock `health_service` methods via `patch.object()` on the imported singleton. `get_status()` is sync, `run_health_checks()` and `get_disk_space()` are async.
+    - **Scope:** `/status` command + 4 callback actions
+    - **Touches:** `tests/integration/test_system_flow.py` (new)
+    - **Action items:**
+        - [RED] Write test: `/status` shows system status text
+        - [RED] Write test: `system_refresh` re-runs checks
+        - [RED] Write test: `system_details` shows service details
+        - [RED] Write test: `system_diskspace` shows disk info
+        - [RED] Write test: `system_back` returns to main menu
+        - [GREEN] Run tests — should pass with correct mocks
+    - **Success:** `pytest tests/integration/test_system_flow.py -v` — 5 tests pass
+
+- [ ] **2.3** Preferences handler integration test
+    - **Context:** See plan.md Task 2.3. Key refs: `src/bot/handlers/preferences.py` — `/preferences` command, `pref_toggle_view` callback. Uses `PreferencesService` singleton.
+    - **Watch out:** Mock `PreferencesService.get_view_mode` and `toggle_view_mode` via `patch.object()`
+    - **Scope:** `/preferences` command + toggle callback
+    - **Touches:** `tests/integration/test_preferences_flow.py` (new)
+    - **Action items:**
+        - [RED] Write test: `/preferences` shows current view mode
+        - [RED] Write test: `pref_toggle_view` toggles and shows new mode
+        - [GREEN] Run tests
+    - **Success:** `pytest tests/integration/test_preferences_flow.py -v` — 2 tests pass
+
+- [ ] **2.4** History handler integration test
+    - **Context:** See plan.md Task 2.4. Key refs: `src/bot/handlers/history.py` — `/history` command, `hist_refresh`, `hist_back` callbacks. Uses `MediaService.get_history()`.
+    - **Watch out:** Need to add `HISTORY_ITEMS` fixture data to `tests/integration/fixtures.py`
+    - **Scope:** `/history` command + empty results + refresh + back
+    - **Touches:** `tests/integration/test_history_flow.py` (new), `tests/integration/fixtures.py`
+    - **Action items:**
+        - [GREEN] Add `HISTORY_ITEMS` to fixtures.py
+        - [RED] Write test: `/history` shows items
+        - [RED] Write test: `/history` with empty results
+        - [RED] Write test: `hist_refresh` re-fetches
+        - [RED] Write test: `hist_back` returns to main menu
+        - [GREEN] Run tests
+    - **Success:** `pytest tests/integration/test_history_flow.py -v` — 4 tests pass
+
+---
+
+### Phase 3: Callback-Driven Flow Tests (5 tasks)
+
+**Goal:** Integration tests for handlers that use multi-step callback button flows (no ConversationHandler).
+
+- [ ] **3.1** Delete handler integration test
+    - **Context:** See plan.md Task 3.1. Key refs: `src/bot/handlers/delete.py` — `/delete` → `delete_type_{type}` → `delete_item_{id}` → `delete_confirm`. Uses `MediaService.get_movies()`, `get_movie()`, `delete_movie()`.
+    - **Watch out:** Handler stores state in `context.user_data["delete_type"]` and `["delete_item"]`. The `handle_delete_selection` method isn't decorated with `@require_auth` — only the entry `/delete` is.
+    - **Scope:** Full delete flow + cancel + empty library
+    - **Touches:** `tests/integration/test_delete_flow.py` (new)
+    - **Action items:**
+        - [RED] Write test: happy path — `/delete` → type → item → confirm → success
+        - [RED] Write test: `/delete` → cancel
+        - [RED] Write test: type selection with empty library
+        - [GREEN] Run tests
+    - **Success:** `pytest tests/integration/test_delete_flow.py -v` — 3 tests pass
+
+- [ ] **3.2** Library handler integration test
+    - **Context:** See plan.md Task 3.2. Key refs: `src/bot/handlers/library.py` — `/allMovies`, `/allSeries`, `/allMusic` commands, `lib_{type}_{page}` pagination. Uses `MediaService.get_movies()` etc.
+    - **Watch out:** Need 15+ items to test pagination (ITEMS_PER_PAGE=10). Items cached in `context.user_data[f"library_{media_type}"]`.
+    - **Scope:** All three library commands + pagination + empty
+    - **Touches:** `tests/integration/test_library_flow.py` (new), `tests/integration/fixtures.py`
+    - **Action items:**
+        - [GREEN] Add `LIBRARY_MOVIES` and `LIBRARY_SERIES` to fixtures.py
+        - [RED] Write test: `/allMovies` shows paginated list
+        - [RED] Write test: `/allSeries` shows list
+        - [RED] Write test: pagination via `lib_m_1`
+        - [RED] Write test: empty library
+        - [GREEN] Run tests
+    - **Success:** `pytest tests/integration/test_library_flow.py -v` — 4 tests pass
+
+- [ ] **3.3** Calendar handler integration test
+    - **Context:** See plan.md Task 3.3. Key refs: `src/bot/handlers/calendar.py` — `/upcoming` command, `cal_period_{days}`, `cal_refresh`, `cal_back` callbacks. Uses `MediaService.get_upcoming(days)`.
+    - **Watch out:** `get_upcoming` is called with `days` parameter. Period change calls it again with new days value.
+    - **Scope:** `/upcoming` + period change + refresh + back + empty
+    - **Touches:** `tests/integration/test_calendar_flow.py` (new), `tests/integration/fixtures.py`
+    - **Action items:**
+        - [GREEN] Add `CALENDAR_ITEMS` to fixtures.py
+        - [RED] Write test: `/upcoming` shows items
+        - [RED] Write test: empty calendar
+        - [RED] Write test: `cal_period_30` changes period
+        - [RED] Write test: `cal_refresh`
+        - [RED] Write test: `cal_back` returns to main menu
+        - [GREEN] Run tests
+    - **Success:** `pytest tests/integration/test_calendar_flow.py -v` — 5 tests pass
+
+- [ ] **3.4** Missing handler integration test
+    - **Context:** See plan.md Task 3.4. Key refs: `src/bot/handlers/missing.py` — `/missing` command, `missing_refresh`, `missing_back` callbacks. Uses `MediaService.get_missing_media()`.
+    - **Watch out:** Items cached in `context.user_data["missing_items"]`
+    - **Scope:** `/missing` + empty + refresh + back
+    - **Touches:** `tests/integration/test_missing_flow.py` (new), `tests/integration/fixtures.py`
+    - **Action items:**
+        - [GREEN] Add `MISSING_ITEMS` to fixtures.py
+        - [RED] Write test: `/missing` shows items
+        - [RED] Write test: empty missing
+        - [RED] Write test: `missing_refresh`
+        - [RED] Write test: `missing_back` returns to main menu
+        - [GREEN] Run tests
+    - **Success:** `pytest tests/integration/test_missing_flow.py -v` — 4 tests pass
+
+- [ ] **3.5** Queue handler integration test
+    - **Context:** See plan.md Task 3.5. Key refs: `src/bot/handlers/queue.py` — `/queue` command, `queue_refresh`, `queue_back` callbacks. Uses `MediaService.get_queue_media()`.
+    - **Watch out:** Items cached in `context.user_data["queue_items"]`
+    - **Scope:** `/queue` + empty + refresh + back
+    - **Touches:** `tests/integration/test_queue_flow.py` (new), `tests/integration/fixtures.py`
+    - **Action items:**
+        - [GREEN] Add `QUEUE_ITEMS` to fixtures.py
+        - [RED] Write test: `/queue` shows items
+        - [RED] Write test: empty queue
+        - [RED] Write test: `queue_refresh`
+        - [RED] Write test: `queue_back` returns to main menu
+        - [GREEN] Run tests
+    - **Success:** `pytest tests/integration/test_queue_flow.py -v` — 4 tests pass
+
+---
+
+### Phase 4: Conversation Flow Tests (2 tasks)
+
+**Goal:** Integration tests for handlers using ConversationHandler with state machines.
+
+- [ ] **4.1** Settings handler integration test (admin flow)
+    - **Context:** See plan.md Task 4.1. Key refs: `src/bot/handlers/settings.py` — `/settings` command, `settings_conversation` ConversationHandler. Admin-only via `is_admin()` from `src.definitions`.
+    - **Watch out:** Must patch `src.bot.handlers.settings.is_admin` (not `src.definitions.is_admin`). Must also patch `config.update_nested` and `config.save` as no-ops to prevent disk writes.
+    - **Scope:** Admin access + non-admin rejection + language flow + back
+    - **Touches:** `tests/integration/test_settings_flow.py` (new)
+    - **Action items:**
+        - [RED] Write test: `/settings` as admin shows menu
+        - [RED] Write test: `/settings` as non-admin rejected
+        - [RED] Write test: settings → language → select → confirmed
+        - [RED] Write test: settings → back ends conversation
+        - [GREEN] Run tests
+    - **Success:** `pytest tests/integration/test_settings_flow.py -v` — 4 tests pass
+
+- [ ] **4.2** Bazarr handler integration test
+    - **Context:** See plan.md Task 4.2. Key refs: `src/bot/handlers/bazarr.py` — `/subtitles` command, `bazarr_wanted_movies`, `bazarr_cancel` callbacks. Uses `BazarrService` singleton. Requires `bazarr_harness` fixture from task 1.1.
+    - **Watch out:** Regular `harness` doesn't register BazarrHandler. Use `bazarr_harness` for enabled tests. For "disabled" test, use regular `harness` and send `/subtitles` — BazarrHandler won't be registered, so no response is expected. Alternative: mock `is_enabled()` to return False in bazarr_harness.
+    - **Scope:** Menu + disabled check + wanted movies + cancel
+    - **Touches:** `tests/integration/test_bazarr_flow.py` (new), `tests/integration/fixtures.py`
+    - **Action items:**
+        - [GREEN] Add `BAZARR_WANTED_MOVIES` to fixtures.py
+        - [RED] Write test: `/subtitles` shows menu when enabled (bazarr_harness)
+        - [RED] Write test: `bazarr_wanted_movies` shows list
+        - [RED] Write test: `bazarr_cancel` sends cancelled message
+        - [GREEN] Run tests
+    - **Success:** `pytest tests/integration/test_bazarr_flow.py -v` — 3 tests pass
+
+---
+
+### Phase 5: Error Path Tests (1 task)
+
+**Goal:** At least one error-path test per conversation flow — API failures mid-conversation.
+
+- [ ] **5.1** Error path integration tests
+    - **Context:** See plan.md Task 5.1. Key refs: existing happy-path tests in `test_media_flow.py` as template.
+    - **Watch out:** Handlers use try/except and send error text — don't expect exceptions to propagate. Assert on the error response text instead.
+    - **Scope:** Movie add failure, series search failure, delete failure
+    - **Touches:** `tests/integration/test_error_paths.py` (new)
+    - **Action items:**
+        - [RED] Write test: movie search OK but add raises exception → error response
+        - [RED] Write test: series search raises exception → error response
+        - [RED] Write test: delete confirm with `delete_movie` returning False → failure text
+        - [GREEN] Run tests
+    - **Success:** `pytest tests/integration/test_error_paths.py -v` — 3 tests pass
+
+---
+
+### Phase 6: Auth Gating Expansion (1 task)
+
+**Goal:** Verify all protected commands gate behind auth.
+
+- [ ] **6.1** Parametrized auth gating test for all commands
+    - **Context:** See plan.md Task 6.1. Key refs: `tests/integration/test_auth_gating.py` (existing file with 3 tests).
+    - **Watch out:** Some commands like `/settings` have admin checks on top of auth, but `@require_auth` fires first. The parametrized test covers the auth decorator. Use `AuthHandler._authenticated_users.discard(12345)` before each command.
+    - **Scope:** Extend existing test file with parametrized test covering all 12 commands
+    - **Touches:** `tests/integration/test_auth_gating.py`
+    - **Action items:**
+        - [RED] Write parametrized test covering: `/help`, `/settings`, `/delete`, `/allMovies`, `/allSeries`, `/allMusic`, `/upcoming`, `/missing`, `/queue`, `/preferences`, `/status`, `/history`
+        - [GREEN] Run tests
+    - **Success:** `pytest tests/integration/test_auth_gating.py -v` — existing 3 + new parametrized (12 cases) all pass

--- a/docs/issues/issue-162/TASKS.md
+++ b/docs/issues/issue-162/TASKS.md
@@ -104,7 +104,7 @@
 
 **Goal:** Integration tests for handlers that use multi-step callback button flows (no ConversationHandler).
 
-- [ ] **3.1** Delete handler integration test
+- [x] **3.1** Delete handler integration test
     - **Context:** See plan.md Task 3.1. Key refs: `src/bot/handlers/delete.py` — `/delete` → `delete_type_{type}` → `delete_item_{id}` → `delete_confirm`. Uses `MediaService.get_movies()`, `get_movie()`, `delete_movie()`.
     - **Watch out:** Handler stores state in `context.user_data["delete_type"]` and `["delete_item"]`. The `handle_delete_selection` method isn't decorated with `@require_auth` — only the entry `/delete` is.
     - **Scope:** Full delete flow + cancel + empty library
@@ -115,8 +115,12 @@
         - [RED] Write test: type selection with empty library
         - [GREEN] Run tests
     - **Success:** `pytest tests/integration/test_delete_flow.py -v` — 3 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** Full multi-step flow works through harness — each tap_button call carries user_data forward.
+    - **Key Changes:** Created `tests/integration/test_delete_flow.py` with 3 tests.
+    - **Notes:** None.
 
-- [ ] **3.2** Library handler integration test
+- [x] **3.2** Library handler integration test
     - **Context:** See plan.md Task 3.2. Key refs: `src/bot/handlers/library.py` — `/allMovies`, `/allSeries`, `/allMusic` commands, `lib_{type}_{page}` pagination. Uses `MediaService.get_movies()` etc.
     - **Watch out:** Need 15+ items to test pagination (ITEMS_PER_PAGE=10). Items cached in `context.user_data[f"library_{media_type}"]`.
     - **Scope:** All three library commands + pagination + empty
@@ -129,8 +133,12 @@
         - [RED] Write test: empty library
         - [GREEN] Run tests
     - **Success:** `pytest tests/integration/test_library_flow.py -v` — 4 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** LIBRARY_MOVIES uses list comprehension for 15 items; pagination kicks in at ITEMS_PER_PAGE=10.
+    - **Key Changes:** Added `LIBRARY_MOVIES`, `LIBRARY_SERIES` to fixtures.py. Created `tests/integration/test_library_flow.py` with 4 tests.
+    - **Notes:** None.
 
-- [ ] **3.3** Calendar handler integration test
+- [x] **3.3** Calendar handler integration test
     - **Context:** See plan.md Task 3.3. Key refs: `src/bot/handlers/calendar.py` — `/upcoming` command, `cal_period_{days}`, `cal_refresh`, `cal_back` callbacks. Uses `MediaService.get_upcoming(days)`.
     - **Watch out:** `get_upcoming` is called with `days` parameter. Period change calls it again with new days value.
     - **Scope:** `/upcoming` + period change + refresh + back + empty
@@ -144,8 +152,12 @@
         - [RED] Write test: `cal_back` returns to main menu
         - [GREEN] Run tests
     - **Success:** `pytest tests/integration/test_calendar_flow.py -v` — 5 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** CALENDAR_ITEMS needs `media_id` key in addition to `id` — `get_calendar_items_keyboard` reads `item['media_id']` for callback data.
+    - **Key Changes:** Added `CALENDAR_ITEMS` to fixtures.py. Created `tests/integration/test_calendar_flow.py` with 5 tests.
+    - **Notes:** None.
 
-- [ ] **3.4** Missing handler integration test
+- [x] **3.4** Missing handler integration test
     - **Context:** See plan.md Task 3.4. Key refs: `src/bot/handlers/missing.py` — `/missing` command, `missing_refresh`, `missing_back` callbacks. Uses `MediaService.get_missing_media()`.
     - **Watch out:** Items cached in `context.user_data["missing_items"]`
     - **Scope:** `/missing` + empty + refresh + back
@@ -158,8 +170,12 @@
         - [RED] Write test: `missing_back` returns to main menu
         - [GREEN] Run tests
     - **Success:** `pytest tests/integration/test_missing_flow.py -v` — 4 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** MISSING_ITEMS needs `internal_id` key — `get_missing_items_keyboard` reads `item['internal_id']` for search callback data.
+    - **Key Changes:** Added `MISSING_ITEMS` (with `internal_id`) to fixtures.py. Created `tests/integration/test_missing_flow.py` with 4 tests.
+    - **Notes:** None.
 
-- [ ] **3.5** Queue handler integration test
+- [x] **3.5** Queue handler integration test
     - **Context:** See plan.md Task 3.5. Key refs: `src/bot/handlers/queue.py` — `/queue` command, `queue_refresh`, `queue_back` callbacks. Uses `MediaService.get_queue_media()`.
     - **Watch out:** Items cached in `context.user_data["queue_items"]`
     - **Scope:** `/queue` + empty + refresh + back
@@ -172,6 +188,10 @@
         - [RED] Write test: `queue_back` returns to main menu
         - [GREEN] Run tests
     - **Success:** `pytest tests/integration/test_queue_flow.py -v` — 4 tests pass
+    - **Completed:** 2026-03-10
+    - **Learnings:** Same pattern as missing/history — straightforward with MediaService mock.
+    - **Key Changes:** Added `QUEUE_ITEMS` to fixtures.py. Created `tests/integration/test_queue_flow.py` with 4 tests.
+    - **Notes:** None.
 
 ---
 

--- a/docs/issues/issue-162/plan.md
+++ b/docs/issues/issue-162/plan.md
@@ -1,0 +1,519 @@
+# Add Missing Integration Tests for All Handler Flows
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add happy-path integration tests for every handler registered in conftest.py's `_register_handlers()`, plus missing handlers (History, Bazarr, Webhooks), and at least one error-path test per conversation flow.
+
+**Architecture:** Each test file follows the existing pattern — use the `harness` fixture to send commands/callbacks, mock service methods on the singleton instances, and assert on `BotResponse` text/method. Three handlers (History, Bazarr, Webhooks) need to be added to conftest's `_register_handlers()` first. Settings tests need `is_admin` patched.
+
+**Tech Stack:** pytest-asyncio, unittest.mock (AsyncMock, patch), BotHarness infrastructure from `tests/integration/conftest.py`
+
+---
+
+## Pre-Work: Update conftest to register missing handlers
+
+The integration test `_register_handlers()` in `tests/integration/conftest.py` is missing three handlers that `main.py` registers: `HistoryHandler`, `BazarrHandler`, and `WebhooksHandler`. These must be added before writing tests for them.
+
+### Conftest Registration Gap Analysis
+
+| Handler | In main.py | In conftest.py | Needs Adding |
+|---------|-----------|---------------|-------------|
+| HistoryHandler | Yes | No | Yes (always) |
+| WebhooksHandler | Yes | No | Yes (always) |
+| BazarrHandler | Yes (conditional) | No | Yes (conditional, like transmission/sabnzbd) |
+
+---
+
+## Phase 1: Infrastructure — Register Missing Handlers in Conftest
+
+### Task 1.1: Add HistoryHandler and WebhooksHandler to conftest
+
+**Files:**
+- Modify: `tests/integration/conftest.py:19-32` (imports), `tests/integration/conftest.py:313-346` (_register_handlers)
+
+**Changes:**
+1. Add imports for `HistoryHandler` and `WebhooksHandler`
+2. Add both to the `handler_classes` list in `_register_handlers()` — `HistoryHandler` after `QueueHandler`, `WebhooksHandler` after `SettingsHandler` (matching main.py order)
+
+**Import additions:**
+```python
+from src.bot.handlers.history import HistoryHandler
+from src.bot.handlers.webhooks import WebhooksHandler
+```
+
+**Registration order (matching main.py):**
+```python
+handler_classes = [
+    StartHandler,
+    AuthHandler,
+    MediaHandler,
+    SettingsHandler,
+    WebhooksHandler,      # NEW
+    DeleteHandler,
+    LibraryHandler,
+    CalendarHandler,
+    MissingHandler,
+    QueueHandler,
+    HistoryHandler,        # NEW
+    HelpHandler,
+    PreferencesHandler,
+    SystemHandler,
+]
+```
+
+### Task 1.2: Add BazarrHandler (conditional) to conftest
+
+**Files:**
+- Modify: `tests/integration/conftest.py` (imports and _register_handlers)
+
+**Changes:**
+1. Add import for `BazarrHandler` and `BazarrService`
+2. Add conditional registration block (like transmission/sabnzbd)
+
+```python
+from src.bot.handlers.bazarr import BazarrHandler
+from src.services.bazarr import BazarrService
+```
+
+In `_register_handlers()`, after the sabnzbd conditional block:
+```python
+if config.get("bazarr", {}).get("enable", False):
+    handler_classes.append(BazarrHandler)
+```
+
+3. Add a `bazarr_harness` fixture that patches `BazarrService.is_enabled` to return True and enables bazarr in config:
+
+```python
+@pytest.fixture
+async def bazarr_harness():
+    """Provide a BotHarness with Bazarr handler enabled."""
+    AuthHandler._authenticated_users.add(12345)
+    with patch.object(BazarrService, "is_enabled", return_value=True):
+        app = _build_application()
+        async for h in _make_harness(app):
+            yield h
+```
+
+**Verification:** Run existing tests to confirm nothing breaks: `pytest tests/integration/ --tb=short -q`
+
+---
+
+## Phase 2: Simple Command Tests (no conversation state)
+
+### Task 2.1: Help handler integration test
+
+**File:** `tests/integration/test_help_flow.py`
+
+**Test: `/help` returns help text**
+- Send `/help` command via harness
+- Assert response is `sendMessage` with non-empty text
+
+**Test: `menu_back` returns to main menu**
+- Tap `menu_back` callback
+- Assert response contains text (welcome message)
+
+**Mock needs:** None (help reads config which is already mocked)
+
+### Task 2.2: System/Status handler integration test
+
+**File:** `tests/integration/test_system_flow.py`
+
+**Test: `/status` shows system status**
+- Mock `health_service.get_status()` to return `{"running": True, "last_check": None, "unhealthy_services": []}`
+- Send `/status`
+- Assert response contains "System Status" or similar text
+
+**Test: `system_refresh` re-runs health checks**
+- Mock `health_service.run_health_checks()` returning `{"media_services": [], "download_clients": []}`
+- Mock `health_service.get_status()` returning status dict
+- Send `/status`, then tap `system_refresh`
+- Assert response is not None
+
+**Test: `system_details` shows service details**
+- Mock `health_service.run_health_checks()` returning service details
+- Send `/status`, then tap `system_details`
+- Assert response text
+
+**Test: `system_diskspace` shows disk info**
+- Mock `health_service.get_disk_space()` returning drive list
+- Send `/status`, then tap `system_diskspace`
+- Assert response text
+
+**Test: `system_back` returns to main menu**
+- Send `/status`, then tap `system_back`
+- Assert response text contains "Main Menu"
+
+**Mock target:** `src.services.health.health_service` — it's a module-level singleton, so patch its methods with `patch.object()`
+
+### Task 2.3: Preferences handler integration test
+
+**File:** `tests/integration/test_preferences_flow.py`
+
+**Test: `/preferences` shows current view mode**
+- Mock `PreferencesService.get_view_mode` returning `"list"`
+- Send `/preferences`
+- Assert response contains "Preferences" or "List View"
+
+**Test: `pref_toggle_view` toggles view mode**
+- Mock `PreferencesService.get_view_mode` returning `"list"`
+- Mock `PreferencesService.toggle_view_mode` returning `"card"`
+- Send `/preferences`, then tap `pref_toggle_view`
+- Assert response contains "Card View"
+
+**Mock target:** `PreferencesService` methods via `patch.object()`
+
+### Task 2.4: History handler integration test
+
+**File:** `tests/integration/test_history_flow.py`
+
+**Test: `/history` shows history items**
+- Mock `MediaService.get_history` returning a list of items
+- Send `/history`
+- Assert response contains history text
+
+**Test: `/history` with empty results**
+- Mock `MediaService.get_history` returning `[]`
+- Send `/history`
+- Assert response contains "HistoryEmpty" text
+
+**Test: `hist_refresh` re-fetches history**
+- Mock `MediaService.get_history` returning items
+- Send `/history`, then tap `hist_refresh`
+- Assert response is not None
+
+**Test: `hist_back` returns to main menu**
+- Send `/history` (with mocked empty results), then tap `hist_back`
+- Assert response text contains "Main Menu"
+
+**Mock target:** `MediaService.get_history` via `patch.object()`
+
+**Fixture data to add to `tests/integration/fixtures.py`:**
+```python
+HISTORY_ITEMS = [
+    {
+        "id": 1,
+        "title": "Fight Club",
+        "event_type": "grabbed",
+        "date": "2026-03-01",
+        "type": "movie",
+    },
+]
+```
+
+---
+
+## Phase 3: Callback-Driven Flow Tests
+
+### Task 3.1: Delete handler integration test
+
+**File:** `tests/integration/test_delete_flow.py`
+
+**Test: `/delete` → type selection → item list → confirm → success**
+- Mock `MediaService.get_movies` returning `[{"id": "1", "title": "Fight Club"}]`
+- Mock `MediaService.get_movie` returning `{"id": "1", "title": "Fight Club"}`
+- Mock `MediaService.delete_movie` returning `True`
+- Send `/delete`
+- Assert response shows type selection buttons
+- Tap `delete_type_movie`
+- Assert response shows item list
+- Tap `delete_item_1`
+- Assert response shows confirmation
+- Tap `delete_confirm`
+- Assert response contains success text
+
+**Test: `/delete` → cancel**
+- Send `/delete`
+- Tap `delete_cancel`
+- Assert response contains "End" text
+
+**Test: `/delete` → type with empty library**
+- Mock `MediaService.get_movies` returning `[]`
+- Send `/delete`, tap `delete_type_movie`
+- Assert response mentions no items
+
+**Mock target:** `MediaService` methods via `patch.object()`
+
+### Task 3.2: Library handler integration test
+
+**File:** `tests/integration/test_library_flow.py`
+
+**Test: `/allMovies` shows paginated list**
+- Mock `MediaService.get_movies` returning 15 items (to test pagination)
+- Send `/allMovies`
+- Assert response contains movie titles and page info
+
+**Test: `/allSeries` shows series list**
+- Mock `MediaService.get_series` returning items
+- Send `/allSeries`
+- Assert response text
+
+**Test: Pagination via `lib_m_1`**
+- Mock `MediaService.get_movies` returning 15 items
+- Send `/allMovies`, then tap `lib_m_1`
+- Assert response shows page 2
+
+**Test: Empty library**
+- Mock `MediaService.get_movies` returning `[]`
+- Send `/allMovies`
+- Assert response contains "LibraryEmpty" text
+
+**Fixture data:**
+```python
+LIBRARY_MOVIES = [{"id": str(i), "title": f"Movie {i:02d}"} for i in range(15)]
+LIBRARY_SERIES = [{"id": str(i), "title": f"Series {i:02d}"} for i in range(3)]
+```
+
+### Task 3.3: Calendar handler integration test
+
+**File:** `tests/integration/test_calendar_flow.py`
+
+**Test: `/upcoming` shows calendar items**
+- Mock `MediaService.get_upcoming` returning items
+- Send `/upcoming`
+- Assert response contains calendar text
+
+**Test: `/upcoming` with no items**
+- Mock `MediaService.get_upcoming` returning `[]`
+- Send `/upcoming`
+- Assert response contains "CalendarEmpty" text
+
+**Test: `cal_period_30` changes period**
+- Mock `MediaService.get_upcoming` (called twice)
+- Send `/upcoming`, then tap `cal_period_30`
+- Assert response text
+
+**Test: `cal_refresh` re-fetches**
+- Mock `MediaService.get_upcoming`
+- Send `/upcoming`, then tap `cal_refresh`
+- Assert response
+
+**Test: `cal_back` returns to main menu**
+- Mock `MediaService.get_upcoming` returning `[]`
+- Send `/upcoming`, then tap `cal_back`
+- Assert "Main Menu"
+
+**Fixture data:**
+```python
+CALENDAR_ITEMS = [
+    {
+        "title": "Upcoming Movie",
+        "type": "movie",
+        "id": "123",
+        "date": "2026-03-15",
+    },
+]
+```
+
+### Task 3.4: Missing handler integration test
+
+**File:** `tests/integration/test_missing_flow.py`
+
+**Test: `/missing` shows wanted items**
+- Mock `MediaService.get_missing_media` returning items
+- Send `/missing`
+- Assert response contains wanted count
+
+**Test: `/missing` with no items**
+- Mock `MediaService.get_missing_media` returning `[]`
+- Send `/missing`
+- Assert "MissingEmpty" text
+
+**Test: `missing_refresh` re-fetches**
+- Mock `MediaService.get_missing_media`
+- Send `/missing`, then tap `missing_refresh`
+- Assert response
+
+**Test: `missing_back` returns to main menu**
+- Mock `MediaService.get_missing_media` returning `[]`
+- Send `/missing`, then tap `missing_back`
+- Assert "Main Menu"
+
+**Fixture data:**
+```python
+MISSING_ITEMS = [
+    {
+        "title": "Missing Movie",
+        "type": "movie",
+        "id": 1,
+        "service": "radarr",
+    },
+]
+```
+
+### Task 3.5: Queue handler integration test
+
+**File:** `tests/integration/test_queue_flow.py`
+
+**Test: `/queue` shows queue items**
+- Mock `MediaService.get_queue_media` returning items
+- Send `/queue`
+- Assert response contains queue text
+
+**Test: `/queue` with empty queue**
+- Mock `MediaService.get_queue_media` returning `[]`
+- Send `/queue`
+- Assert "QueueEmpty" text
+
+**Test: `queue_refresh` re-fetches**
+- Mock `MediaService.get_queue_media`
+- Send `/queue`, then tap `queue_refresh`
+- Assert response
+
+**Test: `queue_back` returns to main menu**
+- Mock `MediaService.get_queue_media` returning `[]`
+- Send `/queue`, then tap `queue_back`
+- Assert "Main Menu"
+
+**Fixture data:**
+```python
+QUEUE_ITEMS = [
+    {
+        "title": "Downloading Movie",
+        "type": "movie",
+        "id": 1,
+        "progress": 45.0,
+        "status": "downloading",
+    },
+]
+```
+
+---
+
+## Phase 4: Conversation Flow Tests
+
+### Task 4.1: Settings handler integration test (admin flow)
+
+**File:** `tests/integration/test_settings_flow.py`
+
+**Test: `/settings` as admin shows settings menu**
+- Patch `src.bot.handlers.settings.is_admin` returning `True`
+- Patch `src.bot.handlers.settings.config.update_nested` and `config.save` as no-ops
+- Send `/settings`
+- Assert response contains "Settings"
+- Assert conversation state is `States.SETTINGS_MENU`
+
+**Test: `/settings` as non-admin gets rejected**
+- Patch `src.bot.handlers.settings.is_admin` returning `False`
+- Send `/settings`
+- Assert response contains "admin" text
+
+**Test: Settings → language → select language → back to settings**
+- Patch `is_admin` True
+- Send `/settings`, tap `settings_language`, tap `lang_en`
+- Assert response contains "Language" confirmation
+
+**Test: Settings → back ends conversation**
+- Patch `is_admin` True
+- Send `/settings`, tap `settings_back`
+- Assert conversation ended
+
+**Mock targets:**
+- `src.bot.handlers.settings.is_admin` via `patch()`
+- `src.bot.handlers.settings.config.update_nested` and `config.save` as no-ops
+
+### Task 4.2: Bazarr handler integration test
+
+**File:** `tests/integration/test_bazarr_flow.py`
+
+Uses `bazarr_harness` fixture (from Task 1.2).
+
+**Test: `/subtitles` shows menu when enabled**
+- Send `/subtitles`
+- Assert response contains "BazarrMenu" text
+
+**Test: `/subtitles` when disabled shows error**
+- Use regular `harness` (Bazarr not enabled)
+- Send `/subtitles`
+- Assert response contains "BazarrNotEnabled" text
+
+**Test: Wanted movies flow**
+- Mock `BazarrService.get_wanted_movies` returning items
+- Send `/subtitles`, then tap `bazarr_wanted_movies`
+- Assert response text
+
+**Test: Bazarr cancel**
+- Send `/subtitles`, then tap `bazarr_cancel`
+- Assert response contains "BazarrCancelled" text
+
+**Fixture data:**
+```python
+BAZARR_WANTED_MOVIES = [
+    {
+        "title": "Fight Club",
+        "missing_subtitles": [{"name": "English"}],
+    },
+]
+```
+
+---
+
+## Phase 5: Error Path Tests
+
+### Task 5.1: Error paths for media conversation
+
+**File:** `tests/integration/test_error_paths.py`
+
+**Test: Movie search succeeds but add fails**
+- Mock `MediaService.search_movies` returning results
+- Mock `MediaService.add_movie` raising an exception
+- Send `/movie`, type search, select result
+- Assert response contains error text (not a crash)
+
+**Test: Series search API failure**
+- Mock `MediaService.search_series` raising `Exception("API timeout")`
+- Send `/series`, type search
+- Assert response contains error text
+
+**Test: Delete confirmation fails**
+- Mock all delete steps but `delete_movie` returns `False`
+- Walk through full flow
+- Assert response contains failure text
+
+---
+
+## Phase 6: Auth Gating Expansion
+
+### Task 6.1: Verify auth gating on all commands
+
+**File:** `tests/integration/test_auth_gating.py` (extend existing)
+
+**Tests:** Parametrize unauthenticated access for all protected commands:
+```python
+@pytest.mark.parametrize("command", [
+    "/help", "/settings", "/delete", "/allMovies", "/allSeries",
+    "/allMusic", "/upcoming", "/missing", "/queue", "/preferences",
+    "/status", "/history",
+])
+```
+
+For each: discard auth user, send command, assert response mentions "auth".
+
+**Note:** Some commands (like `/settings`) have admin checks ON TOP of auth. The auth check happens first (via `@require_auth` decorator), so the parametrized test is still valid.
+
+---
+
+## Verification
+
+After all phases:
+1. `pytest tests/integration/ --tb=short -v` — all pass
+2. `pytest tests/integration/ --cov=src.bot.handlers --cov-report=term-missing` — confirm coverage improvement
+3. Count: every handler in conftest's `_register_handlers()` has at least one happy-path test
+
+## Test File Summary
+
+| File | Handler | Tests |
+|------|---------|-------|
+| test_help_flow.py | HelpHandler | 2 |
+| test_system_flow.py | SystemHandler | 5 |
+| test_preferences_flow.py | PreferencesHandler | 2 |
+| test_history_flow.py | HistoryHandler | 4 |
+| test_delete_flow.py | DeleteHandler | 3 |
+| test_library_flow.py | LibraryHandler | 4 |
+| test_calendar_flow.py | CalendarHandler | 5 |
+| test_missing_flow.py | MissingHandler | 4 |
+| test_queue_flow.py | QueueHandler | 4 |
+| test_settings_flow.py | SettingsHandler | 4 |
+| test_bazarr_flow.py | BazarrHandler | 4 |
+| test_error_paths.py | Various | 3 |
+| test_auth_gating.py | Various (extend) | 1 parametrized (12 cases) |
+| **Total** | | **~45 tests** |

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,16 +22,20 @@ from src.bot.handlers.media import MediaHandler
 from src.bot.handlers.help import HelpHandler
 from src.bot.handlers.system import SystemHandler
 from src.bot.handlers.settings import SettingsHandler
+from src.bot.handlers.webhooks import WebhooksHandler
 from src.bot.handlers.delete import DeleteHandler
 from src.bot.handlers.library import LibraryHandler
 from src.bot.handlers.calendar import CalendarHandler
 from src.bot.handlers.missing import MissingHandler
 from src.bot.handlers.queue import QueueHandler
+from src.bot.handlers.history import HistoryHandler
 from src.bot.handlers.downloads import DownloadsHandler
 from src.bot.handlers.preferences import PreferencesHandler
+from src.bot.handlers.bazarr import BazarrHandler
 from src.config.settings import config
 from src.services.transmission import TransmissionService
 from src.services.sabnzbd import SABnzbdService
+from src.services.bazarr import BazarrService
 
 
 # ---- Response capture -------------------------------------------------------
@@ -317,14 +321,13 @@ def _register_handlers(app: Application):
         AuthHandler,
         MediaHandler,
         SettingsHandler,
+        WebhooksHandler,
         DeleteHandler,
         LibraryHandler,
         CalendarHandler,
         MissingHandler,
         QueueHandler,
-        HelpHandler,
-        PreferencesHandler,
-        SystemHandler,
+        HistoryHandler,
     ]
 
     # Conditionally add download handlers
@@ -336,8 +339,15 @@ def _register_handlers(app: Application):
         from src.bot.handlers.sabnzbd import SabnzbdHandler
         handler_classes.append(SabnzbdHandler)
 
+    # Bazarr handler (if enabled)
+    if config.get("bazarr", {}).get("enable", False):
+        handler_classes.append(BazarrHandler)
+
     # Downloads handler checks is_enabled internally
     handler_classes.append(DownloadsHandler)
+
+    # These come after downloads in main.py
+    handler_classes.extend([HelpHandler, PreferencesHandler, SystemHandler])
 
     for cls in handler_classes:
         instance = cls()
@@ -394,5 +404,28 @@ async def downloads_harness():
         patch.object(SABnzbdService, "is_enabled", return_value=True),
     ):
         app = _build_application()
+        async for h in _make_harness(app):
+            yield h
+
+
+@pytest.fixture
+async def bazarr_harness():
+    """Provide a BotHarness with BazarrHandler enabled."""
+    AuthHandler._authenticated_users.add(12345)
+
+    with patch.object(BazarrService, "is_enabled", return_value=True):
+        app = Application.builder().token("0:TEST").build()
+        # Build with bazarr enabled in config
+        with patch.object(config, "get", wraps=config.get) as mock_get:
+            original_get = config.get
+
+            def _get_with_bazarr(key, default=None):
+                if key == "bazarr":
+                    return {"enable": True}
+                return original_get(key, default)
+
+            mock_get.side_effect = _get_with_bazarr
+            _register_handlers(app)
+
         async for h in _make_harness(app):
             yield h

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -415,16 +415,15 @@ async def bazarr_harness():
 
     with patch.object(BazarrService, "is_enabled", return_value=True):
         app = Application.builder().token("0:TEST").build()
-        # Build with bazarr enabled in config
-        with patch.object(config, "get", wraps=config.get) as mock_get:
-            original_get = config.get
+        # Capture the real get before patching
+        real_get = config.get.__wrapped__ if hasattr(config.get, "__wrapped__") else config.get
 
-            def _get_with_bazarr(key, default=None):
-                if key == "bazarr":
-                    return {"enable": True}
-                return original_get(key, default)
+        def _get_with_bazarr(key, default=None):
+            if key == "bazarr":
+                return {"enable": True}
+            return real_get(key, default)
 
-            mock_get.side_effect = _get_with_bazarr
+        with patch.object(config, "get", side_effect=_get_with_bazarr):
             _register_handlers(app)
 
         async for h in _make_harness(app):

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -1,9 +1,18 @@
 """
-Shared test data for integration tests.
+Shared test data and helpers for integration tests.
 
-Provides reusable search results, quality selection results, and queue data
-used across multiple test files.
+Provides reusable search results, quality selection results, queue data,
+and utility functions used across multiple test files.
 """
+
+
+def find_response(harness, method):
+    """Find the first captured response matching the given API method."""
+    for r in harness.responses:
+        if r.method == method:
+            return r
+    return None
+
 
 MOVIE_SEARCH_RESULTS = [
     {

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -141,3 +141,20 @@ DOWNLOADS_EMPTY_QUEUE = {
     "items_count": 0,
     "items": [],
 }
+
+HISTORY_ITEMS = [
+    {
+        "id": 1,
+        "title": "Fight Club",
+        "event_type": "grabbed",
+        "date": "2026-03-09T10:00:00Z",
+        "quality": "HD-1080p",
+    },
+    {
+        "id": 2,
+        "title": "Breaking Bad S01E01",
+        "event_type": "downloaded",
+        "date": "2026-03-09T09:00:00Z",
+        "quality": "HD-720p",
+    },
+]

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -158,3 +158,64 @@ HISTORY_ITEMS = [
         "quality": "HD-720p",
     },
 ]
+
+CALENDAR_ITEMS = [
+    {
+        "title": "Upcoming Movie",
+        "type": "movie",
+        "date": "2026-03-15",
+        "service": "radarr",
+        "id": 101,
+        "media_id": 101,
+    },
+    {
+        "title": "New Episode S02E01",
+        "type": "episode",
+        "date": "2026-03-12",
+        "service": "sonarr",
+        "id": 202,
+        "media_id": 202,
+    },
+]
+
+LIBRARY_MOVIES = [
+    {"id": str(i), "title": f"Movie {chr(64 + i)}"} for i in range(1, 16)
+]
+
+LIBRARY_SERIES = [
+    {"id": str(i), "title": f"Series {chr(64 + i)}"} for i in range(1, 6)
+]
+
+MISSING_ITEMS = [
+    {
+        "title": "Missing Movie",
+        "type": "movie",
+        "service": "radarr",
+        "id": 301,
+        "internal_id": 301,
+    },
+    {
+        "title": "Missing Episode S01E05",
+        "type": "episode",
+        "service": "sonarr",
+        "id": 302,
+        "internal_id": 302,
+    },
+]
+
+QUEUE_ITEMS = [
+    {
+        "title": "Downloading Movie",
+        "type": "movie",
+        "progress": 45.0,
+        "status": "downloading",
+        "id": 401,
+    },
+    {
+        "title": "Downloading Episode",
+        "type": "episode",
+        "progress": 80.0,
+        "status": "downloading",
+        "id": 402,
+    },
+]

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -203,6 +203,22 @@ MISSING_ITEMS = [
     },
 ]
 
+BAZARR_WANTED_MOVIES = [
+    {
+        "title": "Fight Club",
+        "missing_subtitles": [
+            {"name": "English", "code2": "en"},
+            {"name": "French", "code2": "fr"},
+        ],
+    },
+    {
+        "title": "Inception",
+        "missing_subtitles": [
+            {"name": "Spanish", "code2": "es"},
+        ],
+    },
+]
+
 QUEUE_ITEMS = [
     {
         "title": "Downloading Movie",

--- a/tests/integration/test_auth_gating.py
+++ b/tests/integration/test_auth_gating.py
@@ -13,6 +13,24 @@ from src.bot.handlers.auth import AuthHandler
 from src.bot.handlers.media.dispatch import SEARCHING
 
 
+# All @require_auth-protected commands (excluding /movie, /series, /music
+# which are tested individually above, and /subtitles which needs bazarr_harness)
+AUTH_GATED_COMMANDS = [
+    "/help",
+    "/settings",
+    "/delete",
+    "/allMovies",
+    "/allSeries",
+    "/allMusic",
+    "/upcoming",
+    "/missing",
+    "/queue",
+    "/preferences",
+    "/status",
+    "/history",
+]
+
+
 @pytest.mark.asyncio
 async def test_unauthenticated_user_blocked(harness):
     """Unauthenticated user sending /movie gets auth-required message."""
@@ -40,3 +58,16 @@ async def test_conversation_state_after_command(harness):
     await harness.send_command("/movie")
     state = harness.get_conversation_state("media_conversation", 12345, 12345)
     assert state == SEARCHING
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command", AUTH_GATED_COMMANDS)
+async def test_unauthenticated_user_blocked_all_commands(harness, command):
+    """All @require_auth commands reject unauthenticated users."""
+    AuthHandler._authenticated_users.discard(12345)
+
+    resp = await harness.send_command(command)
+    assert resp is not None, f"{command} returned no response for unauthed user"
+    assert "authenticate" in resp.text.lower() or "auth" in resp.text.lower(), (
+        f"{command} did not show auth message: {resp.text!r}"
+    )

--- a/tests/integration/test_bazarr_flow.py
+++ b/tests/integration/test_bazarr_flow.py
@@ -1,0 +1,61 @@
+"""
+Integration tests for the /subtitles (Bazarr) command flow.
+
+Uses bazarr_harness which registers BazarrHandler with BazarrService.is_enabled
+patched to True. BazarrService methods are patched at class level.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.bazarr import BazarrService
+
+from tests.integration.fixtures import BAZARR_WANTED_MOVIES
+
+
+def _find_response(harness, method):
+    """Find the first captured response matching the given API method."""
+    for r in harness.responses:
+        if r.method == method:
+            return r
+    return None
+
+
+@pytest.mark.asyncio
+async def test_subtitles_menu_when_enabled(bazarr_harness):
+    """/subtitles shows menu with keyboard when bazarr is enabled."""
+    resp = await bazarr_harness.send_command("/subtitles")
+    assert resp is not None
+    assert "BazarrMenu" in resp.text
+    assert resp.reply_markup is not None
+
+
+@pytest.mark.asyncio
+async def test_bazarr_wanted_movies_shows_list(bazarr_harness):
+    """bazarr_wanted_movies callback shows formatted movie list."""
+    with patch.object(
+        BazarrService, "get_wanted_movies",
+        new_callable=AsyncMock, return_value=BAZARR_WANTED_MOVIES,
+    ):
+        # Enter menu first
+        await bazarr_harness.send_command("/subtitles")
+
+        # Tap wanted movies
+        await bazarr_harness.tap_button("bazarr_wanted_movies")
+        edit_resp = _find_response(bazarr_harness, "editMessageText")
+        assert edit_resp is not None
+        assert "Fight Club" in edit_resp.text
+        assert "English" in edit_resp.text
+
+
+@pytest.mark.asyncio
+async def test_bazarr_cancel_sends_cancelled(bazarr_harness):
+    """bazarr_cancel callback sends cancelled message."""
+    # Enter menu first
+    await bazarr_harness.send_command("/subtitles")
+
+    # Tap cancel
+    await bazarr_harness.tap_button("bazarr_cancel")
+    edit_resp = _find_response(bazarr_harness, "editMessageText")
+    assert edit_resp is not None
+    assert "BazarrCancelled" in edit_resp.text

--- a/tests/integration/test_bazarr_flow.py
+++ b/tests/integration/test_bazarr_flow.py
@@ -10,15 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 from src.services.bazarr import BazarrService
 
-from tests.integration.fixtures import BAZARR_WANTED_MOVIES
-
-
-def _find_response(harness, method):
-    """Find the first captured response matching the given API method."""
-    for r in harness.responses:
-        if r.method == method:
-            return r
-    return None
+from tests.integration.fixtures import BAZARR_WANTED_MOVIES, find_response
 
 
 @pytest.mark.asyncio
@@ -42,7 +34,7 @@ async def test_bazarr_wanted_movies_shows_list(bazarr_harness):
 
         # Tap wanted movies
         await bazarr_harness.tap_button("bazarr_wanted_movies")
-        edit_resp = _find_response(bazarr_harness, "editMessageText")
+        edit_resp = find_response(bazarr_harness, "editMessageText")
         assert edit_resp is not None
         assert "Fight Club" in edit_resp.text
         assert "English" in edit_resp.text
@@ -56,6 +48,6 @@ async def test_bazarr_cancel_sends_cancelled(bazarr_harness):
 
     # Tap cancel
     await bazarr_harness.tap_button("bazarr_cancel")
-    edit_resp = _find_response(bazarr_harness, "editMessageText")
+    edit_resp = find_response(bazarr_harness, "editMessageText")
     assert edit_resp is not None
     assert "BazarrCancelled" in edit_resp.text

--- a/tests/integration/test_calendar_flow.py
+++ b/tests/integration/test_calendar_flow.py
@@ -10,15 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 from src.services.media import MediaService
 
-from tests.integration.fixtures import CALENDAR_ITEMS
-
-
-def _find_response(harness, method):
-    """Find the first captured response matching the given API method."""
-    for r in harness.responses:
-        if r.method == method:
-            return r
-    return None
+from tests.integration.fixtures import CALENDAR_ITEMS, find_response
 
 
 @pytest.mark.asyncio
@@ -57,7 +49,7 @@ async def test_calendar_period_change(harness):
 
         # Tap period change button
         await harness.tap_button("cal_period_30")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "30 days" in edit_resp.text
 
@@ -77,7 +69,7 @@ async def test_calendar_refresh(harness):
 
         # Tap refresh
         await harness.tap_button("cal_refresh")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "CalendarTitle" in edit_resp.text
 
@@ -94,6 +86,6 @@ async def test_calendar_back_returns_to_main_menu(harness):
 
         # Tap back
         await harness.tap_button("cal_back")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "Main Menu" in edit_resp.text

--- a/tests/integration/test_calendar_flow.py
+++ b/tests/integration/test_calendar_flow.py
@@ -1,0 +1,99 @@
+"""
+Integration tests for the /upcoming (calendar) command flow.
+
+Uses the standard harness fixture. MediaService.get_upcoming is patched at the
+class level because CalendarHandler instantiates the singleton in __init__.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.media import MediaService
+
+from tests.integration.fixtures import CALENDAR_ITEMS
+
+
+def _find_response(harness, method):
+    """Find the first captured response matching the given API method."""
+    for r in harness.responses:
+        if r.method == method:
+            return r
+    return None
+
+
+@pytest.mark.asyncio
+async def test_upcoming_shows_items(harness):
+    """/upcoming with mocked items returns text containing CalendarTitle and releases."""
+    with patch.object(
+        MediaService, "get_upcoming",
+        new_callable=AsyncMock, return_value=CALENDAR_ITEMS,
+    ):
+        resp = await harness.send_command("/upcoming")
+        assert resp is not None
+        assert "CalendarTitle" in resp.text
+        assert "releases" in resp.text
+        assert str(len(CALENDAR_ITEMS)) in resp.text
+
+
+@pytest.mark.asyncio
+async def test_upcoming_empty_calendar(harness):
+    """/upcoming with empty list returns text containing CalendarEmpty."""
+    with patch.object(
+        MediaService, "get_upcoming",
+        new_callable=AsyncMock, return_value=[],
+    ):
+        resp = await harness.send_command("/upcoming")
+        assert resp is not None
+        assert "CalendarEmpty" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_calendar_period_change(harness):
+    """cal_period_30 callback re-fetches with 30 days and updates text."""
+    mock_upcoming = AsyncMock(return_value=CALENDAR_ITEMS)
+    with patch.object(MediaService, "get_upcoming", mock_upcoming):
+        # Initial command to set up user_data
+        await harness.send_command("/upcoming")
+
+        # Tap period change button
+        await harness.tap_button("cal_period_30")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "30 days" in edit_resp.text
+
+        # Verify get_upcoming was called with 30
+        mock_upcoming.assert_any_call(30)
+
+
+@pytest.mark.asyncio
+async def test_calendar_refresh(harness):
+    """cal_refresh callback re-fetches and updates text with CalendarTitle."""
+    with patch.object(
+        MediaService, "get_upcoming",
+        new_callable=AsyncMock, return_value=CALENDAR_ITEMS,
+    ):
+        # Initial command to set up context
+        await harness.send_command("/upcoming")
+
+        # Tap refresh
+        await harness.tap_button("cal_refresh")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "CalendarTitle" in edit_resp.text
+
+
+@pytest.mark.asyncio
+async def test_calendar_back_returns_to_main_menu(harness):
+    """cal_back returns editMessageText with Main Menu."""
+    with patch.object(
+        MediaService, "get_upcoming",
+        new_callable=AsyncMock, return_value=CALENDAR_ITEMS,
+    ):
+        # Initial command to set up context
+        await harness.send_command("/upcoming")
+
+        # Tap back
+        await harness.tap_button("cal_back")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "Main Menu" in edit_resp.text

--- a/tests/integration/test_delete_flow.py
+++ b/tests/integration/test_delete_flow.py
@@ -10,13 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 from src.services.media import MediaService
 
-
-def _find_response(harness, method):
-    """Find the first captured response matching the given API method."""
-    for r in harness.responses:
-        if r.method == method:
-            return r
-    return None
+from tests.integration.fixtures import find_response
 
 
 @pytest.mark.asyncio
@@ -43,19 +37,19 @@ async def test_delete_happy_path_movie(harness):
 
         # Step 2: Tap movie type → shows item list with "Select"
         await harness.tap_button("delete_type_movie")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "Select" in edit_resp.text
 
         # Step 3: Tap item → shows confirmation with "ThisDelete"
         await harness.tap_button("delete_item_550")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "ThisDelete" in edit_resp.text
 
         # Step 4: Confirm deletion → shows "DeleteSuccess"
         await harness.tap_button("delete_confirm")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "DeleteSuccess" in edit_resp.text
 
@@ -70,7 +64,7 @@ async def test_delete_cancel(harness):
 
     # Step 2: Tap cancel → shows "End"
     await harness.tap_button("delete_cancel")
-    edit_resp = _find_response(harness, "editMessageText")
+    edit_resp = find_response(harness, "editMessageText")
     assert edit_resp is not None
     assert "End" in edit_resp.text
 
@@ -87,6 +81,6 @@ async def test_delete_type_empty_library(harness):
 
         # Step 2: Tap movie type with empty library → shows "NoExist"
         await harness.tap_button("delete_type_movie")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "NoExist" in edit_resp.text

--- a/tests/integration/test_delete_flow.py
+++ b/tests/integration/test_delete_flow.py
@@ -1,0 +1,92 @@
+"""
+Integration tests for the /delete command flow.
+
+Uses the standard harness fixture. MediaService methods are patched at the
+class level because DeleteHandler instantiates the singleton in __init__.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.media import MediaService
+
+
+def _find_response(harness, method):
+    """Find the first captured response matching the given API method."""
+    for r in harness.responses:
+        if r.method == method:
+            return r
+    return None
+
+
+@pytest.mark.asyncio
+async def test_delete_happy_path_movie(harness):
+    """Full delete flow: /delete → type → item → confirm → success."""
+    movies = [{"id": "550", "title": "Fight Club"}]
+    movie_detail = {"id": "550", "title": "Fight Club"}
+
+    with patch.object(
+        MediaService, "get_movies",
+        new_callable=AsyncMock, return_value=movies,
+    ), patch.object(
+        MediaService, "get_movie",
+        new_callable=AsyncMock, return_value=movie_detail,
+    ), patch.object(
+        MediaService, "delete_movie",
+        new_callable=AsyncMock, return_value=True,
+    ):
+        # Step 1: /delete shows type selection keyboard
+        resp = await harness.send_command("/delete")
+        assert resp is not None
+        assert resp.method == "sendMessage"
+        assert resp.reply_markup is not None
+
+        # Step 2: Tap movie type → shows item list with "Select"
+        await harness.tap_button("delete_type_movie")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "Select" in edit_resp.text
+
+        # Step 3: Tap item → shows confirmation with "ThisDelete"
+        await harness.tap_button("delete_item_550")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "ThisDelete" in edit_resp.text
+
+        # Step 4: Confirm deletion → shows "DeleteSuccess"
+        await harness.tap_button("delete_confirm")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "DeleteSuccess" in edit_resp.text
+
+
+@pytest.mark.asyncio
+async def test_delete_cancel(harness):
+    """/delete then cancel → editMessageText with 'End'."""
+    # Step 1: /delete shows type selection keyboard
+    resp = await harness.send_command("/delete")
+    assert resp is not None
+    assert resp.method == "sendMessage"
+
+    # Step 2: Tap cancel → shows "End"
+    await harness.tap_button("delete_cancel")
+    edit_resp = _find_response(harness, "editMessageText")
+    assert edit_resp is not None
+    assert "End" in edit_resp.text
+
+
+@pytest.mark.asyncio
+async def test_delete_type_empty_library(harness):
+    """Selecting movie type with empty library → editMessageText with 'NoExist'."""
+    with patch.object(
+        MediaService, "get_movies",
+        new_callable=AsyncMock, return_value=[],
+    ):
+        # Step 1: /delete
+        await harness.send_command("/delete")
+
+        # Step 2: Tap movie type with empty library → shows "NoExist"
+        await harness.tap_button("delete_type_movie")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "NoExist" in edit_resp.text

--- a/tests/integration/test_error_paths.py
+++ b/tests/integration/test_error_paths.py
@@ -13,16 +13,8 @@ from src.services.media import MediaService
 from tests.integration.fixtures import (
     MOVIE_SEARCH_RESULTS,
     MOVIE_QUALITY_RESULT,
-    SERIES_SEARCH_RESULTS,
+    find_response,
 )
-
-
-def _find_response(harness, method):
-    """Find the first captured response matching the given API method."""
-    for r in harness.responses:
-        if r.method == method:
-            return r
-    return None
 
 
 @pytest.mark.asyncio
@@ -49,7 +41,7 @@ async def test_movie_add_raises_exception_shows_error(harness):
         # Quality select triggers add which raises
         await harness.tap_button("quality_1")
         # Handler catches exception and sends error text
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "Error" in edit_resp.text or "error" in edit_resp.text.lower()
 
@@ -95,6 +87,6 @@ async def test_delete_confirm_returns_false_shows_failure(harness):
 
         # Confirm deletion — returns False
         await harness.tap_button("delete_confirm")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "DeleteFailed" in edit_resp.text

--- a/tests/integration/test_error_paths.py
+++ b/tests/integration/test_error_paths.py
@@ -1,0 +1,100 @@
+"""
+Integration tests for error paths — API failures mid-conversation.
+
+Handlers catch exceptions internally and send error text to the user.
+These tests verify that error responses are sent, not that exceptions propagate.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.media import MediaService
+
+from tests.integration.fixtures import (
+    MOVIE_SEARCH_RESULTS,
+    MOVIE_QUALITY_RESULT,
+    SERIES_SEARCH_RESULTS,
+)
+
+
+def _find_response(harness, method):
+    """Find the first captured response matching the given API method."""
+    for r in harness.responses:
+        if r.method == method:
+            return r
+    return None
+
+
+@pytest.mark.asyncio
+async def test_movie_add_raises_exception_shows_error(harness):
+    """Movie search OK, but add_movie_with_profile raises → error response."""
+    with (
+        patch.object(
+            MediaService, "search_movies",
+            new_callable=AsyncMock, return_value=MOVIE_SEARCH_RESULTS,
+        ),
+        patch.object(
+            MediaService, "add_movie",
+            new_callable=AsyncMock, return_value=MOVIE_QUALITY_RESULT,
+        ),
+        patch.object(
+            MediaService, "add_movie_with_profile",
+            new_callable=AsyncMock, side_effect=Exception("API timeout"),
+        ),
+    ):
+        await harness.send_command("/movie")
+        await harness.send_text("fight club")
+        await harness.tap_button("select_550")
+
+        # Quality select triggers add which raises
+        await harness.tap_button("quality_1")
+        # Handler catches exception and sends error text
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "Error" in edit_resp.text or "error" in edit_resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_series_search_raises_exception_shows_error(harness):
+    """Series search raises exception → error response sent."""
+    with patch.object(
+        MediaService, "search_series",
+        new_callable=AsyncMock, side_effect=Exception("Connection refused"),
+    ):
+        await harness.send_command("/series")
+
+        # Type search text — handler catches the search exception
+        resp = await harness.send_text("breaking bad")
+        assert resp is not None
+        assert "Error" in resp.text or "error" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_confirm_returns_false_shows_failure(harness):
+    """Delete confirm with delete_movie returning False → failure text."""
+    movies = [{"id": "550", "title": "Fight Club"}]
+    movie_detail = {"id": "550", "title": "Fight Club"}
+
+    with (
+        patch.object(
+            MediaService, "get_movies",
+            new_callable=AsyncMock, return_value=movies,
+        ),
+        patch.object(
+            MediaService, "get_movie",
+            new_callable=AsyncMock, return_value=movie_detail,
+        ),
+        patch.object(
+            MediaService, "delete_movie",
+            new_callable=AsyncMock, return_value=False,
+        ),
+    ):
+        await harness.send_command("/delete")
+        await harness.tap_button("delete_type_movie")
+        await harness.tap_button("delete_item_550")
+
+        # Confirm deletion — returns False
+        await harness.tap_button("delete_confirm")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "DeleteFailed" in edit_resp.text

--- a/tests/integration/test_help_flow.py
+++ b/tests/integration/test_help_flow.py
@@ -1,0 +1,25 @@
+"""
+Integration tests for the HelpHandler flow.
+
+Tests /help command and menu_back callback through the full handler chain.
+"""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_help_command_returns_help_text(harness):
+    """/help returns a sendMessage with non-empty help text."""
+    resp = await harness.send_command("/help")
+    assert resp is not None
+    assert resp.method == "sendMessage"
+    assert resp.text
+
+
+@pytest.mark.asyncio
+async def test_menu_back_returns_main_menu(harness):
+    """menu_back callback edits message to welcome text with main menu keyboard."""
+    resp = await harness.tap_button("menu_back")
+    assert resp is not None
+    assert resp.method == "editMessageText"
+    assert resp.reply_markup is not None

--- a/tests/integration/test_history_flow.py
+++ b/tests/integration/test_history_flow.py
@@ -10,15 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 from src.services.media import MediaService
 
-from tests.integration.fixtures import HISTORY_ITEMS
-
-
-def _find_response(harness, method):
-    """Find the first captured response matching the given API method."""
-    for r in harness.responses:
-        if r.method == method:
-            return r
-    return None
+from tests.integration.fixtures import HISTORY_ITEMS, find_response
 
 
 @pytest.mark.asyncio
@@ -58,7 +50,7 @@ async def test_history_refresh_refetches(harness):
 
         # Tap refresh — handler calls edit_text then query.answer()
         await harness.tap_button("hist_refresh")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "HistoryTitle" in edit_resp.text
 
@@ -75,6 +67,6 @@ async def test_history_back_returns_to_main_menu(harness):
 
         # Tap back — handler calls edit_text then query.answer()
         await harness.tap_button("hist_back")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "Main Menu" in edit_resp.text

--- a/tests/integration/test_history_flow.py
+++ b/tests/integration/test_history_flow.py
@@ -1,0 +1,80 @@
+"""
+Integration tests for the /history command flow.
+
+Uses the standard harness fixture. MediaService.get_history is patched at the
+class level because HistoryHandler instantiates the singleton in __init__.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.media import MediaService
+
+from tests.integration.fixtures import HISTORY_ITEMS
+
+
+def _find_response(harness, method):
+    """Find the first captured response matching the given API method."""
+    for r in harness.responses:
+        if r.method == method:
+            return r
+    return None
+
+
+@pytest.mark.asyncio
+async def test_history_command_shows_items(harness):
+    """/history with mocked items returns text containing HistoryTitle and count."""
+    with patch.object(
+        MediaService, "get_history",
+        new_callable=AsyncMock, return_value=HISTORY_ITEMS,
+    ):
+        resp = await harness.send_command("/history")
+        assert resp is not None
+        assert "HistoryTitle" in resp.text
+        assert str(len(HISTORY_ITEMS)) in resp.text
+
+
+@pytest.mark.asyncio
+async def test_history_command_empty_results(harness):
+    """/history with empty list returns text containing HistoryEmpty."""
+    with patch.object(
+        MediaService, "get_history",
+        new_callable=AsyncMock, return_value=[],
+    ):
+        resp = await harness.send_command("/history")
+        assert resp is not None
+        assert "HistoryEmpty" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_history_refresh_refetches(harness):
+    """hist_refresh callback re-fetches history and updates text."""
+    with patch.object(
+        MediaService, "get_history",
+        new_callable=AsyncMock, return_value=HISTORY_ITEMS,
+    ):
+        # Initial command to set up user_data
+        await harness.send_command("/history")
+
+        # Tap refresh — handler calls edit_text then query.answer()
+        await harness.tap_button("hist_refresh")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "HistoryTitle" in edit_resp.text
+
+
+@pytest.mark.asyncio
+async def test_history_back_returns_to_main_menu(harness):
+    """hist_back returns editMessageText with Main Menu."""
+    with patch.object(
+        MediaService, "get_history",
+        new_callable=AsyncMock, return_value=HISTORY_ITEMS,
+    ):
+        # Initial command to set up context
+        await harness.send_command("/history")
+
+        # Tap back — handler calls edit_text then query.answer()
+        await harness.tap_button("hist_back")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "Main Menu" in edit_resp.text

--- a/tests/integration/test_library_flow.py
+++ b/tests/integration/test_library_flow.py
@@ -1,0 +1,77 @@
+"""
+Integration tests for the /allMovies, /allSeries, /allMusic library flows.
+
+Uses the standard harness fixture. MediaService methods are patched at the
+class level because LibraryHandler instantiates the singleton in __init__.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.media import MediaService
+
+from tests.integration.fixtures import LIBRARY_MOVIES, LIBRARY_SERIES
+
+
+def _find_response(harness, method):
+    """Find the first captured response matching the given API method."""
+    for r in harness.responses:
+        if r.method == method:
+            return r
+    return None
+
+
+@pytest.mark.asyncio
+async def test_all_movies_shows_paginated_list(harness):
+    """/allMovies with 15 movies returns paginated sendMessage."""
+    with patch.object(
+        MediaService, "get_movies",
+        new_callable=AsyncMock, return_value=LIBRARY_MOVIES,
+    ):
+        resp = await harness.send_command("/allMovies")
+        assert resp is not None
+        assert "Movies" in resp.text
+        assert "15 total" in resp.text
+        assert resp.reply_markup is not None
+
+
+@pytest.mark.asyncio
+async def test_all_series_shows_list(harness):
+    """/allSeries with 5 series returns sendMessage with count."""
+    with patch.object(
+        MediaService, "get_series",
+        new_callable=AsyncMock, return_value=LIBRARY_SERIES,
+    ):
+        resp = await harness.send_command("/allSeries")
+        assert resp is not None
+        assert "Series" in resp.text
+        assert "5 total" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_pagination_via_lib_callback(harness):
+    """/allMovies then tap lib_m_1 shows page 2 via editMessageText."""
+    with patch.object(
+        MediaService, "get_movies",
+        new_callable=AsyncMock, return_value=LIBRARY_MOVIES,
+    ):
+        # Initial command caches items in user_data
+        await harness.send_command("/allMovies")
+
+        # Navigate to page 2
+        await harness.tap_button("lib_m_1")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "Page 2" in edit_resp.text
+
+
+@pytest.mark.asyncio
+async def test_empty_library(harness):
+    """/allMovies with empty list returns LibraryEmpty text."""
+    with patch.object(
+        MediaService, "get_movies",
+        new_callable=AsyncMock, return_value=[],
+    ):
+        resp = await harness.send_command("/allMovies")
+        assert resp is not None
+        assert "LibraryEmpty" in resp.text

--- a/tests/integration/test_library_flow.py
+++ b/tests/integration/test_library_flow.py
@@ -10,15 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 from src.services.media import MediaService
 
-from tests.integration.fixtures import LIBRARY_MOVIES, LIBRARY_SERIES
-
-
-def _find_response(harness, method):
-    """Find the first captured response matching the given API method."""
-    for r in harness.responses:
-        if r.method == method:
-            return r
-    return None
+from tests.integration.fixtures import LIBRARY_MOVIES, LIBRARY_SERIES, find_response
 
 
 @pytest.mark.asyncio
@@ -60,7 +52,7 @@ async def test_pagination_via_lib_callback(harness):
 
         # Navigate to page 2
         await harness.tap_button("lib_m_1")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "Page 2" in edit_resp.text
 

--- a/tests/integration/test_missing_flow.py
+++ b/tests/integration/test_missing_flow.py
@@ -10,15 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 from src.services.media import MediaService
 
-from tests.integration.fixtures import MISSING_ITEMS
-
-
-def _find_response(harness, method):
-    """Find the first captured response matching the given API method."""
-    for r in harness.responses:
-        if r.method == method:
-            return r
-    return None
+from tests.integration.fixtures import MISSING_ITEMS, find_response
 
 
 @pytest.mark.asyncio
@@ -58,7 +50,7 @@ async def test_missing_refresh(harness):
 
         # Tap refresh — handler calls edit_text then query.answer()
         await harness.tap_button("missing_refresh")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "MissingTitle" in edit_resp.text
 
@@ -75,6 +67,6 @@ async def test_missing_back_returns_to_main_menu(harness):
 
         # Tap back — handler calls edit_text then query.answer()
         await harness.tap_button("missing_back")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "Main Menu" in edit_resp.text

--- a/tests/integration/test_missing_flow.py
+++ b/tests/integration/test_missing_flow.py
@@ -1,0 +1,80 @@
+"""
+Integration tests for the /missing command flow.
+
+Uses the standard harness fixture. MediaService.get_missing_media is patched at
+the class level because MissingHandler instantiates the singleton in __init__.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.media import MediaService
+
+from tests.integration.fixtures import MISSING_ITEMS
+
+
+def _find_response(harness, method):
+    """Find the first captured response matching the given API method."""
+    for r in harness.responses:
+        if r.method == method:
+            return r
+    return None
+
+
+@pytest.mark.asyncio
+async def test_missing_shows_items(harness):
+    """/missing with mocked items returns text containing MissingTitle and count."""
+    with patch.object(
+        MediaService, "get_missing_media",
+        new_callable=AsyncMock, return_value=MISSING_ITEMS,
+    ):
+        resp = await harness.send_command("/missing")
+        assert resp is not None
+        assert "MissingTitle" in resp.text
+        assert "wanted items" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_missing_empty(harness):
+    """/missing with empty list returns text containing MissingEmpty."""
+    with patch.object(
+        MediaService, "get_missing_media",
+        new_callable=AsyncMock, return_value=[],
+    ):
+        resp = await harness.send_command("/missing")
+        assert resp is not None
+        assert "MissingEmpty" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_missing_refresh(harness):
+    """missing_refresh callback re-fetches missing media and updates text."""
+    with patch.object(
+        MediaService, "get_missing_media",
+        new_callable=AsyncMock, return_value=MISSING_ITEMS,
+    ):
+        # Initial command to set up user_data
+        await harness.send_command("/missing")
+
+        # Tap refresh — handler calls edit_text then query.answer()
+        await harness.tap_button("missing_refresh")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "MissingTitle" in edit_resp.text
+
+
+@pytest.mark.asyncio
+async def test_missing_back_returns_to_main_menu(harness):
+    """missing_back returns editMessageText with Main Menu."""
+    with patch.object(
+        MediaService, "get_missing_media",
+        new_callable=AsyncMock, return_value=MISSING_ITEMS,
+    ):
+        # Initial command to set up context
+        await harness.send_command("/missing")
+
+        # Tap back — handler calls edit_text then query.answer()
+        await harness.tap_button("missing_back")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "Main Menu" in edit_resp.text

--- a/tests/integration/test_preferences_flow.py
+++ b/tests/integration/test_preferences_flow.py
@@ -1,0 +1,37 @@
+"""
+Integration tests for the PreferencesHandler flow.
+
+Tests /preferences command and pref_toggle_view callback through the full
+handler chain.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from src.services.preferences import PreferencesService
+
+
+@pytest.mark.asyncio
+async def test_preferences_command_shows_current_mode(harness):
+    """/preferences returns sendMessage with current view mode and toggle button."""
+    with patch.object(PreferencesService, "get_view_mode", return_value="list"):
+        resp = await harness.send_command("/preferences")
+
+    assert resp is not None
+    assert resp.method == "sendMessage"
+    assert "Preferences" in resp.text
+    assert resp.reply_markup is not None
+
+
+@pytest.mark.asyncio
+async def test_toggle_view_switches_mode(harness):
+    """pref_toggle_view callback edits message with updated mode text."""
+    with patch.object(PreferencesService, "toggle_view_mode", return_value="card"):
+        resp = await harness.tap_button("pref_toggle_view")
+
+    assert resp is not None
+    assert resp.method == "editMessageText"
+    assert "Preferences" in resp.text
+    assert "Card View" in resp.text
+    assert resp.reply_markup is not None

--- a/tests/integration/test_queue_flow.py
+++ b/tests/integration/test_queue_flow.py
@@ -10,15 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 from src.services.media import MediaService
 
-from tests.integration.fixtures import QUEUE_ITEMS
-
-
-def _find_response(harness, method):
-    """Find the first captured response matching the given API method."""
-    for r in harness.responses:
-        if r.method == method:
-            return r
-    return None
+from tests.integration.fixtures import QUEUE_ITEMS, find_response
 
 
 @pytest.mark.asyncio
@@ -58,7 +50,7 @@ async def test_queue_refresh(harness):
 
         # Tap refresh — handler calls edit_text then query.answer()
         await harness.tap_button("queue_refresh")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "QueueTitle" in edit_resp.text
 
@@ -75,6 +67,6 @@ async def test_queue_back_returns_to_main_menu(harness):
 
         # Tap back — handler calls edit_text then query.answer()
         await harness.tap_button("queue_back")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "Main Menu" in edit_resp.text

--- a/tests/integration/test_queue_flow.py
+++ b/tests/integration/test_queue_flow.py
@@ -1,0 +1,80 @@
+"""
+Integration tests for the /queue command flow.
+
+Uses the standard harness fixture. MediaService.get_queue_media is patched at
+the class level because QueueHandler instantiates the singleton in __init__.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.media import MediaService
+
+from tests.integration.fixtures import QUEUE_ITEMS
+
+
+def _find_response(harness, method):
+    """Find the first captured response matching the given API method."""
+    for r in harness.responses:
+        if r.method == method:
+            return r
+    return None
+
+
+@pytest.mark.asyncio
+async def test_queue_shows_items(harness):
+    """/queue with mocked items returns text containing QueueTitle and count."""
+    with patch.object(
+        MediaService, "get_queue_media",
+        new_callable=AsyncMock, return_value=QUEUE_ITEMS,
+    ):
+        resp = await harness.send_command("/queue")
+        assert resp is not None
+        assert "QueueTitle" in resp.text
+        assert "queue items" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_queue_empty(harness):
+    """/queue with empty list returns text containing QueueEmpty."""
+    with patch.object(
+        MediaService, "get_queue_media",
+        new_callable=AsyncMock, return_value=[],
+    ):
+        resp = await harness.send_command("/queue")
+        assert resp is not None
+        assert "QueueEmpty" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_queue_refresh(harness):
+    """queue_refresh callback re-fetches queue media and updates text."""
+    with patch.object(
+        MediaService, "get_queue_media",
+        new_callable=AsyncMock, return_value=QUEUE_ITEMS,
+    ):
+        # Initial command to set up user_data
+        await harness.send_command("/queue")
+
+        # Tap refresh — handler calls edit_text then query.answer()
+        await harness.tap_button("queue_refresh")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "QueueTitle" in edit_resp.text
+
+
+@pytest.mark.asyncio
+async def test_queue_back_returns_to_main_menu(harness):
+    """queue_back returns editMessageText with Main Menu."""
+    with patch.object(
+        MediaService, "get_queue_media",
+        new_callable=AsyncMock, return_value=QUEUE_ITEMS,
+    ):
+        # Initial command to set up context
+        await harness.send_command("/queue")
+
+        # Tap back — handler calls edit_text then query.answer()
+        await harness.tap_button("queue_back")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "Main Menu" in edit_resp.text

--- a/tests/integration/test_settings_flow.py
+++ b/tests/integration/test_settings_flow.py
@@ -12,13 +12,7 @@ Patches:
 import pytest
 from unittest.mock import patch, MagicMock
 
-
-def _find_response(harness, method):
-    """Find the first captured response matching the given API method."""
-    for r in harness.responses:
-        if r.method == method:
-            return r
-    return None
+from tests.integration.fixtures import find_response
 
 
 @pytest.mark.asyncio
@@ -56,13 +50,13 @@ async def test_settings_language_flow(harness):
 
         # Tap language
         await harness.tap_button("settings_language")
-        lang_resp = _find_response(harness, "editMessageText")
+        lang_resp = find_response(harness, "editMessageText")
         assert lang_resp is not None
         assert "Settings.Language" in lang_resp.text
 
         # Select a language
         await harness.tap_button("lang_en")
-        select_resp = _find_response(harness, "editMessageText")
+        select_resp = find_response(harness, "editMessageText")
         assert select_resp is not None
         assert "Settings.LanguageChanged" in select_resp.text
         mock_cfg.update_nested.assert_called_with("language", "en")
@@ -76,6 +70,6 @@ async def test_settings_back_ends_conversation(harness):
         await harness.send_command("/settings")
 
         await harness.tap_button("settings_back")
-        edit_resp = _find_response(harness, "editMessageText")
+        edit_resp = find_response(harness, "editMessageText")
         assert edit_resp is not None
         assert "End" in edit_resp.text

--- a/tests/integration/test_settings_flow.py
+++ b/tests/integration/test_settings_flow.py
@@ -1,0 +1,81 @@
+"""
+Integration tests for the /settings command flow.
+
+Settings is admin-only via is_admin() check. Uses ConversationHandler with
+states: SETTINGS_MENU -> SETTINGS_LANGUAGE -> back to SETTINGS_MENU.
+
+Patches:
+- is_admin at the handler import site
+- config.update_nested and config.save as no-ops to prevent disk writes
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def _find_response(harness, method):
+    """Find the first captured response matching the given API method."""
+    for r in harness.responses:
+        if r.method == method:
+            return r
+    return None
+
+
+@pytest.mark.asyncio
+async def test_settings_as_admin_shows_menu(harness):
+    """/settings as admin shows settings menu with keyboard."""
+    with patch("src.bot.handlers.settings.is_admin", return_value=True):
+        resp = await harness.send_command("/settings")
+        assert resp is not None
+        assert "Settings.Menu" in resp.text
+        assert resp.reply_markup is not None
+
+
+@pytest.mark.asyncio
+async def test_settings_as_non_admin_rejected(harness):
+    """/settings as non-admin shows AdminOnly message and ends conversation."""
+    with patch("src.bot.handlers.settings.is_admin", return_value=False):
+        resp = await harness.send_command("/settings")
+        assert resp is not None
+        assert "Settings.AdminOnly" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_settings_language_flow(harness):
+    """settings -> language menu -> select language -> confirmed."""
+    with (
+        patch("src.bot.handlers.settings.is_admin", return_value=True),
+        patch("src.bot.handlers.settings.config") as mock_cfg,
+    ):
+        mock_cfg.get = MagicMock(return_value={})
+        mock_cfg.update_nested = MagicMock()
+        mock_cfg.save = MagicMock()
+
+        # Enter settings
+        await harness.send_command("/settings")
+
+        # Tap language
+        await harness.tap_button("settings_language")
+        lang_resp = _find_response(harness, "editMessageText")
+        assert lang_resp is not None
+        assert "Settings.Language" in lang_resp.text
+
+        # Select a language
+        await harness.tap_button("lang_en")
+        select_resp = _find_response(harness, "editMessageText")
+        assert select_resp is not None
+        assert "Settings.LanguageChanged" in select_resp.text
+        mock_cfg.update_nested.assert_called_with("language", "en")
+        mock_cfg.save.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_settings_back_ends_conversation(harness):
+    """settings -> back ends the conversation."""
+    with patch("src.bot.handlers.settings.is_admin", return_value=True):
+        await harness.send_command("/settings")
+
+        await harness.tap_button("settings_back")
+        edit_resp = _find_response(harness, "editMessageText")
+        assert edit_resp is not None
+        assert "End" in edit_resp.text

--- a/tests/integration/test_system_flow.py
+++ b/tests/integration/test_system_flow.py
@@ -1,0 +1,102 @@
+"""
+Integration tests for the SystemHandler flow.
+
+Tests /status command and system_* callbacks through the full handler chain.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.health import health_service
+
+
+MOCK_STATUS = {
+    "running": True,
+    "last_check": None,
+    "unhealthy_services": [],
+}
+
+MOCK_HEALTH_RESULTS = {
+    "media_services": [
+        {"name": "Radarr", "healthy": True, "status": "OK"},
+        {"name": "Sonarr", "healthy": True, "status": "OK"},
+    ],
+    "download_clients": [],
+}
+
+MOCK_DISK_SPACE = [
+    {
+        "path": "/data",
+        "freeSpace": 500000000000,
+        "totalSpace": 1000000000000,
+    },
+]
+
+
+def _find_response(harness, method):
+    """Find the first captured response matching a given API method."""
+    for resp in harness.responses:
+        if resp.method == method:
+            return resp
+    return None
+
+
+@pytest.mark.asyncio
+async def test_status_command_shows_status(harness):
+    """/status returns sendMessage with system status text."""
+    with patch.object(health_service, "get_status", return_value=MOCK_STATUS):
+        resp = await harness.send_command("/status")
+        assert resp is not None
+        assert resp.method == "sendMessage"
+        assert "System Status" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_system_refresh_reruns_checks(harness):
+    """system_refresh callback edits message with refreshed status."""
+    with (
+        patch.object(
+            health_service, "run_health_checks",
+            new_callable=AsyncMock, return_value=MOCK_HEALTH_RESULTS,
+        ),
+        patch.object(health_service, "get_status", return_value=MOCK_STATUS),
+    ):
+        await harness.tap_button("system_refresh")
+        resp = _find_response(harness, "editMessageText")
+        assert resp is not None
+        assert "System Status" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_system_details_shows_services(harness):
+    """system_details callback edits message with per-service health info."""
+    with patch.object(
+        health_service, "run_health_checks",
+        new_callable=AsyncMock, return_value=MOCK_HEALTH_RESULTS,
+    ):
+        await harness.tap_button("system_details")
+        resp = _find_response(harness, "editMessageText")
+        assert resp is not None
+        assert "Radarr" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_system_diskspace_shows_drives(harness):
+    """system_diskspace callback edits message with disk space info."""
+    with patch.object(
+        health_service, "get_disk_space",
+        new_callable=AsyncMock, return_value=MOCK_DISK_SPACE,
+    ):
+        await harness.tap_button("system_diskspace")
+        resp = _find_response(harness, "editMessageText")
+        assert resp is not None
+        assert "Disk Space" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_system_back_returns_to_main_menu(harness):
+    """system_back callback edits message to main menu."""
+    await harness.tap_button("system_back")
+    resp = _find_response(harness, "editMessageText")
+    assert resp is not None
+    assert "Main Menu" in resp.text

--- a/tests/integration/test_system_flow.py
+++ b/tests/integration/test_system_flow.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock, patch
 
 from src.services.health import health_service
 
+from tests.integration.fixtures import find_response
+
 
 MOCK_STATUS = {
     "running": True,
@@ -33,14 +35,6 @@ MOCK_DISK_SPACE = [
 ]
 
 
-def _find_response(harness, method):
-    """Find the first captured response matching a given API method."""
-    for resp in harness.responses:
-        if resp.method == method:
-            return resp
-    return None
-
-
 @pytest.mark.asyncio
 async def test_status_command_shows_status(harness):
     """/status returns sendMessage with system status text."""
@@ -62,7 +56,7 @@ async def test_system_refresh_reruns_checks(harness):
         patch.object(health_service, "get_status", return_value=MOCK_STATUS),
     ):
         await harness.tap_button("system_refresh")
-        resp = _find_response(harness, "editMessageText")
+        resp = find_response(harness, "editMessageText")
         assert resp is not None
         assert "System Status" in resp.text
 
@@ -75,7 +69,7 @@ async def test_system_details_shows_services(harness):
         new_callable=AsyncMock, return_value=MOCK_HEALTH_RESULTS,
     ):
         await harness.tap_button("system_details")
-        resp = _find_response(harness, "editMessageText")
+        resp = find_response(harness, "editMessageText")
         assert resp is not None
         assert "Radarr" in resp.text
 
@@ -88,7 +82,7 @@ async def test_system_diskspace_shows_drives(harness):
         new_callable=AsyncMock, return_value=MOCK_DISK_SPACE,
     ):
         await harness.tap_button("system_diskspace")
-        resp = _find_response(harness, "editMessageText")
+        resp = find_response(harness, "editMessageText")
         assert resp is not None
         assert "Disk Space" in resp.text
 
@@ -97,6 +91,6 @@ async def test_system_diskspace_shows_drives(harness):
 async def test_system_back_returns_to_main_menu(harness):
     """system_back callback edits message to main menu."""
     await harness.tap_button("system_back")
-    resp = _find_response(harness, "editMessageText")
+    resp = find_response(harness, "editMessageText")
     assert resp is not None
     assert "Main Menu" in resp.text


### PR DESCRIPTION
## Summary

- Add 84 integration tests covering all handler flows missing from the test suite (settings, bazarr, delete, library, calendar, missing, queue, help, system, preferences, history, error paths)
- Add parametrized auth gating test verifying all 12 protected commands reject unauthenticated users
- Register missing handlers (WebhooksHandler, HistoryHandler, BazarrHandler) in integration conftest
- Extract shared `find_response` helper to fixtures.py, eliminating duplication across 10 test files
- Fix bazarr_harness recursion bug in conftest (config.get mock was capturing itself)

Closes #162

## Test plan

- [x] `pytest --tb=short -q` — 2115 passed
- [x] `flake8 .` — clean
- [x] `mypy src/` — clean
- [x] `python run.py --validate-i18n` — all translations valid
- [x] `pytest tests/integration/ -v` — 84 integration tests pass
- [x] No source code changes (test-only branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)