### PR TITLE
chore: add GitHub CLI to cloud environment setup

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -9,6 +9,18 @@ fi
 
 set -e
 
+# Install GitHub CLI
+if ! command -v gh &> /dev/null; then
+  echo "Installing GitHub CLI..."
+  apt-get update -qq && apt-get install -y -qq gh > /dev/null 2>&1
+fi
+
+# Authenticate gh if GH_TOKEN is set (add as secret in web environment settings)
+if [ -n "$GH_TOKEN" ]; then
+  echo "Authenticating GitHub CLI..."
+  echo "$GH_TOKEN" | gh auth login --with-token
+fi
+
 echo "Installing project dependencies..."
 pip install -q -r requirements.txt
 
@@ -19,5 +31,6 @@ echo "Verifying tools..."
 python -m flake8 --version
 python -m pytest --version
 python -m mypy --version
+gh --version
 
 echo "Cloud environment ready."


### PR DESCRIPTION
## Summary
- Install GitHub CLI (gh) in cloud environment setup script
- Auto-authenticate gh when GH_TOKEN env var is set
- Add gh version check to tool verification

## Setup
Add a GH_TOKEN secret in the Claude Code web environment settings (personal access token with repo scope) to enable gh authentication.

## Test plan
- [ ] Open repo in claude.ai/code and verify gh is installed
- [ ] Set GH_TOKEN in environment settings and verify gh auth works
- [ ] Confirm local CLI sessions are unaffected (script exits early)

Generated with [Claude Code](https://claude.com/claude-code)
