### PR TITLE
fix: SABnzbd resume button sends wrong callback_data (#169)

### DIFF
--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -268,9 +268,10 @@ def get_sabnzbd_settings_keyboard(
         [InlineKeyboardButton(
             "⚡ Speed Limit", callback_data="dl_sab_speed"
         )],
-        [InlineKeyboardButton(
-            "⏸ Pause / ▶️ Resume", callback_data="dl_sab_pause"
-        )],
+        [
+            InlineKeyboardButton("⏸ Pause", callback_data="dl_sab_pause"),
+            InlineKeyboardButton("▶️ Resume", callback_data="dl_sab_resume"),
+        ],
         [InlineKeyboardButton(
             f"◀️ {translation.get_text('Back')}",
             callback_data="dl_back"

--- a/tests/test_bot/test_keyboards.py
+++ b/tests/test_bot/test_keyboards.py
@@ -453,7 +453,7 @@ class TestSabnzbdSettingsKeyboard:
         assert "dl_sab_speed" in callback_data
 
     @patch("src.bot.keyboards.TranslationService")
-    def test_has_pause_resume_button(self, mock_ts):
+    def test_has_pause_button(self, mock_ts):
         _mock_translation(mock_ts)
         from src.bot.keyboards import get_sabnzbd_settings_keyboard
 
@@ -464,6 +464,20 @@ class TestSabnzbdSettingsKeyboard:
             for btn in row
         ]
         assert "dl_sab_pause" in callback_data
+
+    @patch("src.bot.keyboards.TranslationService")
+    def test_has_resume_button(self, mock_ts):
+        """Resume must be a separate button so dl_sab_resume callback is sent."""
+        _mock_translation(mock_ts)
+        from src.bot.keyboards import get_sabnzbd_settings_keyboard
+
+        result = get_sabnzbd_settings_keyboard(enabled=True)
+        callback_data = [
+            btn.callback_data
+            for row in result.inline_keyboard
+            for btn in row
+        ]
+        assert "dl_sab_resume" in callback_data
 
     @patch("src.bot.keyboards.TranslationService")
     def test_has_back_button(self, mock_ts):


### PR DESCRIPTION
## Summary

- `keyboards.py:272` had a single "⏸ Pause / ▶️ Resume" button that always sent `dl_sab_pause`, so `dl_sab_resume` was never fired and resume never worked
- Split into two separate buttons: **⏸ Pause** (`dl_sab_pause`) and **▶️ Resume** (`dl_sab_resume`)
- The handler pattern `^dl_sab_(pause|resume)$` and the `if/elif` logic in `handle_sabnzbd_pause_resume` were already correct — only the keyboard needed fixing

## Test plan

- [x] Added `test_has_resume_button` to `TestSabnzbdSettingsKeyboard` — verifies `dl_sab_resume` is present in keyboard callback data
- [x] Renamed `test_has_pause_resume_button` → `test_has_pause_button` for clarity
- [x] All 2138 tests pass
- [x] flake8 and mypy clean

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
