### PR TITLE
fix: system handler unknown action causes button pulse with no response (#170)

### DIFF
--- a/src/bot/handlers/system.py
+++ b/src/bot/handlers/system.py
@@ -110,7 +110,13 @@ class SystemHandler:
         elif action == "back":
             await self._handle_back(query)
         else:
+            logger.warning(f"Unknown system action received: {action}")
             await query.answer(self.translation.get_text("UnknownAction"))
+            status_text = self._build_status_text()
+            await query.message.edit_text(
+                status_text,
+                reply_markup=get_system_keyboard(),
+            )
 
     async def _handle_refresh(self, query):
         """Re-run health checks and update the status display."""

--- a/tests/test_handlers/test_system_handler.py
+++ b/tests/test_handlers/test_system_handler.py
@@ -250,7 +250,7 @@ async def test_handle_back(system_handler, make_update, make_context):
 async def test_handle_unknown_action(
     system_handler, make_update, make_context
 ):
-    """Unknown system action answers with error."""
+    """Unknown system action answers with error toast and re-renders status."""
     update = make_update(callback_data="system_foobar")
     context = make_context()
 
@@ -258,6 +258,24 @@ async def test_handle_unknown_action(
 
     update.callback_query.answer.assert_called_once()
     system_handler._mock_ts.get_text.assert_any_call("UnknownAction")
+    # Message must be edited so the loading animation clears
+    update.callback_query.message.edit_text.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_unknown_action_logs_warning(
+    system_handler, make_update, make_context
+):
+    """Unknown system action logs a warning with the action name."""
+    update = make_update(callback_data="system_foobar")
+    context = make_context()
+
+    with patch("src.bot.handlers.system.logger") as mock_logger:
+        await system_handler.handle_system_action(update, context)
+
+    mock_logger.warning.assert_called_once()
+    warning_msg = mock_logger.warning.call_args[0][0]
+    assert "foobar" in warning_msg
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `system.py:113` — the `else` branch only called `query.answer()` with a toast text, leaving the Telegram loading animation to pulse and disappear with no visible message change
- Added `logger.warning(...)` with the unrecognised action name so silent failures are visible in logs
- Added `query.message.edit_text(...)` re-rendering the current system status, so the user always gets a response when an unknown `system_` callback is received

## Test plan

- [x] Updated `test_handle_unknown_action` — asserts `edit_text` is called (was previously missing)
- [x] Added `test_handle_unknown_action_logs_warning` — asserts `logger.warning` is called with the action name
- [x] All 2138 tests pass
- [x] flake8 and mypy clean

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)