### PR TITLE
fix: callback handlers silently swallow exceptions (#171)

### DIFF
--- a/src/bot/handlers/settings.py
+++ b/src/bot/handlers/settings.py
@@ -405,37 +405,44 @@ class SettingsHandler:
         query = update.callback_query
         await query.answer()
 
-        # Parse: setquality_{service}_{id}
-        parts = query.data.split("_")
-        service = parts[1]
-        profile_id = int(parts[2])
+        try:
+            # Parse: setquality_{service}_{id}
+            parts = query.data.split("_")
+            service = parts[1]
+            profile_id = int(parts[2])
 
-        # Look up profile name from the keyboard buttons
-        profile_name = str(profile_id)
-        if query.message and query.message.reply_markup:
-            for row in query.message.reply_markup.inline_keyboard:
-                for btn in row:
-                    if btn.callback_data == query.data:
-                        profile_name = btn.text.lstrip("✅ ")
-                        break
+            # Look up profile name from the keyboard buttons
+            profile_name = str(profile_id)
+            if query.message and query.message.reply_markup:
+                for row in query.message.reply_markup.inline_keyboard:
+                    for btn in row:
+                        if btn.callback_data == query.data:
+                            profile_name = btn.text.lstrip("✅ ")
+                            break
 
-        config.update_nested(
-            f"{service}.quality.defaultProfileId", profile_id
-        )
-        config.save()
+            config.update_nested(
+                f"{service}.quality.defaultProfileId", profile_id
+            )
+            config.save()
 
-        text = self.translation.get_text(
-            "Settings.QualityProfileSet",
-            default=(
-                f"Default quality profile for {service.title()} "
-                f"set to: {profile_name}"
-            ),
-            profile=profile_name,
-            service=service,
-        )
-        await query.message.edit_text(
-            f"✅ {text}", reply_markup=get_settings_keyboard()
-        )
+            text = self.translation.get_text(
+                "Settings.QualityProfileSet",
+                default=(
+                    f"Default quality profile for {service.title()} "
+                    f"set to: {profile_name}"
+                ),
+                profile=profile_name,
+                service=service,
+            )
+            await query.message.edit_text(
+                f"✅ {text}", reply_markup=get_settings_keyboard()
+            )
+        except Exception as e:
+            logger.error(f"Error saving quality profile ({query.data}): {e}")
+            await query.message.edit_text(
+                "❌ Error saving quality profile.",
+                reply_markup=get_settings_keyboard(),
+            )
         return States.SETTINGS_MENU
 
     # -- Downloads flow --
@@ -615,14 +622,21 @@ class SettingsHandler:
         query = update.callback_query
         await query.answer()
 
-        if query.data == "dl_sab_pause" and self.sabnzbd_service.is_enabled():
-            await self.sabnzbd_service.pause_queue()
-            text = "⏸ Queue paused"
-        elif query.data == "dl_sab_resume" and self.sabnzbd_service.is_enabled():
-            await self.sabnzbd_service.resume_queue()
-            text = "▶️ Queue resumed"
-        else:
-            text = "❌ SABnzbd not available"
+        try:
+            if query.data == "dl_sab_pause" and self.sabnzbd_service.is_enabled():
+                await self.sabnzbd_service.pause_queue()
+                text = "⏸ Queue paused"
+            elif (
+                query.data == "dl_sab_resume"
+                and self.sabnzbd_service.is_enabled()
+            ):
+                await self.sabnzbd_service.resume_queue()
+                text = "▶️ Queue resumed"
+            else:
+                text = "❌ SABnzbd not available"
+        except Exception as e:
+            logger.error(f"Error during SABnzbd pause/resume ({query.data}): {e}")
+            text = "❌ SABnzbd error — could not complete action"
 
         enabled = config.get("sabnzbd", {}).get("enable", False)
         keyboard = get_sabnzbd_settings_keyboard(enabled)

--- a/tests/test_handlers/test_settings_handler.py
+++ b/tests/test_handlers/test_settings_handler.py
@@ -718,6 +718,82 @@ class TestSabnzbdInitError:
             assert handler.sabnzbd_service.is_enabled() is False
 
 
+class TestQualityErrorHandling:
+    """Error handling in quality profile selection"""
+
+    @pytest.mark.asyncio
+    async def test_handle_quality_select_malformed_callback_data(
+        self, settings_handler, make_update, make_context
+    ):
+        """Malformed callback_data (non-int profile id) shows error message"""
+        update = make_update(callback_data="setquality_radarr_notanint")
+        context = make_context()
+
+        result = await settings_handler.handle_quality_select(update, context)
+
+        assert result == States.SETTINGS_MENU
+        call_args = update.callback_query.message.edit_text.call_args
+        assert "❌" in call_args.args[0]
+        settings_handler._mock_cfg.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_quality_select_config_save_error(
+        self, settings_handler, make_update, make_context
+    ):
+        """Config save failure shows error message"""
+        settings_handler._mock_cfg.save.side_effect = Exception("Disk full")
+        update = make_update(callback_data="setquality_radarr_4")
+        context = make_context()
+
+        result = await settings_handler.handle_quality_select(update, context)
+
+        assert result == States.SETTINGS_MENU
+        call_args = update.callback_query.message.edit_text.call_args
+        assert "❌" in call_args.args[0]
+
+
+class TestSabnzbdPauseResumeErrorHandling:
+    """Error handling in SABnzbd pause/resume"""
+
+    @pytest.mark.asyncio
+    async def test_handle_sabnzbd_pause_service_error(
+        self, settings_handler, make_update, make_context
+    ):
+        """Service exception during pause shows error message"""
+        settings_handler._mock_sab.pause_queue = AsyncMock(
+            side_effect=Exception("Connection refused")
+        )
+        update = make_update(callback_data="dl_sab_pause")
+        context = make_context()
+
+        result = await settings_handler.handle_sabnzbd_pause_resume(
+            update, context
+        )
+
+        assert result == States.SETTINGS_DOWNLOADS
+        call_args = update.callback_query.message.edit_text.call_args
+        assert "❌" in call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_handle_sabnzbd_resume_service_error(
+        self, settings_handler, make_update, make_context
+    ):
+        """Service exception during resume shows error message"""
+        settings_handler._mock_sab.resume_queue = AsyncMock(
+            side_effect=Exception("Timeout")
+        )
+        update = make_update(callback_data="dl_sab_resume")
+        context = make_context()
+
+        result = await settings_handler.handle_sabnzbd_pause_resume(
+            update, context
+        )
+
+        assert result == States.SETTINGS_DOWNLOADS
+        call_args = update.callback_query.message.edit_text.call_args
+        assert "❌" in call_args.args[0]
+
+
 class TestDownloadsEdgeCases:
     """Edge cases for downloads sub-menu handlers"""
 


### PR DESCRIPTION
## Summary

- Wrap `handle_quality_select` in `try/except` — `int(parts[2])` on malformed `callback_data` previously raised an unhandled `ValueError`, leaving the user with a pulsing button and no feedback
- Wrap `handle_sabnzbd_pause_resume` service calls in `try/except` — network/service failures now show a user-facing error message and log at ERROR level
- Both handlers always call `query.answer()` first, then edit the message with a `❌` error state on failure

## Test plan

- [x] `test_handle_quality_select_malformed_callback_data` — non-int profile id shows error, config.save not called
- [x] `test_handle_quality_select_config_save_error` — save exception shows error
- [x] `test_handle_sabnzbd_pause_service_error` — pause raises exception → error message shown
- [x] `test_handle_sabnzbd_resume_service_error` — resume raises exception → error message shown
- [x] All 2141 existing tests still pass
- [x] flake8 clean, mypy clean

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)