### PR TITLE
Add architecture tests and development skills

### DIFF
--- a/.claude/skills/addarr-workflow/SKILL.md
+++ b/.claude/skills/addarr-workflow/SKILL.md
@@ -142,6 +142,10 @@ Step 4  ASK     If READY, confirm user wants to create the merge PR to main
 Step 5  RUN     If confirmed: gh pr create --base main --head development
 ```
 
+## Optional: Post-Merge Retrospective
+
+After a PR is merged, optionally run the retrospective process to extract durable learnings from TASKS.md completion metadata. See [references/retrospective.md](references/retrospective.md) for the categorization process. Human-reviewed — never auto-updates skills.
+
 ---
 
 ## Execution Loop

--- a/.claude/skills/addarr-workflow/SKILL.md
+++ b/.claude/skills/addarr-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: addarr-workflow
-description: "Development workflow for Addarr. Invoke via /addarr command. Triggers: /addarr, /addarr new, /addarr continue, /addarr feedback, /addarr pr, /addarr check. Handles: issue selection, branch management, planning, PR creation, preflight validation, PR feedback."
+description: "Development workflow for Addarr. Invoke via /addarr command. Triggers: /addarr, /addarr new, /addarr continue, /addarr feedback, /addarr pr, /addarr check, /addarr release. Handles: issue selection, branch management, planning, PR creation, preflight validation, PR feedback, release readiness."
 ---
 
 # Addarr Workflow
@@ -32,6 +32,7 @@ Self-driving development workflow for Addarr. Entry point: `/addarr [argument]`
 | `/addarr feedback` | feedback | Process PR review comments |
 | `/addarr pr` | create-pr | Review -> preflight -> push -> create PR |
 | `/addarr check` | preflight | Run CI checks locally |
+| `/addarr release` | release | Full readiness check for development -> main merge |
 
 ## Auto-Detection (no argument)
 
@@ -127,6 +128,18 @@ Step 3  RUN     mypy src/
 Step 4  RUN     PYTHONIOENCODING=utf-8 python run.py --validate-i18n
                 On failure: report missing/malformed keys
 Step 5  RUN     Report results summary (1-2 lines)
+```
+
+## Flow: release
+
+Full readiness check before merging `development` -> `main`. Invokes the `@release-readiness` skill.
+
+```
+Step 1  RUN     Checkout development branch, ensure up-to-date with origin
+Step 2  INVOKE  @release-readiness (runs all 4 phases)
+Step 3  RUN     Report final verdict: READY or NOT READY
+Step 4  ASK     If READY, confirm user wants to create the merge PR to main
+Step 5  RUN     If confirmed: gh pr create --base main --head development
 ```
 
 ---

--- a/.claude/skills/addarr-workflow/references/retrospective.md
+++ b/.claude/skills/addarr-workflow/references/retrospective.md
@@ -1,0 +1,55 @@
+# Post-PR Retrospective
+
+Optional step after a PR is merged. Extracts learnings from TASKS.md completion metadata and suggests durable skill/convention updates.
+
+**Key constraint:** Human-reviewed, never automatic. Present suggestions; user approves before any edits.
+
+## Process
+
+### Step 1: Extract Learnings
+
+Read all TASKS.md completion metadata for the merged PR's issue:
+```
+docs/issues/issue-<N>/TASKS.md
+```
+
+Collect all `**Learnings:**` and `**Notes:**` entries.
+
+### Step 2: Categorize
+
+For each learning, determine if it fits a category:
+
+| Category | Target | Example |
+|----------|--------|---------|
+| New anti-pattern | `addarr-testing/references/anti-patterns.md` | "Patching at source module instead of import site silently passes" |
+| New convention | `CLAUDE.md` or `test_conventions.py` | "All handler entry points must have @require_auth" |
+| Recurring bug pattern | `find-bugs` checklist | "Missing query.answer() in callback handlers" |
+| New fixture pattern | `addarr-testing/references/patterns.md` | "Use make_context(user_data={'key': val}) for state-dependent tests" |
+| Workflow improvement | `addarr-workflow` references | "Always run integration tests after handler changes" |
+
+### Step 3: Present Suggestions
+
+For each categorized learning, present:
+- **Learning:** The original text
+- **Suggestion:** What to add/modify and where
+- **Category:** Which category from the table above
+
+### Step 4: Apply (if approved)
+
+Only after user explicitly approves each suggestion:
+- Make the specific edit to the target file
+- Commit with message: `docs: retrospective update from issue-<N>`
+
+## Example
+
+**Learning from TASKS.md:**
+> Telegram requires command names to be lowercase for setMyCommands
+
+**Suggestion:**
+- **Category:** New convention
+- **Target:** `CLAUDE.md` under "Architecture > Key Patterns"
+- **Add:** "Telegram command names must be lowercase for `setMyCommands`. Case-insensitive for user input."
+
+**User says:** "Yes, add that."
+
+**Action:** Edit CLAUDE.md, commit.

--- a/.claude/skills/release-readiness/SKILL.md
+++ b/.claude/skills/release-readiness/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: release-readiness
+description: Use when preparing a development-to-main merge or evaluating whether a release is safe to ship. Runs comprehensive quality, test, documentation, and safety checks beyond the standard preflight.
+---
+
+# Release Readiness
+
+Gate for `development` -> `main` merges. Default stance: **NOT READY** unless all checks pass.
+
+## Phase 1: Code Quality
+
+* [ ] **Bug review** — Run `find-bugs` on full diff: `git diff main...development`
+* [ ] **Simplification** — Run `simplify` on full diff
+* [ ] **No debug artifacts** — No `TODO`, `FIXME`, `HACK` comments in changed files
+* [ ] **No print statements** — No `print()` in `src/` (use `get_logger` from `src/utils/logger.py`)
+* [ ] **No bare excepts** — No `except:` without specific exception types in `src/`
+
+## Phase 2: Test Confidence
+
+* [ ] **Full suite passes** — `pytest --tb=short -q`
+* [ ] **Coverage threshold** — `pytest --cov=src --cov-report=term-missing` on changed modules
+* [ ] **Architecture tests pass** — Both `tests/test_architecture/test_layer_boundaries.py` and `tests/test_architecture/test_conventions.py`
+* [ ] **Integration tests** — `pytest tests/integration/ --tb=short -v` covers all modified handler flows
+
+## Phase 3: Documentation & Metadata
+
+* [ ] **Completion metadata** — All TASKS.md files for included issues have `**Completed:**`, `**Learnings:**`, `**Key Changes:**`, `**Notes:**` fields
+* [ ] **Config template** — Any new config keys are present in `config_example.yaml`
+* [ ] **Translation coverage** — New translation keys present in all locale files: `PYTHONIOENCODING=utf-8 python run.py --validate-i18n`
+* [ ] **CLAUDE.md current** — Any new conventions, services, or patterns reflected in project CLAUDE.md
+
+## Phase 4: Release Safety
+
+* [ ] **Preflight passes** — Full preflight: pytest, flake8, mypy, i18n validation
+* [ ] **Docker build** — `docker build -t addarr .` succeeds
+* [ ] **No blocking issues** — Check for open issues tagged as blockers: `gh issue list --repo Krypt0nBull3t/Addarr --label blocker`
+* [ ] **Clean diff** — `git diff main...development --stat` shows only expected files changed
+
+## Output
+
+For each check: PASS or FAIL with specific details.
+
+**Final verdict:** READY or NOT READY.
+
+If NOT READY, list all failing checks with concrete next steps to resolve each.
+
+Do not make changes — just report findings.

--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: security-audit
+description: Use when performing a full-codebase security audit of Addarr. Covers auth surface, secret handling, API safety, and Telegram-specific risks. Unlike find-bugs (branch diffs only), this audits the entire security posture.
+---
+
+# Security Audit
+
+Full-codebase security review for Addarr. Run on demand to assess the overall security posture, not just branch changes.
+
+## Phase 1: Auth Surface
+
+Audit authentication and authorization controls.
+
+* [ ] **`@require_auth` coverage** — Every handler entry point in `src/bot/handlers/` has `@require_auth` or is in the explicit allowlist in `tests/test_architecture/test_conventions.py:AUTH_ALLOWLIST`
+* [ ] **Private chat enforcement** — `_enforce_private_chat()` in `src/bot/handlers/auth.py` covers all `chatMode` configurations (`private_only`, `public`, etc.)
+* [ ] **Password comparison** — `check_password()` in `src/bot/handlers/auth.py` uses timing-safe comparison (`hmac.compare_digest`) to prevent timing attacks. If it uses `==`, flag as High severity.
+* [ ] **Authenticated user persistence** — `_save_authenticated_users()` in `src/bot/handlers/auth.py` handles file write errors gracefully (permissions, disk full). Check for bare `except:` or silent failures.
+* [ ] **Password message deletion** — `message.delete()` for password messages in `auth.py` works in all chat types (private, group). Check error handling if delete fails (bot may lack permissions in groups).
+* [ ] **Admin-only commands** — Commands restricted to admins check `config.get("admins", [])` consistently. Search for admin checks across all handler files.
+
+## Phase 2: Secret Surface
+
+Audit secret handling and exposure risks.
+
+* [ ] **config.yaml in .gitignore** — Verify `.gitignore` includes `config.yaml` (contains API keys, bot token, passwords)
+* [ ] **API key headers** — All API clients in `src/api/` pass keys via `X-Api-Key` header only (in `BaseApiClient._get_headers()` at `src/api/base.py`). Keys never appear in URLs or logs.
+* [ ] **No secrets in error messages** — Error messages returned to Telegram users (via `reply_text`, `edit_text`) never contain API keys, tokens, or internal URLs. Check all `except` blocks in handlers.
+* [ ] **yaml.safe_load** — All YAML loading uses `yaml.safe_load()`, never `yaml.load()`. Check `src/config/settings.py` and any translation file loading.
+* [ ] **No hardcoded credentials** — No API keys, passwords, or tokens hardcoded in source files. Search for common patterns: `token = "`, `password = "`, `api_key = "`.
+
+## Phase 3: API Surface
+
+Audit API client security.
+
+* [ ] **Error response handling** — `BaseApiClient._make_request()` in `src/api/base.py` does not leak raw response text to users on error. Internal details stay in logs only.
+* [ ] **Rate limiting coverage** — `@rate_limit` decorator from `src/services/rate_limit.py` applied to user-facing operations (search, add). Check all handler entry points.
+* [ ] **Input validation** — Search queries validated/sanitized before passing to *arr APIs. Check `MediaService.search_*` methods in `src/services/media.py` and API client `search()` methods.
+* [ ] **Timeout configuration** — `aiohttp.ClientSession` in `BaseApiClient` has explicit timeouts (`aiohttp.ClientTimeout`). Missing timeouts can cause hanging connections.
+* [ ] **Session lifecycle** — `aiohttp.ClientSession` instances are properly closed on shutdown. Check `BaseApiClient` for session cleanup.
+
+## Phase 4: Telegram Surface
+
+Audit Telegram-specific security concerns.
+
+* [ ] **Bot token exposure** — Bot token (from config) never logged or included in error messages. Search for `bot_token`, `token` in log statements across `src/`.
+* [ ] **User ID integrity** — Authentication uses `update.effective_user.id` (Telegram-guaranteed, not spoofable). Verify no handler accepts user-supplied IDs for auth decisions.
+* [ ] **Callback data validation** — `callback_query.data` validated before use in all `CallbackQueryHandler` methods. Crafted callback_data could inject unexpected values. Check pattern matching vs raw string parsing.
+* [ ] **Callback data size** — All `callback_data` values in `src/bot/keyboards.py` stay within Telegram's 64-byte limit. Long data strings silently fail.
+* [ ] **Group chat behavior** — When `chatMode` is not `private_only`, verify bot behavior in group chats: no sensitive data exposed, commands work correctly, no state leakage between users.
+
+## Output
+
+**Only report actionable findings.** Skip:
+- Pre-existing patterns consistent with the codebase
+- Theoretical risks with no practical exploit path in this context
+- Items already covered by architecture tests in `tests/test_architecture/`
+
+For each real issue:
+
+* **File:Line** — Brief description
+* **Severity**: Critical / High / Medium / Low
+* **Problem**: What's wrong
+* **Fix**: Concrete suggestion with specific code change
+
+If nothing significant found, say so in one line. Do not pad output with "clean" confirmations per checklist item.
+
+Do not make changes — just report findings.

--- a/.claude/skills/telegram-ux-review/SKILL.md
+++ b/.claude/skills/telegram-ux-review/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: telegram-ux-review
+description: Use when reviewing Telegram bot interaction quality, keyboard consistency, flow efficiency, or message formatting. Covers Telegram-specific constraints (64-byte callback_data, 1024-char caption limit, 4096-char text limit) and bot UX patterns.
+---
+
+# Telegram UX Review
+
+On-demand review of bot interaction quality. Fills the gap left by traditional UI/UX tools that don't apply to Telegram's constrained interaction model.
+
+**Key files to audit:** `src/bot/keyboards.py`, `src/bot/handlers/media/formatters.py`, `src/bot/handlers/media/handler.py`, all handler files that build inline keyboards.
+
+## Telegram Platform Constraints
+
+These are hard limits enforced by the Telegram API:
+
+| Constraint | Limit | Consequence |
+|-----------|-------|-------------|
+| `callback_data` | 64 bytes | Button silently fails if exceeded |
+| Photo caption | 1024 characters | Caption truncated |
+| Text message | 4096 characters | Message fails to send |
+| Inline keyboard buttons per row | 8 | Layout breaks |
+| Button text | ~30 chars on mobile | Text truncated on small screens |
+
+## Phase 1: Keyboard Consistency
+
+* [ ] **Back/cancel placement** — Every keyboard has back/cancel in the last row
+* [ ] **Pagination pattern** — All paginated views use same format (e.g., arrows + page indicator)
+* [ ] **Filter checkmark convention** — Consistent symbol for active/inactive filters across all keyboards. Known issue: history uses `bullet` for active filter while queue/missing use `checkmark` — flag if still present
+* [ ] **Mobile fit** — Button text fits typical phone screen widths without truncation
+* [ ] **Callback data size** — All `callback_data` values in `src/bot/keyboards.py` stay within 64-byte limit
+* [ ] **No duplicate callback_data** — No identical callback_data values across unrelated keyboards (would cause wrong handler to fire)
+
+## Phase 2: Flow Efficiency
+
+* [ ] **Tap count** — Common actions (search -> select -> add) require <= 5 taps. Count and flag if more.
+* [ ] **Dead-end detection** — Every conversation state has a clear exit path (back, cancel, or timeout)
+* [ ] **Actionable errors** — Error states offer next steps, not just "something went wrong"
+* [ ] **Conversation timeouts** — All `ConversationHandler` flows have `conversation_timeout` configured
+* [ ] **Cancel from anywhere** — `/cancel` command works from every conversation state (check `fallbacks` in each ConversationHandler)
+
+## Phase 3: Information Density
+
+* [ ] **Caption length** — Photo captions stay within 1024-character Telegram limit. Check `formatters.py` caption builders.
+* [ ] **Text length** — Text messages stay within 4096-character limit. Check error messages, help text, status output.
+* [ ] **Truncation strategy** — Consistent approach when content exceeds limits (ellipsis, "and N more", pagination)
+* [ ] **Format consistency** — Search result formatting consistent between list view and card view
+* [ ] **Metadata order** — Rating, genre, year, links display follows same order across all media types (movie, series, music)
+
+## Phase 4: Accessibility
+
+* [ ] **Emoji + text pairing** — Emoji used as visual markers, always paired with text labels (e.g., `Added` not just the checkmark emoji)
+* [ ] **Image fallback** — Text-only fallback exists when poster images fail to load
+* [ ] **Plain text degradation** — Messages remain readable without Markdown/HTML formatting
+* [ ] **Status clarity** — Status indicators use both symbol and word (e.g., `Success: Added` not just a symbol)
+
+## Output
+
+**Only report actionable findings.** Skip:
+- Stylistic preferences without UX impact
+- Platform limitations that can't be worked around
+- Pre-existing patterns consistent with the codebase
+
+For each issue:
+
+* **File:Line** — Brief description
+* **Severity**: Critical / High / Medium / Low
+* **Problem**: What's wrong from a user perspective
+* **Fix**: Concrete suggestion
+
+If nothing significant found, say so in one line.
+
+Do not make changes — just report findings.

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ settings.local.json
 .coverage
 htmlcov/
 user_preferences.json
+.aider*

--- a/docs/issues/addarr-improvements/TASKS.md
+++ b/docs/issues/addarr-improvements/TASKS.md
@@ -121,7 +121,7 @@
 - Each skill's plan section serves as the spec — `/skill-creator` handles scaffolding
 - Skills follow the same output format as `find-bugs`: File:Line, Severity, Problem, Fix
 
-- [ ] **3.1** Create security audit skill
+- [x] **3.1** Create security audit skill
     - **Context:**
         - **Why:** No full-codebase security review exists. `find-bugs` only reviews branch diffs. Need a comprehensive audit covering auth surface, secret handling, API safety, and Telegram-specific risks.
         - **Architecture:** New skill at `.claude/skills/security-audit/SKILL.md`. Four-phase checklist structure (Auth → Secrets → API → Telegram). Output format matches `find-bugs`.
@@ -134,6 +134,10 @@
         - [GREEN] Review generated skill for Addarr-specific accuracy — every checklist item should reference a real file/function
         - [GREEN] Verify skill loads correctly by checking trigger description
     - **Success:** `/security-audit` skill exists, loads, and contains all 4 phases with Addarr-specific file references.
+    - **Completed:** 2026-03-11
+    - **Learnings:** Verified file references against actual codebase — caught `_build_headers` should be `_get_headers`. Always verify method/function names in skill checklists against the real code.
+    - **Key Changes:** Created `.claude/skills/security-audit/SKILL.md` with 4-phase checklist (Auth Surface, Secret Surface, API Surface, Telegram Surface). Follows find-bugs output format.
+    - **Notes:** Skill is now discoverable in the skills list. Description follows "Use when..." CSO pattern per writing-skills guidelines.
 
 - [ ] **3.2** Create release readiness skill + workflow integration
     - **Context:**

--- a/docs/issues/addarr-improvements/TASKS.md
+++ b/docs/issues/addarr-improvements/TASKS.md
@@ -89,7 +89,7 @@
 - Plan recommends the simpler alternative: a sync check test, not the `_reset_attrs` refactor
 - Why NOT the `_reset_attrs` approach: requires touching every service file for a maintenance convenience improvement — higher risk, lower ROI
 
-- [ ] **2.1** Singleton reset coverage test
+- [x] **2.1** Singleton reset coverage test
     - **Context:**
         - **Why:** `SINGLETON_CLASSES` in `test_conventions.py` (11 entries) and `reset_singletons` fixture in `conftest.py` (11 imports + resets) are manually kept in sync. Adding a new service to one but forgetting the other means either the convention test misses it or tests leak state between runs.
         - **Architecture:** Test reads the `reset_singletons` fixture source to extract class names being reset, then compares against `SINGLETON_CLASSES`. Also needs to verify `AuthHandler` is reset (it's not in `SINGLETON_CLASSES` because it's not a singleton, but it has class-level state).
@@ -104,6 +104,10 @@
         - [RED] Write `test_singleton_reset_coverage` — parse `conftest.py` AST to extract all class names that have `._instance = None` assignments in the `reset_singletons` function. Compare against `SINGLETON_CLASSES`. Separately verify `AuthHandler._authenticated_users` is reset.
         - [GREEN] Implement the AST extraction: find the `reset_singletons` function def, walk its body for attribute assignments where the target matches `ClassName._instance`
     - **Success:** `pytest tests/test_architecture/test_conventions.py::test_singleton_reset_coverage -v` passes. Adding a new class to `SINGLETON_CLASSES` without updating `reset_singletons` would fail with a clear message.
+    - **Completed:** 2026-03-11
+    - **Learnings:** AuthHandler is an edge case — it's reset in the fixture (class-level `_authenticated_users`) but is NOT in SINGLETON_CLASSES because it's a handler, not a singleton service. The test uses an `expected_extra` set to handle this.
+    - **Key Changes:** Added `_extract_reset_classes()` AST helper and `test_singleton_reset_coverage` to `test_conventions.py`. Checks both directions: SINGLETON_CLASSES entries missing from fixture, and fixture entries missing from SINGLETON_CLASSES.
+    - **Notes:** If a non-singleton class gets reset in the fixture, add it to `expected_extra` in the test with a comment.
 
 ---
 

--- a/docs/issues/addarr-improvements/TASKS.md
+++ b/docs/issues/addarr-improvements/TASKS.md
@@ -31,7 +31,7 @@
     - **Key Changes:** Added `_extract_media_config_methods()` AST helper and `test_media_config_dispatch_integrity` to `tests/test_architecture/test_conventions.py`
     - **Notes:** The helper skips `config_key` entries (config section names, not method names). If MEDIA_CONFIG structure changes, the extractor may need updating.
 
-- [ ] **1.2** State constant sync check test
+- [x] **1.2** State constant sync check test
     - **Context:**
         - **Why:** Media state constants are duplicated: `dispatch.py` lines 12-16 (`SEARCHING=1` through `ALBUM_SELECT=5`) and `states.py` lines 13-17 (`States.SEARCHING=1` through `States.ALBUM_SELECT=5`). No enforcement keeps them in sync — a drift would cause ConversationHandler state routing to silently break.
         - **Architecture:** Direct comparison test — import both sources and assert equality. No AST parsing needed since both are importable.
@@ -43,6 +43,10 @@
         - [RED] Write `test_media_state_constants_in_sync` — define the list of media state names (`SEARCHING`, `SELECTING`, `QUALITY_SELECT`, `SEASON_SELECT`, `ALBUM_SELECT`), compare `getattr(dispatch_module, name)` vs `getattr(States, name)` for each
         - [GREEN] Implement the test. Import `src.bot.handlers.media.dispatch` and `src.bot.states.States`
     - **Success:** `pytest tests/test_architecture/test_conventions.py::test_media_state_constants_in_sync -v` passes. Clear failure message if values diverge (e.g., `"SELECTING: dispatch.py=2, States=3"`).
+    - **Completed:** 2026-03-11
+    - **Learnings:** Simple direct-import comparison is cleaner than AST parsing when both sources are importable. The `<MISSING>` sentinel handles the case where a state name doesn't exist in one source.
+    - **Key Changes:** Added `MEDIA_STATE_NAMES` constant and `test_media_state_constants_in_sync` to `tests/test_architecture/test_conventions.py`
+    - **Notes:** Only the 5 media states are compared; non-media states (SETTINGS_MENU, PASSWORD, etc.) in States class are intentionally excluded.
 
 - [ ] **1.3** `@require_auth` coverage check test
     - **Context:**

--- a/docs/issues/addarr-improvements/TASKS.md
+++ b/docs/issues/addarr-improvements/TASKS.md
@@ -157,7 +157,7 @@
     - **Key Changes:** Created `.claude/skills/release-readiness/SKILL.md` with 4-phase checklist. Added `/addarr release` flow entry and release flow definition to `addarr-workflow/SKILL.md`.
     - **Notes:** The release flow defaults to NOT READY — all checks must pass. Asks user confirmation before creating the merge PR to main.
 
-- [ ] **3.3** Create Telegram UX review skill
+- [x] **3.3** Create Telegram UX review skill
     - **Context:**
         - **Why:** Traditional UI/UX tooling doesn't apply to Telegram bots. Known inconsistencies exist (e.g., `✓` vs `•` for active filters between queue/missing and history keyboards). No systematic way to audit keyboard patterns, flow efficiency, or message formatting.
         - **Architecture:** New skill at `.claude/skills/telegram-ux-review/SKILL.md`. Four-phase checklist (Keyboard Consistency → Flow Efficiency → Information Density → Accessibility). Output format matches `find-bugs`.
@@ -170,6 +170,10 @@
         - [GREEN] Verify Telegram-specific constraints (character limits, callback_data size) are concrete, not generic
         - [GREEN] Verify skill references the correct key files (`keyboards.py`, `formatters.py`, `handler.py`)
     - **Success:** `/telegram-ux-review` skill exists with all 4 phases, references Telegram platform constraints, and includes known issues as examples.
+    - **Completed:** 2026-03-11
+    - **Learnings:** Telegram has hard platform constraints (64-byte callback_data, 1024-char caption, 4096-char text) that must be documented as concrete limits, not generic UX advice. Including a constraints table at the top makes the skill immediately useful.
+    - **Key Changes:** Created `.claude/skills/telegram-ux-review/SKILL.md` with 4 phases (Keyboard Consistency, Flow Efficiency, Information Density, Accessibility). Includes known filter checkmark inconsistency as an example.
+    - **Notes:** Description follows "Use when..." CSO pattern and includes specific Telegram constraint numbers for discoverability.
 
 - [ ] **3.4** Create post-PR retrospective workflow reference
     - **Context:**

--- a/docs/issues/addarr-improvements/TASKS.md
+++ b/docs/issues/addarr-improvements/TASKS.md
@@ -139,7 +139,7 @@
     - **Key Changes:** Created `.claude/skills/security-audit/SKILL.md` with 4-phase checklist (Auth Surface, Secret Surface, API Surface, Telegram Surface). Follows find-bugs output format.
     - **Notes:** Skill is now discoverable in the skills list. Description follows "Use when..." CSO pattern per writing-skills guidelines.
 
-- [ ] **3.2** Create release readiness skill + workflow integration
+- [x] **3.2** Create release readiness skill + workflow integration
     - **Context:**
         - **Why:** No gate exists for `development` → `main` merges. The existing preflight (pytest, flake8, mypy, i18n) is a subset — missing code quality review, coverage thresholds, documentation checks, and Docker build verification.
         - **Architecture:** New skill at `.claude/skills/release-readiness/SKILL.md`. Four-phase checklist (Code Quality → Test Confidence → Documentation → Release Safety). Also add `/addarr release` entry point to `addarr-workflow/SKILL.md`.
@@ -152,6 +152,10 @@
         - [GREEN] Add `/addarr release` row to the flow table in `addarr-workflow/SKILL.md`
         - [GREEN] Verify both the new skill and the workflow integration load correctly
     - **Success:** `/release-readiness` skill exists with all 4 phases. `/addarr release` appears in workflow flow table and routes to the readiness check.
+    - **Completed:** 2026-03-11
+    - **Learnings:** Workflow description field needs to include all triggers for discoverability. Added `/addarr release` to both the flow table and the description frontmatter.
+    - **Key Changes:** Created `.claude/skills/release-readiness/SKILL.md` with 4-phase checklist. Added `/addarr release` flow entry and release flow definition to `addarr-workflow/SKILL.md`.
+    - **Notes:** The release flow defaults to NOT READY — all checks must pass. Asks user confirmation before creating the merge PR to main.
 
 - [ ] **3.3** Create Telegram UX review skill
     - **Context:**

--- a/docs/issues/addarr-improvements/TASKS.md
+++ b/docs/issues/addarr-improvements/TASKS.md
@@ -175,7 +175,7 @@
     - **Key Changes:** Created `.claude/skills/telegram-ux-review/SKILL.md` with 4 phases (Keyboard Consistency, Flow Efficiency, Information Density, Accessibility). Includes known filter checkmark inconsistency as an example.
     - **Notes:** Description follows "Use when..." CSO pattern and includes specific Telegram constraint numbers for discoverability.
 
-- [ ] **3.4** Create post-PR retrospective workflow reference
+- [x] **3.4** Create post-PR retrospective workflow reference
     - **Context:**
         - **Why:** TASKS.md completion metadata captures learnings, but nothing systematically extracts them into durable skill updates. Patterns discovered during implementation get lost after the PR merges.
         - **Architecture:** New reference file at `.claude/skills/addarr-workflow/references/retrospective.md`. Adds an optional post-merge step to the workflow: read completion metadata → categorize learnings → suggest skill/convention updates → user reviews and approves.
@@ -188,3 +188,7 @@
         - [GREEN] Add optional post-merge step reference in `addarr-workflow/SKILL.md`
         - [GREEN] Include example: show what a learning entry looks like and how it maps to a skill update suggestion
     - **Success:** Retrospective reference exists with categorization logic and example. Workflow mentions it as optional post-merge step.
+    - **Completed:** 2026-03-11
+    - **Learnings:** Retrospective is a reference file (not a standalone skill) since it's an optional workflow step, not independently invocable. The categorization table maps learning types to specific target files.
+    - **Key Changes:** Created `references/retrospective.md` with 4-step extract-categorize-present-apply process. Added "Optional: Post-Merge Retrospective" section to `addarr-workflow/SKILL.md`.
+    - **Notes:** This is human-reviewed by design — never auto-updates skills. The categorization table covers 5 target types: anti-patterns, conventions, bug patterns, fixture patterns, workflow improvements.

--- a/docs/issues/addarr-improvements/TASKS.md
+++ b/docs/issues/addarr-improvements/TASKS.md
@@ -1,0 +1,160 @@
+# TASKS: Addarr Tooling & Convention Improvements
+
+> Converted from `plan.md`. See plan for full rationale and design decisions.
+
+---
+
+### Phase 1: Architecture Tests — Convention Enforcement (3 tasks)
+
+**Goal:** Add three AST-based tests to `test_conventions.py` that catch runtime-only bugs at CI time.
+
+**Phase Context:**
+
+- All three tests go in the existing `tests/test_architecture/test_conventions.py` file, following the established pattern of AST parsing + assertion
+- Tests must work with the existing `conftest.py` mock config injection (no real config.yaml needed)
+
+- [x] **1.1** MEDIA_CONFIG dispatch integrity test
+    - **Context:**
+        - **Why:** `MEDIA_CONFIG` in `dispatch.py` maps media types to `MediaService` method name strings (e.g., `"search_movies"`, `"add_movie"`). These are resolved via `getattr()` at runtime in `handler.py:~line 90`. A rename typo would only surface when a user triggers the command — no compile-time check exists.
+        - **Architecture:** AST-based test in `test_conventions.py`, following the same pattern as `test_no_config_bracket_access_in_business_logic` (parse file → walk AST → assert)
+        - **Key refs:** `src/bot/handlers/media/dispatch.py:21-40` (MEDIA_CONFIG dict), `src/services/media.py:23` (MediaService class), `tests/test_architecture/test_conventions.py:50-66` (existing AST helpers)
+        - **Watch out:** MEDIA_CONFIG has nested structure — each media type has `search`, `add`, `add_with_profile` keys mapping to method name strings. Need to extract string values from the dict literal, not just top-level keys. The `config_key` values (e.g., `"radarr"`) are config keys, not method names — don't validate those against MediaService.
+    - **Scope:** One new test function + any AST helpers needed to extract method name strings from the MEDIA_CONFIG dict literal
+    - **Touches:** `tests/test_architecture/test_conventions.py`
+    - **Action items:**
+        - [RED] Write `test_media_config_dispatch_integrity` — parse `dispatch.py` AST, extract all method name string values from `MEDIA_CONFIG`, verify each resolves to a method on `MediaService` via `hasattr()` or `inspect.getmembers()`
+        - [RED] Add negative test case: temporarily verify the test would fail with a bogus method name (manual verification, not committed)
+        - [GREEN] Implement the test and any supporting helpers (e.g., `_extract_media_config_methods`)
+    - **Success:** `pytest tests/test_architecture/test_conventions.py::test_media_config_dispatch_integrity -v` passes. Test would fail if any MEDIA_CONFIG method string doesn't match a real MediaService method.
+    - **Completed:** 2026-03-11
+    - **Learnings:** Architecture tests that validate existing correct code don't follow the traditional red-green cycle — they pass immediately. Negative verification (bogus method name) confirms detection works.
+    - **Key Changes:** Added `_extract_media_config_methods()` AST helper and `test_media_config_dispatch_integrity` to `tests/test_architecture/test_conventions.py`
+    - **Notes:** The helper skips `config_key` entries (config section names, not method names). If MEDIA_CONFIG structure changes, the extractor may need updating.
+
+- [ ] **1.2** State constant sync check test
+    - **Context:**
+        - **Why:** Media state constants are duplicated: `dispatch.py` lines 12-16 (`SEARCHING=1` through `ALBUM_SELECT=5`) and `states.py` lines 13-17 (`States.SEARCHING=1` through `States.ALBUM_SELECT=5`). No enforcement keeps them in sync — a drift would cause ConversationHandler state routing to silently break.
+        - **Architecture:** Direct comparison test — import both sources and assert equality. No AST parsing needed since both are importable.
+        - **Key refs:** `src/bot/handlers/media/dispatch.py:12-16` (module-level constants), `src/bot/states.py:13-17` (States class attributes)
+        - **Watch out:** Only the 5 media states (SEARCHING through ALBUM_SELECT) need to be compared. States class has additional non-media states (SETTINGS_MENU, PASSWORD, etc.) that don't exist in dispatch.py — don't compare those. The state names are identical in both locations.
+    - **Scope:** One new test function comparing the 5 media state constants between dispatch.py and States
+    - **Touches:** `tests/test_architecture/test_conventions.py`
+    - **Action items:**
+        - [RED] Write `test_media_state_constants_in_sync` — define the list of media state names (`SEARCHING`, `SELECTING`, `QUALITY_SELECT`, `SEASON_SELECT`, `ALBUM_SELECT`), compare `getattr(dispatch_module, name)` vs `getattr(States, name)` for each
+        - [GREEN] Implement the test. Import `src.bot.handlers.media.dispatch` and `src.bot.states.States`
+    - **Success:** `pytest tests/test_architecture/test_conventions.py::test_media_state_constants_in_sync -v` passes. Clear failure message if values diverge (e.g., `"SELECTING: dispatch.py=2, States=3"`).
+
+- [ ] **1.3** `@require_auth` coverage check test
+    - **Context:**
+        - **Why:** Handler entry points (methods wired into `CommandHandler`/`ConversationHandler` `entry_points`) should have `@require_auth` unless explicitly exempted. A missing decorator means unauthenticated users can access the command. Currently only caught by manual review.
+        - **Architecture:** AST-based test. Scan all `*Handler` classes in `src/bot/handlers/`, find methods referenced in `get_handler()` return values as entry_points, check each for `require_auth` in its decorator list. Explicit allowlist for intentionally unprotected handlers.
+        - **Key refs:** `src/bot/handlers/auth.py:54-71` (`require_auth` decorator), `src/bot/handlers/auth.py:108-120` (`get_handler()` returning ConversationHandler with entry_points), `src/bot/handlers/start.py` (example of `@require_auth` usage)
+        - **Watch out:**
+            - The allowlist must include: `AuthHandler.start_auth` (is the auth flow itself), `AuthHandler.check_password`, `AuthHandler.cancel_auth` (internal conversation states). TransmissionHandler.transmission_command uses `is_enabled()` check instead of `@require_auth` — decide whether to allowlist or flag.
+            - Entry points are identified differently per handler type: `CommandHandler(cmd, self.method)` vs `ConversationHandler(entry_points=[...])`. The AST must handle both patterns.
+            - Decorator detection: look for `require_auth` in `node.decorator_list` — it could be `ast.Name(id='require_auth')` or `ast.Attribute(attr='require_auth')`.
+            - Some handlers are in subdirectories (`media/handler.py`) — must recurse.
+    - **Scope:** One new test function + AST helpers to extract entry point method names from `get_handler()` and check decorator presence. Explicit allowlist constant.
+    - **Touches:** `tests/test_architecture/test_conventions.py`
+    - **Action items:**
+        - [RED] Write `test_handler_entry_points_have_require_auth` with known allowlist. Plan for ~6-8 test assertions (one per handler class with entry points)
+        - [RED] Verify the test correctly identifies the TransmissionHandler gap (no `@require_auth` on `transmission_command`)
+        - [GREEN] Implement entry point extraction logic: parse `get_handler()` body, find `CommandHandler`/`ConversationHandler` constructors, extract method name references from `entry_points` argument
+        - [GREEN] Implement decorator check: for each entry point method name, find matching method def in the class and check `decorator_list`
+        - [GREEN] Define `AUTH_ALLOWLIST` constant with documented rationale for each exemption
+    - **Success:** `pytest tests/test_architecture/test_conventions.py::test_handler_entry_points_have_require_auth -v` passes. Adding a new handler without `@require_auth` would fail unless added to allowlist.
+
+---
+
+### Phase 2: Singleton Reset Sync Check (1 task)
+
+**Goal:** Add a test that verifies every class in `SINGLETON_CLASSES` has a corresponding reset in the `reset_singletons` fixture, catching "forgot to add reset" errors.
+
+**Phase Context:**
+
+- Plan recommends the simpler alternative: a sync check test, not the `_reset_attrs` refactor
+- Why NOT the `_reset_attrs` approach: requires touching every service file for a maintenance convenience improvement — higher risk, lower ROI
+
+- [ ] **2.1** Singleton reset coverage test
+    - **Context:**
+        - **Why:** `SINGLETON_CLASSES` in `test_conventions.py` (11 entries) and `reset_singletons` fixture in `conftest.py` (11 imports + resets) are manually kept in sync. Adding a new service to one but forgetting the other means either the convention test misses it or tests leak state between runs.
+        - **Architecture:** Test reads the `reset_singletons` fixture source to extract class names being reset, then compares against `SINGLETON_CLASSES`. Also needs to verify `AuthHandler` is reset (it's not in `SINGLETON_CLASSES` because it's not a singleton, but it has class-level state).
+        - **Key refs:** `tests/conftest.py:223-277` (reset_singletons fixture), `tests/test_architecture/test_conventions.py:20-32` (SINGLETON_CLASSES set)
+        - **Watch out:**
+            - `AuthHandler` is reset in the fixture (line 277) but is NOT in `SINGLETON_CLASSES` (it's a handler, not a service). The test needs a separate assertion or a `CLASSES_WITH_RESET` superset that includes it.
+            - The fixture uses `from src.services.X import XService` imports — extract class names from these import statements via AST.
+            - Don't make this test brittle to formatting changes — parse AST, don't regex the source.
+    - **Scope:** One new test function in `test_conventions.py` that compares SINGLETON_CLASSES against classes reset in the fixture
+    - **Touches:** `tests/test_architecture/test_conventions.py`
+    - **Action items:**
+        - [RED] Write `test_singleton_reset_coverage` — parse `conftest.py` AST to extract all class names that have `._instance = None` assignments in the `reset_singletons` function. Compare against `SINGLETON_CLASSES`. Separately verify `AuthHandler._authenticated_users` is reset.
+        - [GREEN] Implement the AST extraction: find the `reset_singletons` function def, walk its body for attribute assignments where the target matches `ClassName._instance`
+    - **Success:** `pytest tests/test_architecture/test_conventions.py::test_singleton_reset_coverage -v` passes. Adding a new class to `SINGLETON_CLASSES` without updating `reset_singletons` would fail with a clear message.
+
+---
+
+### Phase 3: New Skills (4 tasks)
+
+**Goal:** Create four new skills using `/skill-creator` that fill gaps in security auditing, release gating, UX review, and feedback loops.
+
+**Phase Context:**
+
+- All skills built via `/skill-creator` for consistent structure and YAML frontmatter
+- Each skill's plan section serves as the spec — `/skill-creator` handles scaffolding
+- Skills follow the same output format as `find-bugs`: File:Line, Severity, Problem, Fix
+
+- [ ] **3.1** Create security audit skill
+    - **Context:**
+        - **Why:** No full-codebase security review exists. `find-bugs` only reviews branch diffs. Need a comprehensive audit covering auth surface, secret handling, API safety, and Telegram-specific risks.
+        - **Architecture:** New skill at `.claude/skills/security-audit/SKILL.md`. Four-phase checklist structure (Auth → Secrets → API → Telegram). Output format matches `find-bugs`.
+        - **Key refs:** `.claude/skills/find-bugs/SKILL.md` (output format template), `src/bot/handlers/auth.py` (auth surface), `src/api/base.py` (API surface), `src/config/settings.py` (secret handling)
+        - **Watch out:** Must be Addarr-specific, not generic security advice. Each checklist item references a concrete file/function. Inspired by agency-agents Security Engineer persona but adapted to Telegram bot threat model.
+    - **Scope:** Invoke `/skill-creator` with the Phase 3.1 spec from plan.md. Checklist covers: auth decorator coverage, private chat enforcement, password comparison, config.yaml secrets, API key handling, yaml.safe_load usage, rate limiting, callback_data validation, bot token exposure.
+    - **Touches:** `.claude/skills/security-audit/SKILL.md` (new), possibly reference files
+    - **Action items:**
+        - [GREEN] Invoke `/skill-creator` with the 4-phase security audit checklist from plan.md as spec
+        - [GREEN] Review generated skill for Addarr-specific accuracy — every checklist item should reference a real file/function
+        - [GREEN] Verify skill loads correctly by checking trigger description
+    - **Success:** `/security-audit` skill exists, loads, and contains all 4 phases with Addarr-specific file references.
+
+- [ ] **3.2** Create release readiness skill + workflow integration
+    - **Context:**
+        - **Why:** No gate exists for `development` → `main` merges. The existing preflight (pytest, flake8, mypy, i18n) is a subset — missing code quality review, coverage thresholds, documentation checks, and Docker build verification.
+        - **Architecture:** New skill at `.claude/skills/release-readiness/SKILL.md`. Four-phase checklist (Code Quality → Test Confidence → Documentation → Release Safety). Also add `/addarr release` entry point to `addarr-workflow/SKILL.md`.
+        - **Key refs:** `.claude/skills/addarr-workflow/SKILL.md` (flow table to extend), `.claude/skills/addarr-workflow/references/preflight.md` (existing preflight steps to build on), `plan.md` Phase 3.2 (full checklist)
+        - **Watch out:** The `/addarr release` flow entry must be added to the workflow's flow table. Default stance is "NOT READY" unless all checks pass.
+    - **Scope:** Invoke `/skill-creator` with the Phase 3.2 spec. Then manually add the `/addarr release` entry to `addarr-workflow/SKILL.md` flow table.
+    - **Touches:** `.claude/skills/release-readiness/SKILL.md` (new), `.claude/skills/addarr-workflow/SKILL.md` (add flow entry)
+    - **Action items:**
+        - [GREEN] Invoke `/skill-creator` with the 4-phase release readiness checklist from plan.md
+        - [GREEN] Add `/addarr release` row to the flow table in `addarr-workflow/SKILL.md`
+        - [GREEN] Verify both the new skill and the workflow integration load correctly
+    - **Success:** `/release-readiness` skill exists with all 4 phases. `/addarr release` appears in workflow flow table and routes to the readiness check.
+
+- [ ] **3.3** Create Telegram UX review skill
+    - **Context:**
+        - **Why:** Traditional UI/UX tooling doesn't apply to Telegram bots. Known inconsistencies exist (e.g., `✓` vs `•` for active filters between queue/missing and history keyboards). No systematic way to audit keyboard patterns, flow efficiency, or message formatting.
+        - **Architecture:** New skill at `.claude/skills/telegram-ux-review/SKILL.md`. Four-phase checklist (Keyboard Consistency → Flow Efficiency → Information Density → Accessibility). Output format matches `find-bugs`.
+        - **Key refs:** `src/bot/keyboards.py` (1288 lines, all keyboard layouts), `src/bot/handlers/media/formatters.py` (caption building, result display), `plan.md` Phase 3.4 (full checklist with known issues)
+        - **Watch out:** Telegram-specific constraints: 64-byte callback_data limit, 1024-char photo caption limit, 4096-char text limit, inline keyboard only (no custom UI). The skill must reference these concrete limits, not generic UX principles.
+    - **Scope:** Invoke `/skill-creator` with the Phase 3.4 spec. Include known issues as examples (filter checkmark inconsistency).
+    - **Touches:** `.claude/skills/telegram-ux-review/SKILL.md` (new), possibly reference files
+    - **Action items:**
+        - [GREEN] Invoke `/skill-creator` with the 4-phase Telegram UX checklist from plan.md
+        - [GREEN] Verify Telegram-specific constraints (character limits, callback_data size) are concrete, not generic
+        - [GREEN] Verify skill references the correct key files (`keyboards.py`, `formatters.py`, `handler.py`)
+    - **Success:** `/telegram-ux-review` skill exists with all 4 phases, references Telegram platform constraints, and includes known issues as examples.
+
+- [ ] **3.4** Create post-PR retrospective workflow reference
+    - **Context:**
+        - **Why:** TASKS.md completion metadata captures learnings, but nothing systematically extracts them into durable skill updates. Patterns discovered during implementation get lost after the PR merges.
+        - **Architecture:** New reference file at `.claude/skills/addarr-workflow/references/retrospective.md`. Adds an optional post-merge step to the workflow: read completion metadata → categorize learnings → suggest skill/convention updates → user reviews and approves.
+        - **Key refs:** `.claude/skills/addarr-workflow/SKILL.md` (workflow to integrate with), `docs/issues/issue-79/TASKS.md` (example of completion metadata format), `plan.md` Phase 3.3 (categorization logic)
+        - **Watch out:** This is human-reviewed, not automatic. Never auto-update skills. The categories are: new anti-pattern → `anti-patterns.md`, new convention → `CLAUDE.md` or `test_conventions.py`, recurring bug → `find-bugs`, new fixture pattern → `fixtures.md`.
+    - **Scope:** Create the reference file with the retrospective process. Add a mention in `addarr-workflow/SKILL.md` as an optional post-merge step.
+    - **Touches:** `.claude/skills/addarr-workflow/references/retrospective.md` (new), `.claude/skills/addarr-workflow/SKILL.md` (add reference)
+    - **Action items:**
+        - [GREEN] Write the retrospective reference file with the 4-step categorization process from plan.md
+        - [GREEN] Add optional post-merge step reference in `addarr-workflow/SKILL.md`
+        - [GREEN] Include example: show what a learning entry looks like and how it maps to a skill update suggestion
+    - **Success:** Retrospective reference exists with categorization logic and example. Workflow mentions it as optional post-merge step.

--- a/docs/issues/addarr-improvements/TASKS.md
+++ b/docs/issues/addarr-improvements/TASKS.md
@@ -48,7 +48,7 @@
     - **Key Changes:** Added `MEDIA_STATE_NAMES` constant and `test_media_state_constants_in_sync` to `tests/test_architecture/test_conventions.py`
     - **Notes:** Only the 5 media states are compared; non-media states (SETTINGS_MENU, PASSWORD, etc.) in States class are intentionally excluded.
 
-- [ ] **1.3** `@require_auth` coverage check test
+- [x] **1.3** `@require_auth` coverage check test
     - **Context:**
         - **Why:** Handler entry points (methods wired into `CommandHandler`/`ConversationHandler` `entry_points`) should have `@require_auth` unless explicitly exempted. A missing decorator means unauthenticated users can access the command. Currently only caught by manual review.
         - **Architecture:** AST-based test. Scan all `*Handler` classes in `src/bot/handlers/`, find methods referenced in `get_handler()` return values as entry_points, check each for `require_auth` in its decorator list. Explicit allowlist for intentionally unprotected handlers.
@@ -67,6 +67,16 @@
         - [GREEN] Implement decorator check: for each entry point method name, find matching method def in the class and check `decorator_list`
         - [GREEN] Define `AUTH_ALLOWLIST` constant with documented rationale for each exemption
     - **Success:** `pytest tests/test_architecture/test_conventions.py::test_handler_entry_points_have_require_auth -v` passes. Adding a new handler without `@require_auth` would fail unless added to allowlist.
+    - **Completed:** 2026-03-11
+    - **Learnings:**
+        - `MediaHandler.handle_menu_callback` is in ConversationHandler entry_points (triggered from start menu) but doesn't need @require_auth since the start menu already enforces it — needed allowlisting.
+        - AST extraction of entry points requires distinguishing between ConversationHandler entry_points and standalone CommandHandler callbacks. CallbackQueryHandler at the return list level is intentionally excluded (not a user-triggerable command).
+        - `_method_has_decorator` must handle both `@require_auth` and `@require_auth()` (call) forms.
+    - **Key Changes:**
+        - Added `_get_call_name()`, `_extract_self_methods()`, `_extract_entry_point_methods()`, `_method_has_decorator()` AST helpers
+        - Added `AUTH_ALLOWLIST` with 3 exempted methods (AuthHandler.start_auth, TransmissionHandler.transmission_command, MediaHandler.handle_menu_callback)
+        - Added `test_handler_entry_points_have_require_auth` test
+    - **Notes:** When adding new handlers, if they don't use @require_auth, add to AUTH_ALLOWLIST with a comment explaining why. Test only checks CommandHandler callbacks and ConversationHandler entry_points, not standalone CallbackQueryHandler.
 
 ---
 

--- a/docs/issues/addarr-improvements/plan.md
+++ b/docs/issues/addarr-improvements/plan.md
@@ -1,0 +1,244 @@
+# Plan: Addarr Tooling & Convention Improvements
+
+## Context
+
+Based on analysis of the agency-agents repository and comparative evaluation with ChatGPT and Qwen, we identified concrete gaps in Addarr's architecture tests, development skills, and feedback loop. This plan addresses those gaps using skills (not agents) — encoding project knowledge into reusable checklists and workflows.
+
+## Phase 1: Architecture Tests (Convention Enforcement)
+
+Add three new tests to `tests/test_architecture/test_conventions.py` that catch real issues at CI time.
+
+### 1.1 MEDIA_CONFIG Dispatch Integrity
+
+**Problem:** `MEDIA_CONFIG` in `src/bot/handlers/media/dispatch.py` maps string keys (`"search_movies"`, `"add_movie"`, etc.) to `MediaService` method names. These are resolved at runtime via `getattr()` in `handler.py`. A refactoring typo would only surface when a user triggers the command.
+
+**Solution:** AST-based test that:
+- Parses `dispatch.py` to extract all method name strings from `MEDIA_CONFIG`
+- Verifies each resolves to an actual method on `MediaService`
+- Fails with a clear message like: `MEDIA_CONFIG["movie"]["search"] references "search_movies" but MediaService has no such method`
+
+**Files:** `tests/test_architecture/test_conventions.py`, `src/bot/handlers/media/dispatch.py`, `src/services/media.py`
+
+### 1.2 State Constant Sync Check
+
+**Problem:** Conversation state constants are defined in two places:
+- `src/bot/handlers/media/dispatch.py`: `SEARCHING = 1`, `SELECTING = 2`, etc.
+- `src/bot/states.py`: `States.SEARCHING = 1`, `States.SELECTING = 2`, etc.
+
+These are manually kept in sync with no enforcement. A drift would cause conversation handlers to break silently.
+
+**Solution:** Test that compares the media state values in `dispatch.py` against `States` class attributes and fails if they diverge.
+
+**Files:** `tests/test_architecture/test_conventions.py`, `src/bot/handlers/media/dispatch.py`, `src/bot/states.py`
+
+### 1.3 `@require_auth` Coverage Check
+
+**Problem:** Handler entry points that should require authentication could accidentally omit the `@require_auth` decorator. Currently nothing enforces this — it would only be caught by manual review or integration tests.
+
+**Solution:** AST-based test that:
+- Scans all `*Handler` classes in `src/bot/handlers/`
+- For each method referenced as an `entry_point` in a `ConversationHandler` or `CommandHandler`, checks whether `@require_auth` is present
+- Maintains an explicit allowlist for handlers that intentionally skip auth (e.g., `StartHandler.start`, `AuthHandler.start_auth`, `HelpHandler.help`)
+- Fails if an entry point is undecorated and not in the allowlist
+
+**Design consideration:** The allowlist approach is better than trying to infer which handlers "should" have auth. It makes the decision explicit and reviewable.
+
+**Files:** `tests/test_architecture/test_conventions.py`, `src/bot/handlers/**/*.py`
+
+---
+
+## Phase 2: Dynamic Singleton Reset
+
+### 2.1 Refactor `reset_singletons` Fixture
+
+**Problem:** The `reset_singletons` fixture in `tests/conftest.py` manually lists 11 singleton services with their specific class-level attributes to reset. Adding a new service requires updating both `SINGLETON_CLASSES` in `test_conventions.py` and the reset fixture — but there's no enforcement linking them, so it's easy to update one and forget the other.
+
+**Complication:** Each singleton has different state beyond `_instance`:
+- `MediaService`: `_radarr`, `_sonarr`, `_lidarr`
+- `BazarrService`: `_client`, `_config`
+- `TranslationService`: `_translations`
+- `NotificationService`: `_bot`
+- `PreferencesService`: `_preferences`
+- `RateLimitService`: `_records`
+- `WebhookService`: `_enabled`, `_running`, `_runner`
+- `AuthHandler`: `_authenticated_users` (not even a singleton — class-level state)
+
+**Solution:** Add a `_reset_attrs` class-level dict or method to each singleton service that declares its resettable state. The fixture then auto-discovers singletons from `SINGLETON_CLASSES` and calls the reset. This keeps the type-safe per-class reset behavior but removes the manual listing from `conftest.py`.
+
+**Alternative (simpler):** Keep the manual reset but add a test that verifies every class in `SINGLETON_CLASSES` appears in the `reset_singletons` fixture. This is less elegant but lower risk and still catches the "forgot to add reset" failure mode.
+
+**Recommendation:** Start with the simpler alternative. The `_reset_attrs` approach requires touching every service file, which is a larger change with more risk for a maintenance convenience improvement.
+
+**Files:** `tests/conftest.py`, `tests/test_architecture/test_conventions.py`
+
+---
+
+## Phase 3: New Skills
+
+### 3.1 Security Audit Skill
+
+**Purpose:** Full-codebase security review on demand. Unlike `find-bugs` (which reviews branch diffs), this audits the entire security posture.
+
+**Location:** `.claude/skills/security-audit/SKILL.md`
+
+**Structure (inspired by agency-agents Security Engineer, adapted for Addarr):**
+
+**Phase 1: Auth Surface**
+- [ ] Every handler entry point has `@require_auth` or is in the explicit allowlist
+- [ ] `_enforce_private_chat` covers all chat mode configurations
+- [ ] Password comparison in `auth.py:check_password` — plaintext comparison timing attack risk
+- [ ] `_save_authenticated_users` — file write permissions, error handling
+- [ ] `message.delete()` for password messages — does it work in all chat types?
+- [ ] Admin-only commands check `config.get("admins", [])` consistently
+
+**Phase 2: Secret Surface**
+- [ ] `config.yaml` is in `.gitignore` (API keys, bot token, passwords)
+- [ ] API keys passed only via `X-Api-Key` header, never logged
+- [ ] No secrets in error messages returned to users
+- [ ] `yaml.safe_load` used everywhere (not `yaml.load`)
+- [ ] No hardcoded credentials in source
+
+**Phase 3: API Surface**
+- [ ] `BaseApiClient._make_request` — response text not leaked to users on error
+- [ ] Rate limiting configured and enforced (`@rate_limit` decorator coverage)
+- [ ] Input validation on search queries before passing to *arr APIs
+- [ ] Timeout configuration prevents hanging connections
+
+**Phase 4: Telegram Surface**
+- [ ] Bot token not logged or exposed in error messages
+- [ ] User ID used for auth cannot be spoofed (Telegram guarantees this, but verify we don't accept user-supplied IDs)
+- [ ] Callback data validated before use (no injection via crafted callback_data)
+- [ ] Group chat behavior tested when `chatMode` is not `private_only`
+
+**Output format:** Same as `find-bugs` — File:Line, Severity, Problem, Fix. Only actionable findings.
+
+### 3.2 Release Readiness Skill
+
+**Purpose:** Gate for `development` → `main` merges. Runs before creating a release PR.
+
+**Location:** `.claude/skills/release-readiness/SKILL.md` (or add as `/addarr release` flow in `addarr-workflow`)
+
+**Checklist:**
+
+**Phase 1: Code Quality**
+- [ ] `find-bugs` on full diff: `git diff main...development`
+- [ ] `simplify` on full diff
+- [ ] No `TODO`, `FIXME`, `HACK` comments in changed files
+- [ ] No `print()` statements in `src/` (should use logger)
+
+**Phase 2: Test Confidence**
+- [ ] Full test suite passes: `pytest --tb=short -q`
+- [ ] Coverage on changed modules meets threshold
+- [ ] All architecture tests pass (layer boundaries + conventions)
+- [ ] Integration tests cover all modified handler flows
+
+**Phase 3: Documentation & Metadata**
+- [ ] All TASKS.md files for included issues have completion metadata
+- [ ] Version in `src/__init__.py` (or wherever defined) reflects the release
+- [ ] Any new config keys are documented in `config_example.yaml`
+- [ ] Any new translation keys are present in all locale files
+
+**Phase 4: Release Safety**
+- [ ] No open issues blocking this release
+- [ ] Docker build succeeds: `docker build -t addarr .`
+- [ ] Preflight passes (tests, lint, mypy, i18n validation)
+
+**Output:** Pass/fail with specific failures listed. Default stance: "NOT READY" unless all checks pass (Reality Checker principle).
+
+**Integration with workflow:** Add as a new flow in `addarr-workflow`:
+```
+| `/addarr release` | release | Full readiness check for development → main merge |
+```
+
+### 3.3 Post-PR Retrospective (Feedback Loop)
+
+**Purpose:** After a PR is merged, extract learnings from TASKS.md completion metadata and check whether any should become durable skill updates.
+
+**Location:** `.claude/skills/addarr-workflow/references/retrospective.md` (add as optional step after PR merge)
+
+**Process:**
+
+1. Read all TASKS.md completion metadata for the merged PR's issue
+2. For each learning entry, categorize:
+   - **New anti-pattern?** → Suggest addition to relevant skill's `references/anti-patterns.md`
+   - **New convention?** → Suggest addition to `CLAUDE.md` or `test_conventions.py`
+   - **Recurring bug category?** → Suggest new check in `find-bugs`
+   - **New fixture pattern?** → Suggest addition to `addarr-testing/references/fixtures.md`
+3. Present suggestions to user for review (never auto-update skills)
+4. If approved, make the edits
+
+**Key constraint:** This is human-reviewed, not automatic. The "self-improving" part is structured extraction, not unsupervised updates.
+
+### 3.4 Telegram UX Review Skill
+
+**Purpose:** On-demand review of bot interaction quality — keyboard consistency, flow efficiency, information density, and chat bot accessibility. Fills the gap left by traditional UI/UX tools that don't apply to Telegram's constrained interaction model.
+
+**Location:** `.claude/skills/telegram-ux-review/SKILL.md`
+
+**Phase 1: Keyboard Consistency**
+- [ ] Every keyboard has back/cancel in the last row
+- [ ] Pagination follows the same `⬅️ Prev | Page X/Y | ➡️ Next` pattern everywhere
+- [ ] Filter tabs use the same checkmark convention (`✓` vs `•` — known inconsistency: history uses `•` for active filter while queue/missing use `✓`)
+- [ ] Button text fits mobile screens (no truncation on typical phone widths)
+- [ ] Callback data stays within Telegram's 64-byte limit
+- [ ] No duplicate callback_data values across unrelated keyboards
+
+**Phase 2: Flow Efficiency**
+- [ ] Tap count for common actions (search → add): count and flag if > 5 taps
+- [ ] Dead-end detection: every state has a clear exit path (back, cancel, or timeout)
+- [ ] Error states offer actionable next steps (not just "something went wrong")
+- [ ] Conversation timeouts configured and tested for all `ConversationHandler` flows
+- [ ] Cancel command works from every conversation state
+
+**Phase 3: Information Density**
+- [ ] Photo captions stay within 1024-character Telegram limit
+- [ ] Text messages stay within 4096-character limit
+- [ ] Consistent truncation strategy when content exceeds limits (ellipsis, "and N more")
+- [ ] Search result formatting consistent between list view and card view
+- [ ] Rating/genre/link display follows same order across all media types
+
+**Phase 4: Chat Bot Accessibility**
+- [ ] Emoji used as visual markers, not sole indicators (always paired with text)
+- [ ] Text-only fallback exists when poster images fail to load
+- [ ] Messages readable without formatting (plain text degradation)
+- [ ] Status indicators use both symbol and word (e.g., `✅ Added` not just `✅`)
+
+**Key files to audit:** `src/bot/keyboards.py`, `src/bot/handlers/media/formatters.py`, `src/bot/handlers/media/handler.py`, all handler files that build inline keyboards.
+
+**Output format:** Same as `find-bugs` — File:Line, Severity, Problem, Fix. Only actionable findings.
+
+---
+
+## Skill Creation Method
+
+All new skills (3.1, 3.2, 3.3) should be built using `/skill-creator`. This ensures:
+- Consistent YAML frontmatter and structure
+- Proper placement in `.claude/skills/`
+- Reference file organization matching existing skills
+- Trigger descriptions that integrate with the skill loading system
+
+For each skill, invoke `/skill-creator` with the requirements and checklists defined above as input. The plan sections for each skill serve as the spec — `/skill-creator` handles the scaffolding and structure.
+
+The Phase 3.2 release readiness skill also requires a workflow integration step: adding the `/addarr release` entry point to `addarr-workflow/SKILL.md` after the skill is created.
+
+---
+
+## Phase Summary
+
+| Phase | Items | Effort | Value |
+|-------|-------|--------|-------|
+| 1 — Architecture tests | 3 new tests in `test_conventions.py` | Small | High — catches runtime bugs at CI |
+| 2 — Singleton reset | 1 sync check or refactor | Small | Medium — reduces maintenance friction |
+| 3.1 — Security audit skill | New skill with Addarr-specific checklists | Medium | High — fills real gap in tooling |
+| 3.2 — Release readiness skill | New skill or workflow flow | Medium | High — gates releases with evidence |
+| 3.3 — Post-PR retrospective | New workflow reference | Small | Medium — closes the learning loop |
+| 3.4 — Telegram UX review skill | New skill with Telegram-specific checklists | Medium | Medium — catches UX inconsistencies systematically |
+
+## Recommended Order
+
+1. Phase 1 (architecture tests) — immediate value, small scope, testable
+2. Phase 2 (singleton reset sync) — quick win while in test_conventions.py
+3. Phase 3.1 (security audit) — new capability, no existing coverage
+4. Phase 3.2 (release readiness) — builds on Phase 1 tests + existing preflight
+5. Phase 3.4 (Telegram UX review) — catches known inconsistencies, informs future UI work
+6. Phase 3.3 (retrospective) — lowest urgency, highest long-term value

--- a/tests/test_architecture/test_conventions.py
+++ b/tests/test_architecture/test_conventions.py
@@ -85,6 +85,114 @@ def _class_inherits_from(class_node, base_name):
     return False
 
 
+def _get_call_name(call_node):
+    """Get the function/class name from an ast.Call node."""
+    if isinstance(call_node.func, ast.Name):
+        return call_node.func.id
+    if isinstance(call_node.func, ast.Attribute):
+        return call_node.func.attr
+    return None
+
+
+def _extract_self_methods(node):
+    """Extract all self.method attribute names from an AST subtree."""
+    methods = []
+    for child in ast.walk(node):
+        if (isinstance(child, ast.Attribute)
+                and isinstance(child.value, ast.Name)
+                and child.value.id == "self"):
+            methods.append(child.attr)
+    return methods
+
+
+def _extract_entry_point_methods(class_node):
+    """Extract method names used as handler entry points in get_handler().
+
+    Entry points are:
+    - Callback methods in standalone CommandHandler calls
+    - Callback methods in ConversationHandler entry_points lists
+    """
+    get_handler = None
+    for node in class_node.body:
+        if (isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == "get_handler"):
+            get_handler = node
+            break
+    if not get_handler:
+        return []
+
+    # Find the return statement
+    return_node = None
+    for node in ast.walk(get_handler):
+        if isinstance(node, ast.Return) and node.value is not None:
+            return_node = node
+            break
+    if not return_node or not isinstance(return_node.value, ast.List):
+        return []
+
+    methods = []
+    for elt in return_node.value.elts:
+        if not isinstance(elt, ast.Call):
+            continue
+
+        func_name = _get_call_name(elt)
+
+        if func_name == "ConversationHandler":
+            # Extract self.method references from entry_points keyword
+            for kw in elt.keywords:
+                if kw.arg == "entry_points":
+                    methods.extend(_extract_self_methods(kw.value))
+        elif func_name == "CommandHandler":
+            # The callback is the 2nd positional arg: CommandHandler(cmd, self.method)
+            if len(elt.args) >= 2:
+                arg = elt.args[1]
+                if (isinstance(arg, ast.Attribute)
+                        and isinstance(arg.value, ast.Name)
+                        and arg.value.id == "self"):
+                    methods.append(arg.attr)
+
+    return methods
+
+
+def _method_has_decorator(class_node, method_name, decorator_name):
+    """Check if a method in a class has a specific decorator."""
+    for node in class_node.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name != method_name:
+            continue
+        # Found the method — check its decorators
+        for dec in node.decorator_list:
+            if isinstance(dec, ast.Name) and dec.id == decorator_name:
+                return True
+            if isinstance(dec, ast.Attribute) and dec.attr == decorator_name:
+                return True
+            # Handle @decorator(args) form
+            if isinstance(dec, ast.Call):
+                if (isinstance(dec.func, ast.Name)
+                        and dec.func.id == decorator_name):
+                    return True
+                if (isinstance(dec.func, ast.Attribute)
+                        and dec.func.attr == decorator_name):
+                    return True
+        # Method found but decorator not present
+        return False
+    # Method not found in class
+    return False
+
+
+# Handler entry points that intentionally skip @require_auth.
+# Each entry documents why the exemption is safe.
+AUTH_ALLOWLIST = {
+    # AuthHandler IS the auth flow — requiring auth to authenticate is circular
+    "AuthHandler.start_auth",
+    # TransmissionHandler uses is_enabled() check instead
+    "TransmissionHandler.transmission_command",
+    # Triggered from StartHandler menu which already enforces auth
+    "MediaHandler.handle_menu_callback",
+}
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -274,6 +382,33 @@ def test_media_state_constants_in_sync():
     assert not mismatches, (
         "Media state constants out of sync:\n"
         + "\n".join(f"  {m}" for m in mismatches)
+    )
+
+
+def test_handler_entry_points_have_require_auth():
+    """Handler entry points must use @require_auth unless allowlisted.
+
+    Entry points are methods wired as callbacks in CommandHandler or
+    in ConversationHandler entry_points. Missing @require_auth means
+    unauthenticated users can access the command.
+    """
+    missing = []
+    for filepath in _get_python_files(HANDLERS_DIR):
+        for cls in _get_classes_in_file(filepath):
+            if not cls.name.endswith("Handler"):
+                continue
+            entry_methods = _extract_entry_point_methods(cls)
+            for method_name in entry_methods:
+                qualified = f"{cls.name}.{method_name}"
+                if qualified in AUTH_ALLOWLIST:
+                    continue
+                if not _method_has_decorator(cls, method_name, "require_auth"):
+                    missing.append(qualified)
+
+    assert not missing, (
+        "Handler entry points missing @require_auth "
+        "(add to AUTH_ALLOWLIST if intentional):\n"
+        + "\n".join(f"  {m}" for m in missing)
     )
 
 

--- a/tests/test_architecture/test_conventions.py
+++ b/tests/test_architecture/test_conventions.py
@@ -181,6 +181,71 @@ def _find_config_bracket_access(filepath):
     return violations
 
 
+def _extract_media_config_methods(filepath):
+    """Extract method name strings from the MEDIA_CONFIG dict in dispatch.py.
+
+    Walks the AST to find the MEDIA_CONFIG assignment, then extracts all
+    string values that are NOT under the 'config_key' key (those are config
+    section names, not MediaService method names).
+    """
+    with open(filepath, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=filepath)
+
+    methods = []
+    for node in ast.iter_child_nodes(tree):
+        if not (isinstance(node, ast.Assign)
+                and any(isinstance(t, ast.Name) and t.id == "MEDIA_CONFIG"
+                        for t in node.targets)):
+            continue
+        # node.value is the outer dict
+        if not isinstance(node.value, ast.Dict):
+            continue
+        for media_type_dict in node.value.values:
+            if not isinstance(media_type_dict, ast.Dict):
+                continue
+            for key_node, val_node in zip(
+                media_type_dict.keys, media_type_dict.values
+            ):
+                if (isinstance(key_node, ast.Constant)
+                        and key_node.value == "config_key"):
+                    continue
+                if isinstance(val_node, ast.Constant) and isinstance(
+                    val_node.value, str
+                ):
+                    methods.append(val_node.value)
+    return methods
+
+
+def test_media_config_dispatch_integrity():
+    """Every method name in MEDIA_CONFIG must exist on MediaService.
+
+    MEDIA_CONFIG maps media types to MediaService method name strings that
+    are resolved via getattr() at runtime. A rename typo would only surface
+    when a user triggers the command. This test catches the mismatch at CI.
+    """
+    from src.services.media import MediaService
+
+    dispatch_path = os.path.join(
+        HANDLERS_DIR, "media", "dispatch.py"
+    )
+    method_names = _extract_media_config_methods(dispatch_path)
+
+    assert method_names, (
+        "No method names extracted from MEDIA_CONFIG — "
+        "is the dict structure still the same?"
+    )
+
+    missing = []
+    for name in method_names:
+        if not hasattr(MediaService, name):
+            missing.append(name)
+
+    assert not missing, (
+        "MEDIA_CONFIG references methods not found on MediaService: "
+        + ", ".join(missing)
+    )
+
+
 def test_no_config_bracket_access_in_business_logic():
     """Business logic must use config.get() instead of config["key"].
 

--- a/tests/test_architecture/test_conventions.py
+++ b/tests/test_architecture/test_conventions.py
@@ -246,6 +246,37 @@ def test_media_config_dispatch_integrity():
     )
 
 
+# Media state names that must be in sync between dispatch.py and States.
+MEDIA_STATE_NAMES = [
+    "SEARCHING", "SELECTING", "QUALITY_SELECT", "SEASON_SELECT", "ALBUM_SELECT",
+]
+
+
+def test_media_state_constants_in_sync():
+    """Media state constants in dispatch.py must match States class values.
+
+    States are duplicated in dispatch.py (module-level constants) and
+    states.py (States class attributes). A drift would cause
+    ConversationHandler state routing to silently break.
+    """
+    from src.bot.handlers.media import dispatch as dispatch_module
+    from src.bot.states import States
+
+    mismatches = []
+    for name in MEDIA_STATE_NAMES:
+        dispatch_val = getattr(dispatch_module, name, "<MISSING>")
+        states_val = getattr(States, name, "<MISSING>")
+        if dispatch_val != states_val:
+            mismatches.append(
+                f"{name}: dispatch.py={dispatch_val}, States={states_val}"
+            )
+
+    assert not mismatches, (
+        "Media state constants out of sync:\n"
+        + "\n".join(f"  {m}" for m in mismatches)
+    )
+
+
 def test_no_config_bracket_access_in_business_logic():
     """Business logic must use config.get() instead of config["key"].
 

--- a/tests/test_architecture/test_conventions.py
+++ b/tests/test_architecture/test_conventions.py
@@ -412,6 +412,65 @@ def test_handler_entry_points_have_require_auth():
     )
 
 
+def _extract_reset_classes(filepath):
+    """Extract class names that have ._instance = None in reset_singletons.
+
+    Parses the conftest.py AST to find the reset_singletons function,
+    then collects all class names from ClassName._instance = None assignments.
+    """
+    with open(filepath, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=filepath)
+
+    # Find the reset_singletons function
+    func_node = None
+    for node in ast.iter_child_nodes(tree):
+        if (isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == "reset_singletons"):
+            func_node = node
+            break
+    if not func_node:
+        return set()
+
+    classes = set()
+    for node in ast.walk(func_node):
+        # Match: ClassName._instance = None
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if (isinstance(target, ast.Attribute)
+                    and target.attr == "_instance"
+                    and isinstance(target.value, ast.Name)):
+                classes.add(target.value.id)
+    return classes
+
+
+def test_singleton_reset_coverage():
+    """Every SINGLETON_CLASSES entry must be reset in reset_singletons fixture.
+
+    SINGLETON_CLASSES (convention test) and reset_singletons (conftest fixture)
+    are manually kept in sync. Adding a service to one but forgetting the other
+    means either the convention test misses it or tests leak state.
+    """
+    conftest_path = os.path.join(PROJECT_ROOT, "tests", "conftest.py")
+    reset_classes = _extract_reset_classes(conftest_path)
+
+    # Check SINGLETON_CLASSES are all reset
+    not_reset = SINGLETON_CLASSES - reset_classes
+    assert not not_reset, (
+        "SINGLETON_CLASSES entries missing from reset_singletons fixture: "
+        + ", ".join(sorted(not_reset))
+    )
+
+    not_in_set = reset_classes - SINGLETON_CLASSES
+    # AuthHandler is reset but is not in SINGLETON_CLASSES (it's a handler)
+    expected_extra = {"AuthHandler"}
+    unexpected = not_in_set - expected_extra
+    assert not unexpected, (
+        "Classes reset in fixture but missing from SINGLETON_CLASSES: "
+        + ", ".join(sorted(unexpected))
+    )
+
+
 def test_no_config_bracket_access_in_business_logic():
     """Business logic must use config.get() instead of config["key"].
 


### PR DESCRIPTION
## Summary

- Add 4 new AST-based architecture tests to `test_conventions.py` that catch runtime-only bugs at CI time: MEDIA_CONFIG dispatch integrity, media state constant sync, @require_auth coverage on handler entry points, and singleton reset fixture coverage
- Add 3 new skills: security audit (full-codebase security review), release readiness (development-to-main gate), Telegram UX review (bot interaction quality)
- Add post-PR retrospective reference to the workflow for extracting durable learnings from TASKS.md completion metadata
- Integrate `/addarr release` flow into the workflow skill

## Test plan

- [x] All 8 new convention tests pass: `pytest tests/test_architecture/test_conventions.py -v`
- [x] Full test suite passes: 2119 tests, 0 failures
- [x] flake8 clean
- [x] mypy clean (74 source files)
- [x] i18n validation passes
- [x] All 3 new skills appear in skills list and load correctly
- [x] Pre-PR review (find-bugs, simplify, code-clarity): no significant issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
